### PR TITLE
build(ios): Mindest-System auf iOS 16 senken — iPhone 8 und X kommen dazu

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ keine der beiden Apps noch einmal.
 | Verzeichnis | Inhalt |
 |---|---|
 | `android/` | Native Android-App (Kotlin, Jetpack Compose, Material 3, MapLibre) |
-| `ios/` | Native iOS-App (Swift 6, SwiftUI, MapLibre, ab iOS 17, iPhone und iPad). Xcode-Projekt wird aus `project.yml` erzeugt, nicht committet. Eigener Zugang: `ios/README.md` |
+| `ios/` | Native iOS-App (Swift 6, SwiftUI, MapLibre, ab iOS 16, iPhone und iPad). Xcode-Projekt wird aus `project.yml` erzeugt, nicht committet. Eigener Zugang: `ios/README.md` |
 | `backend/` | Go-Backend: REST-API, MCP-Server, Web-Admin. SQLite (WAL) |
 | `deploy/`  | Kustomize-Overlay für den K3S-Cluster (Flux deployt) |
 | `.github/workflows/` | CI: Tests, E2E auf Emulatoren, Multi-Arch-Images, Releases |

--- a/ios/Dorf/Anmeldung/Anmeldung.swift
+++ b/ios/Dorf/Anmeldung/Anmeldung.swift
@@ -1,7 +1,7 @@
 import AuthenticationServices
+import Combine
 import CryptoKit
 import Foundation
-import Observation
 
 /// Der Scope, mit dem Zitadel die Projektrollen ins Token legt.
 ///
@@ -47,19 +47,18 @@ struct OidcEndpunkte: Codable, Sendable {
 /// ein eingebettetes WebView scheitern würde. Der Rest ist ein
 /// Authorization-Code-Fluss nach Vorschrift — knapp hundert Zeilen, die
 /// niemand für uns pflegen muss.
-@Observable
-final class Anmeldung: NSObject {
-    private(set) var sitzung: Sitzungszustand = .laedt
+final class Anmeldung: NSObject, ObservableObject {
+    @Published private(set) var sitzung: Sitzungszustand = .laedt
 
     /// Das zuletzt erhaltene ID-Token — nur zur Diagnose („warum bin ich
     /// nicht Verwaltung?"). Zitadel legt Rollen je nach Einstellung ins
     /// Zugangs- oder ins ID-Token; wer das untersucht, braucht beide.
-    private(set) var letztesIdToken: String?
+    @Published private(set) var letztesIdToken: String?
 
-    @ObservationIgnored private var tokensatz: Tokensatz?
-    @ObservationIgnored private var entwicklerToken: String?
-    @ObservationIgnored private var endpunkte: OidcEndpunkte?
-    @ObservationIgnored private var laufendeAnmeldung: ASWebAuthenticationSession?
+    private var tokensatz: Tokensatz?
+    private var entwicklerToken: String?
+    private var endpunkte: OidcEndpunkte?
+    private var laufendeAnmeldung: ASWebAuthenticationSession?
 
     override init() {
         super.init()

--- a/ios/Dorf/Anmeldung/AnmeldungView.swift
+++ b/ios/Dorf/Anmeldung/AnmeldungView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// Impressum und Datenschutz stehen auch hier — wer noch kein Konto hat, muss
 /// trotzdem nachlesen können, was mit seinen Daten geschieht (§ 5 DDG).
 struct AnmeldungView: View {
-    @Environment(AppUmgebung.self) private var umgebung
+    @EnvironmentObject private var umgebung: AppUmgebung
     @State private var laeuft = false
     @State private var fehler: String?
 

--- a/ios/Dorf/Bereiche/Einstellungen/EinstellungenView.swift
+++ b/ios/Dorf/Bereiche/Einstellungen/EinstellungenView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// Apples Richtlinie 5.1.1 (v) verlangt von jeder App mit Konto einen Weg
 /// dorthin **in der App**, nicht per E-Mail an irgendwen.
 struct EinstellungenView: View {
-    @Environment(AppUmgebung.self) private var umgebung
+    @EnvironmentObject private var umgebung: AppUmgebung
     @State private var modell: KontoModell?
 
     var body: some View {
@@ -59,7 +59,7 @@ struct EinstellungenView: View {
 
 /// „Mein Konto": wer angemeldet ist und mit welcher Rolle.
 private struct KontoAbschnitt: View {
-    let umgebung: AppUmgebung
+    @ObservedObject var umgebung: AppUmgebung
 
     var body: some View {
         Section("Mein Konto") {
@@ -85,7 +85,7 @@ private struct KontoAbschnitt: View {
 
 /// Der Weg zum Löschen des Kontos — mit der Erklärung davor, nicht danach.
 private struct LoeschAbschnitt: View {
-    @Bindable var modell: KontoModell
+    @ObservedObject var modell: KontoModell
 
     var body: some View {
         Section {
@@ -128,7 +128,7 @@ private struct LoeschAbschnitt: View {
 /// Die Rückfrage. Bewusst ein eigenes Blatt und kein Hinweisfenster: Was hier
 /// steht, passt in keine drei Zeilen — und der Name will abgetippt werden.
 private struct KontoLoeschenBlatt: View {
-    @Bindable var modell: KontoModell
+    @ObservedObject var modell: KontoModell
     @Environment(\.dismiss) private var schliessen
 
     var body: some View {

--- a/ios/Dorf/Bereiche/Einstellungen/KontoModell.swift
+++ b/ios/Dorf/Bereiche/Einstellungen/KontoModell.swift
@@ -1,5 +1,5 @@
+import Combine
 import Foundation
-import Observation
 
 /// Woher „Einstellungen" das Löschen bekommt und wie danach abgemeldet wird.
 ///
@@ -33,24 +33,23 @@ struct Kontoquelle {
 /// Die zweite wichtige Eigenschaft: **Scheitert das Löschen, wird nicht
 /// abgemeldet.** Sonst stünde jemand vor dem Anmeldebildschirm und wüsste
 /// nicht, ob sein Konto nun weg ist oder nicht.
-@Observable
-final class KontoModell {
+final class KontoModell: ObservableObject {
     /// Der Name, der abgeschrieben werden muss — der eigene, wie ihn die
     /// App auch sonst anzeigt.
     let erwarteterName: String
 
-    @ObservationIgnored private let quelle: Kontoquelle
+    private let quelle: Kontoquelle
 
     /// Steht die Rückfrage offen? Erst danach gibt es überhaupt ein Feld zum
     /// Tippen — das ist die erste der beiden Stufen.
-    private(set) var rueckfrageOffen = false
-    var getippterName = ""
-    private(set) var laeuft = false
+    @Published private(set) var rueckfrageOffen = false
+    @Published var getippterName = ""
+    @Published private(set) var laeuft = false
     /// Ein gescheiterter Versuch — im Wortlaut des Backends.
-    private(set) var fehler: String?
+    @Published private(set) var fehler: String?
     /// Steht nach dem Löschen: was mit den Erledigungen passiert ist und dass
     /// die Rössing-ID bleibt. Beides sagt das Backend, nicht die App.
-    private(set) var abschied: Kontoloeschung?
+    @Published private(set) var abschied: Kontoloeschung?
 
     init(erwarteterName: String, quelle: Kontoquelle) {
         self.erwarteterName = erwarteterName

--- a/ios/Dorf/Bereiche/Ideen/IdeenModell.swift
+++ b/ios/Dorf/Bereiche/Ideen/IdeenModell.swift
@@ -1,5 +1,5 @@
+import Combine
 import Foundation
-import Observation
 
 /// Zustand des Ideen-Formulars — dasselbe Verhalten wie im
 /// `IdeenViewModel` der Android-App.
@@ -8,23 +8,22 @@ import Observation
 /// Profil vorbelegt. Der Missbrauchsschutz (Zugriffsgrenze, verstecktes
 /// Feld, Mindestzeit) sitzt im Backend und wird hier bewusst **nicht**
 /// nachgebaut: Für Website und App sollen dieselben Regeln gelten.
-@Observable
-final class IdeenModell {
+final class IdeenModell: ObservableObject {
     /// Kürzer ergibt keinen Wunsch. Verbindlich prüft das Backend
     /// (5–2000 Zeichen) — hier geht es nur darum, niemanden mit einer
     /// vermeidbaren Fehlermeldung zu ärgern.
     static let mindestZeichen = 5
     static let maxZeichen = 2000
 
-    private(set) var wunsch = ""
-    private(set) var name = ""
-    private(set) var email = ""
-    private(set) var sendet = false
+    @Published private(set) var wunsch = ""
+    @Published private(set) var name = ""
+    @Published private(set) var email = ""
+    @Published private(set) var sendet = false
     /// Begründung des Backends im Wortlaut, wenn die Einreichung abgewiesen
     /// wurde — sonst nil.
-    private(set) var fehler: String?
+    @Published private(set) var fehler: String?
     /// Nach dem Abschicken: „Danke, deine Idee ist angekommen!"
-    private(set) var dank = false
+    @Published private(set) var dank = false
 
     init() {}
 

--- a/ios/Dorf/Bereiche/Ideen/IdeenView.swift
+++ b/ios/Dorf/Bereiche/Ideen/IdeenView.swift
@@ -8,8 +8,8 @@ import SwiftUI
 /// Fehler kosten nie den getippten Text: Bei einer Ablehnung bleibt alles
 /// stehen und die Begründung des Backends steht wörtlich darüber.
 struct IdeenView: View {
-    @Environment(AppUmgebung.self) private var umgebung
-    @State private var modell = IdeenModell()
+    @EnvironmentObject private var umgebung: AppUmgebung
+    @StateObject private var modell = IdeenModell()
 
     var body: some View {
         Form {
@@ -138,7 +138,7 @@ struct IdeenView: View {
         .task { modell.vorbelegen(aus: umgebung.ich) }
         // Das Profil kommt womöglich erst nach dem Öffnen an. Nachgetragen
         // wird nur, was noch leer ist (siehe `IdeenModell.vorbelegen`).
-        .onChange(of: umgebung.ich?.profile) { _, _ in
+        .onChange(of: umgebung.ich?.profile) { _ in
             modell.vorbelegen(aus: umgebung.ich)
         }
     }
@@ -163,7 +163,7 @@ struct IdeenView: View {
     NavigationStack {
         IdeenView()
     }
-    .environment(
+    .environmentObject(
         AppUmgebung(
             anmeldung: Anmeldung(),
             api: DorfApi(tokenGeber: { nil }),

--- a/ios/Dorf/Bereiche/Karte/KarteView.swift
+++ b/ios/Dorf/Bereiche/Karte/KarteView.swift
@@ -32,7 +32,7 @@ struct KarteView: View {
         self.flaecheGetippt = flaecheGetippt
     }
 
-    @State private var standort = Standortgeber()
+    @StateObject private var standort = Standortgeber()
     /// Eigener Punkt auf der Karte — erst nach erteilter Freigabe.
     @State private var standortZeigen = false
     /// Jeder Druck auf „Mein Standort" erhöht den Zähler; die Karte fährt
@@ -63,7 +63,7 @@ struct KarteView: View {
         }
         .overlay(alignment: .top) { hinweise }
         .overlay(alignment: .bottomTrailing) { standortknopf }
-        .onChange(of: standort.freigabe) { _, neue in freigabeGeaendert(neue) }
+        .onChange(of: standort.freigabe) { neue in freigabeGeaendert(neue) }
     }
 
     // MARK: - Knopf „Mein Standort"
@@ -74,7 +74,7 @@ struct KarteView: View {
                 .font(.title3)
                 .padding(14)
                 .background(.regularMaterial, in: Circle())
-                .overlay(Circle().strokeBorder(.separator))
+                .overlay(Circle().strokeBorder(Color.trennlinie))
         }
         .buttonStyle(.plain)
         .padding(16)
@@ -163,7 +163,7 @@ struct KarteView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(12)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
-        .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(.separator))
+        .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(Color.trennlinie))
     }
 }
 

--- a/ios/Dorf/Bereiche/Karte/Standortgeber.swift
+++ b/ios/Dorf/Bereiche/Karte/Standortgeber.swift
@@ -1,5 +1,5 @@
+import Combine
 import CoreLocation
-import Observation
 
 /// Die Ortungsfreigabe für die Karte — und sonst nichts.
 ///
@@ -7,8 +7,7 @@ import Observation
 /// beim ersten Öffnen einen Systemdialog wirft, bekommt ein „Nicht erlauben"
 /// und danach nie wieder eine Chance. Der Standort bleibt auf dem Gerät: Die
 /// App zeigt ihn nur an und schickt ihn nirgendwohin.
-@Observable
-final class Standortgeber: NSObject, CLLocationManagerDelegate {
+final class Standortgeber: NSObject, ObservableObject, CLLocationManagerDelegate {
     enum Freigabe: Sendable {
         /// Noch nie gefragt — der Knopf darf den Systemdialog auslösen.
         case ungefragt
@@ -18,12 +17,12 @@ final class Standortgeber: NSObject, CLLocationManagerDelegate {
         case verweigert
     }
 
-    private(set) var freigabe: Freigabe = .ungefragt
+    @Published private(set) var freigabe: Freigabe = .ungefragt
 
     /// Der zuletzt gemeldete eigene Standort — nur gefüllt, solange jemand
     /// ihn ausdrücklich angefordert hat (`beobachten()`). Die Karte selbst
     /// braucht ihn nicht: Den eigenen Punkt zeichnet MapLibre.
-    private(set) var letzterPunkt: Kartenpunkt?
+    @Published private(set) var letzterPunkt: Kartenpunkt?
 
     private let verwalter = CLLocationManager()
 

--- a/ios/Dorf/Bereiche/Mithelfen/MithelfenView.swift
+++ b/ios/Dorf/Bereiche/Mithelfen/MithelfenView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Der Bereich „Mithelfen": Was gerade im Dorf ansteht — als Karte oder als
 /// Liste, und dahinter je Ort die Aufgaben mit dem Knopf zum Melden.
 struct MithelfenView: View {
-    @Environment(AppUmgebung.self) private var umgebung
+    @EnvironmentObject private var umgebung: AppUmgebung
 
     var body: some View {
         // Das Modell gehört der **Umgebung**, nicht dieser Seite: Die
@@ -36,7 +36,7 @@ enum Mithelfenansicht: String, CaseIterable, Identifiable {
 
 /// Der eigentliche Bereich, sobald das Modell steht.
 struct MithelfenInhalt: View {
-    let modell: OrteModell
+    @ObservedObject var modell: OrteModell
     let meinSub: String?
 
     @State private var ansicht: Mithelfenansicht = .liste
@@ -64,8 +64,13 @@ struct MithelfenInhalt: View {
                 OrteListe(modell: modell) { gewaehlterOrt = $0 }
             }
         }
-        .navigationDestination(item: $gewaehlterOrt) { id in
-            OrtDetailView(modell: modell, ortId: id, meinSub: meinSub)
+        // `navigationDestination(item:)` gibt es erst ab iOS 17. Mit
+        // `isPresented` steht dasselbe ab iOS 16: Der gewählte Ort liegt
+        // daneben, und beim Zurückgehen wird er wieder geleert.
+        .navigationDestination(isPresented: ortOffen) {
+            if let gewaehlterOrt {
+                OrtDetailView(modell: modell, ortId: gewaehlterOrt, meinSub: meinSub)
+            }
         }
         // Der Fehler hängt am ganzen Bereich, damit er auch über der
         // Detailseite erscheint — dort wird gemeldet.
@@ -80,12 +85,16 @@ struct MithelfenInhalt: View {
     private var fehlerOffen: Binding<Bool> {
         Binding(get: { modell.fehler != nil }, set: { if !$0 { modell.fehlerVerwerfen() } })
     }
+
+    private var ortOffen: Binding<Bool> {
+        Binding(get: { gewaehlterOrt != nil }, set: { if !$0 { gewaehlterOrt = nil } })
+    }
 }
 
 /// Hinweis und Dank über der Liste — beide sagen es im Text, nicht nur in der
 /// Farbe.
 struct Streifen: View {
-    let modell: OrteModell
+    @ObservedObject var modell: OrteModell
 
     var body: some View {
         VStack(spacing: 0) {
@@ -135,7 +144,7 @@ struct Hinweisstreifen: View {
 
 /// Die Orte, dringendste zuerst.
 struct OrteListe: View {
-    let modell: OrteModell
+    @ObservedObject var modell: OrteModell
     var auswahl: (Int64) -> Void
 
     var body: some View {

--- a/ios/Dorf/Bereiche/Mithelfen/OrtDetailView.swift
+++ b/ios/Dorf/Bereiche/Mithelfen/OrtDetailView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Ein Ort mit allem, was dort ansteht: Beschreibung, Aufgaben mit Ampel,
 /// Plan bzw. Termin, letzte Erledigung, Historie — und der Knopf zum Melden.
 struct OrtDetailView: View {
-    let modell: OrteModell
+    @ObservedObject var modell: OrteModell
     let ortId: Int64
     let meinSub: String?
 
@@ -142,7 +142,7 @@ struct OrtDetailView: View {
 /// nicht alle auf einmal. Wann und wen, entscheidet das Backend; die App
 /// meldet nur an und ab.
 struct HelferKarte: View {
-    let modell: OrteModell
+    @ObservedObject var modell: OrteModell
     let ort: Ort
 
     /// Wofür ich mithelfen will. Nur vor dem Anmelden zu wählen — zum
@@ -240,7 +240,7 @@ struct HelferKarte: View {
 
 /// Eine Aufgabe des Ortes.
 struct AufgabenKarte: View {
-    let modell: OrteModell
+    @ObservedObject var modell: OrteModell
     let aufgabe: Aufgabe
     let meinSub: String?
     var nachfragen: (Aufgabe) -> Void

--- a/ios/Dorf/Bereiche/Mithelfen/OrtDetailView.swift
+++ b/ios/Dorf/Bereiche/Mithelfen/OrtDetailView.swift
@@ -19,10 +19,10 @@ struct OrtDetailView: View {
             if let ort {
                 inhalt(ort)
             } else {
-                ContentUnavailableView(
+                Hinweistafel(
                     "Der Ort ist nicht mehr da",
-                    systemImage: "mappin.slash",
-                    description: Text("Vielleicht wurde er gerade abgeschaltet oder erledigt.")
+                    symbol: "mappin.slash",
+                    beschreibung: "Vielleicht wurde er gerade abgeschaltet oder erledigt."
                 )
             }
         }

--- a/ios/Dorf/Bereiche/Mithelfen/OrteModell.swift
+++ b/ios/Dorf/Bereiche/Mithelfen/OrteModell.swift
@@ -1,5 +1,5 @@
+import Combine
 import Foundation
-import Observation
 
 /// Woher „Mithelfen" seine Daten holt.
 ///
@@ -45,31 +45,30 @@ struct OrteQuelle {
 /// aus, wird die Liste nicht geleert — sie bekommt einen Hinweis darüber.
 /// Eine leere Seite im Funkloch wäre eine Falschaussage („es steht nichts an"),
 /// und im Dorf ist die Verbindung nun einmal nicht überall gut.
-@Observable
-final class OrteModell {
+final class OrteModell: ObservableObject {
     private let quelle: OrteQuelle
 
-    private(set) var orte: [Ort] = []
+    @Published private(set) var orte: [Ort] = []
     /// Wetterfaktor des Backends (1 = normal). Wird angezeigt, nicht gerechnet.
-    private(set) var giessfaktor: Double = 1
-    private(set) var laeuft = false
+    @Published private(set) var giessfaktor: Double = 1
+    @Published private(set) var laeuft = false
     /// Ob überhaupt schon einmal ein Abruf durch war — davor zeigt die Liste
     /// einen Ladekreis statt „nichts zu tun".
-    private(set) var jeGeladen = false
+    @Published private(set) var jeGeladen = false
     /// Der letzte Abruf ist gescheitert; im Wortlaut des Backends.
-    private(set) var hinweis: String?
+    @Published private(set) var hinweis: String?
     /// Kurze Rückmeldung nach einer Meldung („Danke fürs Gießen! 💚").
-    private(set) var bestaetigung: String?
+    @Published private(set) var bestaetigung: String?
     /// Ein abgelehnter Schreibvorgang — im Wortlaut des Backends.
-    private(set) var fehler: String?
+    @Published private(set) var fehler: String?
     /// Aufgaben, für die gerade geschrieben wird (Knopf sperren).
-    private(set) var laufendeAufgaben: Set<Int64> = []
+    @Published private(set) var laufendeAufgaben: Set<Int64> = []
     /// Orte, an denen gerade an- oder abgemeldet wird.
-    private(set) var laufendeOrte: Set<Int64> = []
+    @Published private(set) var laufendeOrte: Set<Int64> = []
     /// Historie je Aufgabe. Wird nachgeladen und blockiert das Öffnen nicht.
-    private(set) var historie: [Int64: [Erledigung]] = [:]
+    @Published private(set) var historie: [Int64: [Erledigung]] = [:]
 
-    @ObservationIgnored private var verblassen: Task<Void, Never>?
+    private var verblassen: Task<Void, Never>?
 
     init(quelle: OrteQuelle) { self.quelle = quelle }
 

--- a/ios/Dorf/Bereiche/Profil/DorfbewohnerView.swift
+++ b/ios/Dorf/Bereiche/Profil/DorfbewohnerView.swift
@@ -116,15 +116,15 @@ struct DorfbewohnerView: View {
         if modell.laedt && modell.bewohner.isEmpty {
             ProgressView("Wird geladen …")
         } else if modell.gefiltert.isEmpty && !modell.suche.isEmpty {
-            ContentUnavailableView.search(text: modell.suche)
+            Hinweistafel.suche(text: modell.suche)
         } else if modell.gefiltert.isEmpty && modell.fehler == nil {
-            ContentUnavailableView(
+            Hinweistafel(
                 "Noch niemand dabei",
-                systemImage: "person.2",
-                description: Text("""
+                symbol: "person.2",
+                beschreibung: """
                 Bisher hat niemand Angaben freigegeben. Wer in „Mein Profil“ \
                 Anzeigenamen oder Nickname freigibt, steht hier.
-                """)
+                """
             )
             .accessibilityIdentifier("dorfbewohner-leer")
         }

--- a/ios/Dorf/Bereiche/Profil/DorfbewohnerView.swift
+++ b/ios/Dorf/Bereiche/Profil/DorfbewohnerView.swift
@@ -1,4 +1,3 @@
-import Observation
 import SwiftUI
 
 /// Eine Person, so wie sie in dieser Liste erscheinen darf.
@@ -19,15 +18,14 @@ struct Bewohneransicht: Identifiable, Sendable {
 }
 
 /// Der Zustand der Dorfbewohner-Liste.
-@Observable
-final class Dorfbewohnermodell {
-    private(set) var bewohner: [Dorfbewohner] = []
+final class Dorfbewohnermodell: ObservableObject {
+    @Published private(set) var bewohner: [Dorfbewohner] = []
     /// Kam die Liste in der Verwaltungs-Sicht (`adminView`)?
-    private(set) var verwaltungssicht = false
-    private(set) var laedt = false
-    private(set) var geladen = false
-    private(set) var fehler: String?
-    var suche = ""
+    @Published private(set) var verwaltungssicht = false
+    @Published private(set) var laedt = false
+    @Published private(set) var geladen = false
+    @Published private(set) var fehler: String?
+    @Published var suche = ""
 
     /// Gesucht wird über die Namen — der angezeigte Name, der Anzeigename und
     /// der Nickname. Andere Angaben bleiben außen vor: Wer eine Rufnummer
@@ -62,12 +60,10 @@ final class Dorfbewohnermodell {
 /// wurden. Was hier fehlt, hat die Person nicht freigegeben; das Backend
 /// schickt es gar nicht erst mit.
 struct DorfbewohnerView: View {
-    @Environment(AppUmgebung.self) private var umgebung
-    @State private var modell = Dorfbewohnermodell()
+    @EnvironmentObject private var umgebung: AppUmgebung
+    @StateObject private var modell = Dorfbewohnermodell()
 
     var body: some View {
-        @Bindable var modell = modell
-
         List {
             if let fehler = modell.fehler {
                 Section {
@@ -237,7 +233,7 @@ private struct NurVerwaltungsmarke: View {
     NavigationStack {
         DorfbewohnerView()
     }
-    .environment(AppUmgebung(
+    .environmentObject(AppUmgebung(
         anmeldung: Anmeldung(),
         api: DorfApi(tokenGeber: { nil }),
         ich: Ich(sub: "abc", name: "Anna Beispiel")

--- a/ios/Dorf/Bereiche/Profil/ProfilView.swift
+++ b/ios/Dorf/Bereiche/Profil/ProfilView.swift
@@ -1,4 +1,3 @@
-import Observation
 import SwiftUI
 
 /// Der Zustand der Profilseite.
@@ -7,20 +6,19 @@ import SwiftUI
 /// was passiert bei einer Ablehnung — ohne Oberfläche prüfbar sind. Die
 /// Speicherfunktion wird von außen hereingereicht: Die Seite kennt das
 /// Backend nur als „das hier tut es".
-@Observable
-final class Profilmodell {
+final class Profilmodell: ObservableObject {
     /// Der bearbeitete Stand — daran hängen die Eingabefelder.
-    var stand = Profilstand()
+    @Published var stand = Profilstand()
     /// Der zuletzt vom Backend bestätigte Stand.
-    private(set) var gespeichert = Profilstand()
-    private(set) var speichert = false
+    @Published private(set) var gespeichert = Profilstand()
+    @Published private(set) var speichert = false
     /// Begründung einer Ablehnung — im Wortlaut des Backends.
-    private(set) var fehler: String?
-    private(set) var hinweis: String?
+    @Published private(set) var fehler: String?
+    @Published private(set) var hinweis: String?
 
     /// Ob schon einmal etwas hereingereicht wurde. Solange nicht, darf die
     /// Vorbelegung nachgeholt werden, sobald `GET /api/v1/me` da ist.
-    private(set) var vorbelegt = false
+    @Published private(set) var vorbelegt = false
 
     /// Der Speichern-Knopf ist nur offen, wenn es etwas zu speichern gibt.
     var hatAenderungen: Bool { stand.geaendert(gegenueber: gespeichert) }
@@ -74,12 +72,10 @@ final class Profilmodell {
 /// `backend/SICHERHEIT.md` festgehalten). Jeder Schalter sagt in Worten, wer
 /// das Feld sieht — ein nackter Schalter wäre hier zu wenig.
 struct ProfilView: View {
-    @Environment(AppUmgebung.self) private var umgebung
-    @State private var modell = Profilmodell()
+    @EnvironmentObject private var umgebung: AppUmgebung
+    @StateObject private var modell = Profilmodell()
 
     var body: some View {
-        @Bindable var modell = modell
-
         Form {
             sichtbarkeitshinweis
 
@@ -283,7 +279,7 @@ private struct Profilfeld: View {
     NavigationStack {
         ProfilView()
     }
-    .environment(AppUmgebung(
+    .environmentObject(AppUmgebung(
         anmeldung: Anmeldung(),
         api: DorfApi(tokenGeber: { nil }),
         ich: Ich(sub: "abc", name: "Anna Beispiel", email: "anna@example.org")

--- a/ios/Dorf/Bereiche/Rangliste/RanglisteModell.swift
+++ b/ios/Dorf/Bereiche/Rangliste/RanglisteModell.swift
@@ -1,5 +1,5 @@
+import Combine
 import Foundation
-import Observation
 
 /// Der Stand der Rangliste für einen Zeitraum.
 ///
@@ -9,14 +9,13 @@ import Observation
 ///
 /// Fällt das Netz aus, bleibt der zuletzt geladene Stand stehen und bekommt
 /// einen Hinweis darüber: Eine leere Seite wäre die schlechtere Auskunft.
-@Observable
-final class RanglisteModell {
-    private(set) var stand: Rangliste?
-    private(set) var laedt = false
+final class RanglisteModell: ObservableObject {
+    @Published private(set) var stand: Rangliste?
+    @Published private(set) var laedt = false
     /// Klartext des letzten Fehlversuchs — vom Backend, nicht von der App.
-    private(set) var hinweis: String?
+    @Published private(set) var hinweis: String?
     /// Der Zeitraum, zu dem der angezeigte Stand gehört.
-    private(set) var geladenerZeitraum: Zeitraum?
+    @Published private(set) var geladenerZeitraum: Zeitraum?
 
     func laden(api: DorfApi, zeitraum: Zeitraum) async {
         laedt = true

--- a/ios/Dorf/Bereiche/Rangliste/RanglisteView.swift
+++ b/ios/Dorf/Bereiche/Rangliste/RanglisteView.swift
@@ -7,8 +7,8 @@ import SwiftUI
 /// Lust machen, nicht Druck. Die ersten drei bekommen eine Medaille, mehr
 /// Podest braucht es nicht.
 struct RanglisteView: View {
-    @Environment(AppUmgebung.self) private var umgebung
-    @State private var modell = RanglisteModell()
+    @EnvironmentObject private var umgebung: AppUmgebung
+    @StateObject private var modell = RanglisteModell()
     @State private var zeitraum: Zeitraum = .saison
     @State private var erklaerteAuszeichnung: Auszeichnung?
 

--- a/ios/Dorf/Bereiche/Veranstaltungen/VeranstaltungenModell.swift
+++ b/ios/Dorf/Bereiche/Veranstaltungen/VeranstaltungenModell.swift
@@ -1,5 +1,5 @@
+import Combine
 import Foundation
-import Observation
 
 /// Zustand der Ansicht „Was ist los in Rössing".
 ///
@@ -10,11 +10,10 @@ import Observation
 /// Es wird nichts geschrieben und nichts gemeldet — die App zeigt hier nur
 /// an. Kein Push für Termine: Eine Erinnerung wäre ein eigenes Thema mit
 /// eigener Einwilligung.
-@Observable
-final class VeranstaltungenModell {
-    private(set) var termine: [Termin] = []
-    private(set) var laedt = false
-    private(set) var fehlertext: String?
+final class VeranstaltungenModell: ObservableObject {
+    @Published private(set) var termine: [Termin] = []
+    @Published private(set) var laedt = false
+    @Published private(set) var fehlertext: String?
 
     private var geholt = false
     private let holen: () async throws -> [VeranstaltungDto]

--- a/ios/Dorf/Bereiche/Veranstaltungen/VeranstaltungenView.swift
+++ b/ios/Dorf/Bereiche/Veranstaltungen/VeranstaltungenView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// dorthin, wo der Termin zu Hause ist: bei einer externen Primärquelle zum
 /// Veranstalter, sonst auf die Seite des Dorfes. Doppelt erzählt wird nichts.
 struct VeranstaltungenView: View {
-    @State private var modell = VeranstaltungenModell()
+    @StateObject private var modell = VeranstaltungenModell()
 
     var body: some View {
         List {

--- a/ios/Dorf/Bereiche/Vergabe/VergabeModell.swift
+++ b/ios/Dorf/Bereiche/Vergabe/VergabeModell.swift
@@ -1,5 +1,5 @@
+import Combine
 import Foundation
-import Observation
 
 /// Woher der Bereich „Anfragen" seine Daten holt.
 ///
@@ -48,29 +48,28 @@ struct Zusagestand: Identifiable, Hashable {
 /// Wie in „Mithelfen" gilt: **Der letzte Stand bleibt stehen.** Fällt das
 /// Netz aus, wird die Liste nicht geleert, sondern bekommt einen Hinweis
 /// darüber — „gerade ist nichts offen" wäre im Funkloch eine Falschaussage.
-@Observable
-final class VergabeModell {
+final class VergabeModell: ObservableObject {
     private let quelle: VergabeQuelle
     /// Die eigene Kennung — nur, um eine Zusage als die eigene zu erkennen.
     let meinSub: String?
 
-    private(set) var eintraege: [Benachrichtigung] = []
-    private(set) var zusagen: [Zusagestand] = []
-    private(set) var laeuft = false
+    @Published private(set) var eintraege: [Benachrichtigung] = []
+    @Published private(set) var zusagen: [Zusagestand] = []
+    @Published private(set) var laeuft = false
     /// Ob überhaupt schon einmal ein Abruf durch war — davor zeigt die Liste
     /// einen Ladekreis statt „nichts offen".
-    private(set) var jeGeladen = false
+    @Published private(set) var jeGeladen = false
     /// Der letzte Abruf ist gescheitert, oder jemand war schneller — im
     /// Wortlaut des Backends.
-    private(set) var hinweis: String?
+    @Published private(set) var hinweis: String?
     /// Ein wirklich abgelehnter Schreibvorgang; als Meldung mit Ok-Knopf.
-    private(set) var fehler: String?
+    @Published private(set) var fehler: String?
     /// Kurze Rückmeldung nach einer Zusage.
-    private(set) var bestaetigung: String?
-    private(set) var laufendeVorgaenge: Set<Int64> = []
-    private(set) var laufendeHinweise: Set<Int64> = []
+    @Published private(set) var bestaetigung: String?
+    @Published private(set) var laufendeVorgaenge: Set<Int64> = []
+    @Published private(set) var laufendeHinweise: Set<Int64> = []
 
-    @ObservationIgnored private var verblassen: Task<Void, Never>?
+    private var verblassen: Task<Void, Never>?
 
     init(quelle: VergabeQuelle, meinSub: String? = nil) {
         self.quelle = quelle

--- a/ios/Dorf/Bereiche/Vergabe/VergabeView.swift
+++ b/ios/Dorf/Bereiche/Vergabe/VergabeView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// Die Regeln dazu (Reihenfolge, Fristen, Ruhezeiten) stehen im Backend.
 /// Hier steht nur, wie das aussieht und welche Knöpfe es gibt.
 struct VergabeView: View {
-    @Environment(AppUmgebung.self) private var umgebung
+    @EnvironmentObject private var umgebung: AppUmgebung
     @State private var modell: VergabeModell?
 
     var body: some View {
@@ -31,7 +31,7 @@ struct VergabeView: View {
 
 /// Die Liste, sobald das Modell steht.
 struct VergabeInhalt: View {
-    let modell: VergabeModell
+    @ObservedObject var modell: VergabeModell
 
     /// Der Vorgang, zu dem gerade nach der Rückgabe gefragt wird. Eine Zusage
     /// gibt niemand aus Versehen zurück.
@@ -137,7 +137,7 @@ struct VergabeInhalt: View {
 
 /// Eine Anfrage („du bist dran") oder ein Hinweis.
 struct BenachrichtigungZeile: View {
-    let modell: VergabeModell
+    @ObservedObject var modell: VergabeModell
     let eintrag: Benachrichtigung
 
     var body: some View {
@@ -200,7 +200,7 @@ struct BenachrichtigungZeile: View {
 
 /// Eine Zusage, die ich gegeben habe — samt Frist und dem Weg zurück.
 struct ZusageZeile: View {
-    let modell: VergabeModell
+    @ObservedObject var modell: VergabeModell
     let stand: Zusagestand
     var zurueckgeben: () -> Void
 

--- a/ios/Dorf/Bereiche/Verwaltung/VerwaltungFormulare.swift
+++ b/ios/Dorf/Bereiche/Verwaltung/VerwaltungFormulare.swift
@@ -43,11 +43,11 @@ extension VerwaltungModell {
 /// aus einem Tipp auf die Karte. Getippt wird sie nicht: Wer Zahlen abtippt,
 /// vertauscht Breite und Länge.
 struct OrtFormularView: View {
-    let modell: VerwaltungModell
+    @ObservedObject var modell: VerwaltungModell
     /// Die vorhandenen Orte — als Orientierung auf der Auswahlkarte.
     let orte: [Ort]
 
-    @State private var standort = Standortgeber()
+    @StateObject private var standort = Standortgeber()
     @State private var standortHinweis: String?
     @State private var wartetAufFreigabe = false
 
@@ -111,7 +111,7 @@ struct OrtFormularView: View {
         }
         .task { standort.beobachten() }
         .onDisappear { standort.ruhen() }
-        .onChange(of: standort.freigabe) { _, neue in freigabeGeaendert(neue) }
+        .onChange(of: standort.freigabe) { neue in freigabeGeaendert(neue) }
     }
 
     // MARK: Standort
@@ -210,7 +210,7 @@ struct OrtFormularView: View {
 /// das Backend wiese es ab, und die Ampel wüsste nicht, woran sie sich halten
 /// soll.
 struct AufgabeFormularView: View {
-    let modell: VerwaltungModell
+    @ObservedObject var modell: VerwaltungModell
 
     var body: some View {
         NavigationStack {
@@ -328,7 +328,7 @@ struct AufgabeFormularView: View {
 
 /// Der Hitzefaktor: eine tagesaktuelle Einstellung für das ganze Dorf.
 struct HitzefaktorAbschnitt: View {
-    let modell: VerwaltungModell
+    @ObservedObject var modell: VerwaltungModell
 
     @State private var wert: Double = 1
 
@@ -357,7 +357,7 @@ struct HitzefaktorAbschnitt: View {
             Text(Verwaltungstexte.hitzefaktor)
         }
         .task { wert = modell.hitzefaktor }
-        .onChange(of: modell.hitzefaktor) { _, neu in wert = neu }
+        .onChange(of: modell.hitzefaktor) { neu in wert = neu }
     }
 
     /// Der Stepper rechnet in Zehnteln; ohne Runden stünde nach ein paar

--- a/ios/Dorf/Bereiche/Verwaltung/VerwaltungModell.swift
+++ b/ios/Dorf/Bereiche/Verwaltung/VerwaltungModell.swift
@@ -1,5 +1,5 @@
+import Combine
 import Foundation
-import Observation
 
 /// Der Stand des Bereichs „Verwaltung": welches Formular offen ist, was
 /// gerade geschickt wird, was das Backend zuletzt abgelehnt hat.
@@ -297,29 +297,28 @@ enum Verwaltungstexte {
 
 // MARK: - Modell
 
-@Observable
-final class VerwaltungModell {
+final class VerwaltungModell: ObservableObject {
     private let quelle: VerwaltungQuelle
 
     /// Das offene Ortsformular (oder keins).
-    var ortFormular: OrtFormular?
+    @Published var ortFormular: OrtFormular?
     /// Das offene Aufgabenformular (oder keins).
-    var aufgabeFormular: AufgabeFormular?
+    @Published var aufgabeFormular: AufgabeFormular?
 
     /// Orte und Aufgaben, für die gerade geschrieben wird — solange bleiben
     /// ihre Knöpfe gesperrt.
-    private(set) var laufend: Set<Int64> = []
+    @Published private(set) var laufend: Set<Int64> = []
     /// Ein abgelehnter Vorgang außerhalb eines Formulars, im Wortlaut des
     /// Backends.
-    private(set) var fehler: String?
+    @Published private(set) var fehler: String?
     /// Kurze Rückmeldung („Ort gespeichert.").
-    private(set) var bestaetigung: String?
+    @Published private(set) var bestaetigung: String?
 
-    private(set) var hitzefaktor: Double = 1
-    private(set) var hitzefaktorGeladen = false
-    private(set) var hitzefaktorLaeuft = false
+    @Published private(set) var hitzefaktor: Double = 1
+    @Published private(set) var hitzefaktorGeladen = false
+    @Published private(set) var hitzefaktorLaeuft = false
 
-    @ObservationIgnored private var verblassen: Task<Void, Never>?
+    private var verblassen: Task<Void, Never>?
 
     init(quelle: VerwaltungQuelle) { self.quelle = quelle }
 

--- a/ios/Dorf/Bereiche/Verwaltung/VerwaltungView.swift
+++ b/ios/Dorf/Bereiche/Verwaltung/VerwaltungView.swift
@@ -17,13 +17,11 @@ struct VerwaltungView: View {
     var body: some View {
         Group {
             if !umgebung.binAdmin {
-                ContentUnavailableView(
+                Hinweistafel(
                     "Nur für die Verwaltung",
-                    systemImage: "lock",
-                    description: Text(
-                        "Orte und Aufgaben pflegt die Verwaltung des Dorfes. "
-                            + "Melden und Mithelfen kannst du in „Mithelfen“."
-                    )
+                    symbol: "lock",
+                    beschreibung: "Orte und Aufgaben pflegt die Verwaltung des Dorfes. "
+                        + "Melden und Mithelfen kannst du in „Mithelfen“."
                 )
                 .accessibilityIdentifier("verwaltung-gesperrt")
             } else if let orte, let modell {

--- a/ios/Dorf/Bereiche/Verwaltung/VerwaltungView.swift
+++ b/ios/Dorf/Bereiche/Verwaltung/VerwaltungView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// jede Änderung ohne die Rolle `admin` mit 403 abweist. Kommt trotzdem
 /// jemand hierher, steht hier der Satz des Backends — nicht ein erfundener.
 struct VerwaltungView: View {
-    @Environment(AppUmgebung.self) private var umgebung
+    @EnvironmentObject private var umgebung: AppUmgebung
     /// Die Ortsliste kommt aus demselben Modell wie „Mithelfen" — ein
     /// zweiter Abruf wäre eine zweite Wahrheit.
     @State private var orte: OrteModell?
@@ -51,8 +51,8 @@ struct VerwaltungView: View {
 // MARK: - Inhalt
 
 struct VerwaltungInhalt: View {
-    let orte: OrteModell
-    let modell: VerwaltungModell
+    @ObservedObject var orte: OrteModell
+    @ObservedObject var modell: VerwaltungModell
 
     @State private var rueckfrage: Rueckfrage?
 
@@ -224,7 +224,7 @@ enum Rueckfrage: Identifiable, Hashable {
 
 struct OrtAbschnitt: View {
     let ort: Ort
-    let modell: VerwaltungModell
+    @ObservedObject var modell: VerwaltungModell
     var frage: (Rueckfrage) -> Void
 
     var body: some View {
@@ -285,7 +285,7 @@ struct OrtAbschnitt: View {
 struct AufgabeZeile: View {
     let ort: Ort
     let aufgabe: Aufgabe
-    let modell: VerwaltungModell
+    @ObservedObject var modell: VerwaltungModell
     var frage: (Rueckfrage) -> Void
 
     var body: some View {

--- a/ios/Dorf/Design/Farben.swift
+++ b/ios/Dorf/Design/Farben.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+extension Color {
+    /// Die Trennlinienfarbe des Systems — dieselbe, die iOS zwischen
+    /// Listenzeilen zeichnet, und damit auch im Dunkelmodus richtig.
+    ///
+    /// SwiftUI kennt sie als `ShapeStyle.separator` erst ab iOS 17. Die App
+    /// läuft ab iOS 16, deshalb der Umweg über `UIColor` — es ist derselbe
+    /// Farbwert, nur älter erreichbar.
+    static let trennlinie = Color(uiColor: .separator)
+}

--- a/ios/Dorf/Design/Hinweistafel.swift
+++ b/ios/Dorf/Design/Hinweistafel.swift
@@ -61,7 +61,7 @@ struct Hinweistafel: View {
         Hinweistafel(
             "Keine Ergebnisse für \u{201E}\(text)\u{201C}",
             symbol: "magnifyingglass",
-            beschreibung: "Prüf die Schreibweise oder versuch es mit einem anderen Namen."
+            beschreibung: "Überprüfe die Schreibweise oder starte eine neue Suche."
         )
     }
 }

--- a/ios/Dorf/Design/Hinweistafel.swift
+++ b/ios/Dorf/Design/Hinweistafel.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// „Hier ist gerade nichts" — die ganzseitige Auskunft, wenn eine Liste oder
+/// eine Seite leer bleibt.
+///
+/// Sie ersetzt Apples `ContentUnavailableView`, die es erst ab iOS 17 gibt.
+/// Die App läuft ab iOS 16, damit auch ein iPhone 8 oder X mitkommt — und
+/// eine leere Fläche ohne Erklärung wäre die schlechteste Auskunft, gerade
+/// dort. Aufbau und Größenverhältnisse sind dieselben wie im Original: großes
+/// Symbol in Sekundärfarbe, darunter der Titel fett, darunter die
+/// Beschreibung — alles mittig.
+///
+/// Für VoiceOver ist die Tafel **ein** Element: Symbol, Titel und
+/// Beschreibung gehören zusammen und werden am Stück vorgelesen. Das Symbol
+/// selbst sagt nichts, was der Titel nicht schon sagt, und bleibt deshalb
+/// stumm.
+struct Hinweistafel: View {
+    /// Die Überschrift — kurz und in ganzen Worten („Noch niemand dabei").
+    let titel: String
+    /// Ein SF-Symbol, das zum Titel passt.
+    let symbol: String
+    /// Der erklärende Satz darunter. Ohne ihn steht nur der Titel da.
+    var beschreibung: String?
+
+    init(_ titel: String, symbol: String, beschreibung: String? = nil) {
+        self.titel = titel
+        self.symbol = symbol
+        self.beschreibung = beschreibung
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: symbol)
+                .font(.system(size: 52, weight: .regular))
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 4)
+                // Das Symbol wiederholt nur den Titel — vorgelesen wird es
+                // nicht.
+                .accessibilityHidden(true)
+
+            Text(titel)
+                .font(.title2.weight(.bold))
+                .multilineTextAlignment(.center)
+
+            if let beschreibung {
+                Text(beschreibung)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.horizontal, 32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+    }
+
+    /// Der Sonderfall „Suche ohne Treffer" — entspricht
+    /// `ContentUnavailableView.search(text:)`.
+    static func suche(text: String) -> Hinweistafel {
+        Hinweistafel(
+            "Keine Ergebnisse für \u{201E}\(text)\u{201C}",
+            symbol: "magnifyingglass",
+            beschreibung: "Prüf die Schreibweise oder versuch es mit einem anderen Namen."
+        )
+    }
+}
+
+#Preview("Leer") {
+    Hinweistafel(
+        "Noch niemand dabei",
+        symbol: "person.2",
+        beschreibung: "Bisher hat niemand Angaben freigegeben."
+    )
+}
+
+#Preview("Suche") {
+    Hinweistafel.suche(text: "Meier")
+}

--- a/ios/Dorf/DorfApp.swift
+++ b/ios/Dorf/DorfApp.swift
@@ -10,19 +10,22 @@ struct DorfApp: App {
     @UIApplicationDelegateAdaptor(PushDelegat.self) private var pushDelegat
 
     @Environment(\.scenePhase) private var szene
-    @State private var umgebung = AppUmgebung()
+    @StateObject private var umgebung = AppUmgebung()
 
     var body: some Scene {
         WindowGroup {
             WurzelView()
-                .environment(umgebung)
+                .environmentObject(umgebung)
                 .tint(Color(red: 0.18, green: 0.56, blue: 0.24))
                 // Bei jeder Rückkehr in den Vordergrund: Die Kennung folgt
                 // der Erlaubnis. Wer die Mitteilungen in den
                 // iOS-Einstellungen wieder abdreht, dessen Kennung wird beim
                 // nächsten Mal weggeräumt. Gefragt wird hier niemand —
                 // das passiert erst beim Eintragen als Helfer:in.
-                .onChange(of: szene, initial: true) { _, neu in
+                // `initial:` gibt es erst ab iOS 17 — der erste Durchlauf
+                // steht deshalb als eigene Aufgabe daneben.
+                .task { await Benachrichtigungen.gemeinsam.abgleichen() }
+                .onChange(of: szene) { neu in
                     guard neu == .active else { return }
                     Task { await Benachrichtigungen.gemeinsam.abgleichen() }
                 }

--- a/ios/Dorf/Navigation/StartView.swift
+++ b/ios/Dorf/Navigation/StartView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// Bereich. Weitere kommen — deshalb eine Liste von Bereichen und keine
 /// Registerkarten, in die sich nichts mehr einfügen ließe.
 struct StartView: View {
-    @Environment(AppUmgebung.self) private var umgebung
+    @EnvironmentObject private var umgebung: AppUmgebung
     @State private var pfad = NavigationPath()
 
     var body: some View {

--- a/ios/Dorf/Navigation/WurzelView.swift
+++ b/ios/Dorf/Navigation/WurzelView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Entscheidet nur eins: angemeldet oder nicht. Alles Weitere hängt an
 /// [StartView].
 struct WurzelView: View {
-    @Environment(AppUmgebung.self) private var umgebung
+    @EnvironmentObject private var umgebung: AppUmgebung
 
     var body: some View {
         switch umgebung.anmeldung.sitzung {

--- a/ios/Dorf/Push/Benachrichtigungen.swift
+++ b/ios/Dorf/Push/Benachrichtigungen.swift
@@ -1,5 +1,5 @@
+import Combine
 import Foundation
-import Observation
 import UIKit
 import UserNotifications
 
@@ -35,8 +35,7 @@ nonisolated enum Benachrichtigungserlaubnis {
 /// **rohe APNs-Kennung** beim Dorfserver an, der Server spricht direkt mit
 /// Apple (`backend/internal/push/apns.go`). Kein Google im Spiel, keine
 /// schwere Fremdbibliothek — nur `UserNotifications` aus dem System.
-@Observable
-final class Benachrichtigungen {
+final class Benachrichtigungen: ObservableObject {
     /// Die Instanz, die der Systemdelegat bedient. Eine App hat genau ein
     /// Mitteilungszentrum, und `@UIApplicationDelegateAdaptor` baut sich
     /// seinen Delegaten selbst — deshalb ein fester Ort statt Durchreichen.
@@ -44,14 +43,14 @@ final class Benachrichtigungen {
 
     /// Was das System zuletzt gesagt hat. Für die Oberfläche („Mitteilungen
     /// sind aus — in den Einstellungen einschaltbar").
-    private(set) var stand: UNAuthorizationStatus = .notDetermined
+    @Published private(set) var stand: UNAuthorizationStatus = .notDetermined
 
     /// Ein Tipp auf eine Meldung. Wer die Navigation kennt, hängt sich hier
     /// ein; dieser Bereich weiß nichts über Bildschirme.
     var beiTipp: ((PushZiel) -> Void)?
 
-    @ObservationIgnored private var api: DorfApi?
-    @ObservationIgnored private let ablage: UserDefaults
+    private var api: DorfApi?
+    private let ablage: UserDefaults
 
     /// Für Tests und Vorschauen: eigene Ablage statt der der App.
     init(ablage: UserDefaults = .standard) {

--- a/ios/Dorf/Umgebung.swift
+++ b/ios/Dorf/Umgebung.swift
@@ -1,4 +1,4 @@
-import Observation
+import Combine
 import SwiftUI
 
 /// Alles, was die Bereiche der App brauchen, an einer Stelle — die
@@ -8,10 +8,9 @@ import SwiftUI
 ///
 /// Zugriff aus einer View:
 /// ```swift
-/// @Environment(AppUmgebung.self) private var umgebung
+/// @EnvironmentObject private var umgebung: AppUmgebung
 /// ```
-@Observable
-final class AppUmgebung {
+final class AppUmgebung: ObservableObject {
     let anmeldung: Anmeldung
     let api: DorfApi
 
@@ -26,8 +25,19 @@ final class AppUmgebung {
     /// Wer gerade angemeldet ist. Wird nach der Anmeldung einmal geladen und
     /// danach von den Bereichen mitbenutzt — `isAdmin` entscheidet, ob der
     /// Bereich „Verwaltung" überhaupt auftaucht.
-    private(set) var ich: Ich?
-    private(set) var ichFehler: String?
+    @Published private(set) var ich: Ich?
+    @Published private(set) var ichFehler: String?
+
+    /// Die Änderungen der beiden eigenen Modelle weiterreichen.
+    ///
+    /// `ObservableObject` beobachtet — anders als das Observation-Framework —
+    /// **nicht** durch verschachtelte Objekte hindurch: Eine Ansicht, die
+    /// `umgebung.orte.giessfaktor` liest, erführe von einer neuen Ortsliste
+    /// sonst nichts. Deshalb sagt die Umgebung selbst Bescheid, sobald eines
+    /// ihrer Modelle sich meldet. Gröber als vorher (die ganze Ansicht wird
+    /// neu gezeichnet statt nur das gelesene Feld), aber inhaltlich gleich —
+    /// und niemand muss daran denken.
+    private var weiterleitungen: [AnyCancellable] = []
 
     init(anmeldung: Anmeldung = Anmeldung()) {
         let api = DorfApi(tokenGeber: { [anmeldung] in
@@ -40,6 +50,7 @@ final class AppUmgebung {
         // Gerätekennung an und beim Abmelden wieder ab. Gefragt wird damit
         // noch niemand — das passiert erst beim Eintragen als Helfer:in.
         Benachrichtigungen.gemeinsam.verdrahten(api: api)
+        kinderWeiterreichen()
     }
 
     /// Für Vorschauen und Tests: eine Umgebung, die nichts abruft.
@@ -48,6 +59,14 @@ final class AppUmgebung {
         self.api = api
         self.orte = orte ?? OrteModell(api: api)
         self.ich = ich
+        kinderWeiterreichen()
+    }
+
+    private func kinderWeiterreichen() {
+        weiterleitungen = [
+            anmeldung.objectWillChange.sink { [weak self] in self?.objectWillChange.send() },
+            orte.objectWillChange.sink { [weak self] in self?.objectWillChange.send() },
+        ]
     }
 
     var binAdmin: Bool { ich?.isAdmin ?? false }

--- a/ios/OFFEN.md
+++ b/ios/OFFEN.md
@@ -90,6 +90,42 @@ gleichzeitig an der App gebaut haben; sie sind eingearbeitet und gelöscht.
 - **Kein Zwischenspeicher je Zeitraum** in der Rangliste: Jedes Umschalten
   fragt neu. Bei fünf Zeiträumen und kleinen Antworten verschmerzbar.
 
+## Was iOS 16 als Mindestfassung bedeutet
+
+Die App läuft ab **iOS 16** (vorher iOS 17), damit iPhone 8, 8 Plus und X
+(2017) mitkommen. Tiefer geht es bewusst nicht: Ein iPhone 6s tut sich mit
+der Vektorkarte schwer. Was dafür anders ist als in einer iOS-17-App:
+
+- **Kein Observation-Framework.** Die dreizehn Modelle sind
+  `ObservableObject` mit `@Published`; die Ansichten halten sie als
+  `@StateObject`, `@ObservedObject` oder `@EnvironmentObject`. Das beobachtet
+  **gröber** als `@Observable`: Jede Meldung zeichnet die ganze Ansicht neu,
+  nicht nur das gelesene Feld. Für eine App dieser Größe ist das nicht zu
+  merken — wer aber eine Eigenschaft **ohne** `@Published` hinzufügt,
+  bekommt eine Oberfläche, die sich nicht mehr aktualisiert, und **kein Test
+  merkt das**: Die Tests prüfen die Modelle direkt.
+- **`ObservableObject` beobachtet nicht durch verschachtelte Objekte
+  hindurch.** `AppUmgebung` reicht die Meldungen von `Anmeldung` und
+  `OrteModell` deshalb ausdrücklich weiter (siehe `Umgebung.swift`). Kommt
+  ein drittes eigenes Modell in die Umgebung, gehört es dort dazu — sonst
+  bleibt die Startseite stehen.
+- **Kein `ContentUnavailableView`.** An seiner Stelle steht `Hinweistafel`
+  (`Dorf/Design/Hinweistafel.swift`), gleiches Aussehen, gleiche
+  Zugänglichkeit. Ihre Texte sind jetzt unsere, nicht mehr Apples — eine
+  neue Systemsprache übersetzt sie also nicht mit.
+- **Ältere Fassungen einiger SwiftUI-Aufrufe**: `onChange` ohne `initial:`
+  und ohne alten Wert, `navigationDestination(isPresented:)` statt
+  `(item:)`, `Color.trennlinie` statt `ShapeStyle.separator`. Alle vier sind
+  ab iOS 17 als veraltet markiert; solange die Mindestfassung 16 ist, warnt
+  der Übersetzer nicht.
+- **Ein `if #available` gibt es nirgends.** Für jede benutzte iOS-17-API gab
+  es eine ältere Fassung mit demselben Verhalten; keine Funktion wurde
+  weggelassen.
+- **Geprüft wurde bisher nur auf einem iOS-26-Simulator.** Das Mindest-Ziel
+  ist gesenkt, ein Lauf auf einem echten iOS-16-Gerät (oder wenigstens einer
+  iOS-16-Simulator-Laufzeit) steht aus — dort verhalten sich `List`,
+  `NavigationStack` und `.searchable` in Kleinigkeiten anders.
+
 ## Aus der Zusammenführung der Zugänge
 
 Seit `refactor(ios): genau ein Weg zum Backend` gibt es wieder genau **eine**

--- a/ios/README.md
+++ b/ios/README.md
@@ -4,8 +4,21 @@ Native iOS-App zur Dorf-App Rössing — dieselbe Rössing-ID, dasselbe Backend,
 dieselben Regeln wie in `android/`. Was das Backend entscheidet, entscheidet
 die App nicht noch einmal.
 
-Swift 6 und SwiftUI, Mindestfassung iOS 17, iPhone und iPad
+Swift 6 und SwiftUI, **Mindestfassung iOS 16**, iPhone und iPad
 (`TARGETED_DEVICE_FAMILY: "1,2"`). Einzige Fremdbibliothek ist MapLibre.
+
+iOS 16 statt 17 ist eine Entscheidung fürs Dorf: iOS 17 läuft erst ab
+iPhone XS/XR (2018), iOS 16 nimmt iPhone 8, 8 Plus und X (2017) dazu. Wer die
+Blumenkästen gießt, hat nicht zwangsläufig das neueste Telefon. Tiefer geht
+es bewusst nicht — ein iPhone 6s tut sich mit der Vektorkarte schwer, und
+eine App zu versprechen, die dann ruckelt, wäre keine Wohltat.
+
+Was das im Quelltext heißt: **kein Observation-Framework** (`@Observable`
+gibt es erst ab iOS 17) — die Modelle sind `ObservableObject` mit
+`@Published`, die Ansichten halten sie als `@StateObject`,
+`@ObservedObject` oder `@EnvironmentObject`. Und **kein
+`ContentUnavailableView`**: An seiner Stelle steht `Hinweistafel` unter
+`Dorf/Design/`.
 
 ## Bauen und testen
 
@@ -74,7 +87,7 @@ Der Weg im Ganzen, mit allem, was ein Mensch bei Apple klicken muss:
 | Ort | Inhalt |
 |---|---|
 | `Dorf/Konfiguration.swift` | Adressen und Kennungen, aus Build-Einstellungen (`project.yml`) über die `Info.plist` |
-| `Dorf/Umgebung.swift` | `AppUmgebung` — die Handverdrahtung, Gegenstück zu `AppContainer` auf Android |
+| `Dorf/Umgebung.swift` | `AppUmgebung` — die Handverdrahtung, Gegenstück zu `AppContainer` auf Android; reicht die Meldungen von `Anmeldung` und `OrteModell` weiter, weil `ObservableObject` nicht durch verschachtelte Objekte hindurch beobachtet |
 | `Dorf/Daten/Modelle.swift` | Die DTOs des Backends. Feldnamen 1:1 wie im JSON |
 | `Dorf/Daten/DorfApi.swift` | Der einzige Weg zum Backend (`URLSession`, kein Framework) |
 | `Dorf/Daten/DorfApi+*.swift` | Weitere Endpunkte als Anhänge — derselbe Transport |
@@ -82,7 +95,7 @@ Der Weg im Ganzen, mit allem, was ein Mensch bei Apple klicken muss:
 | `Dorf/Anmeldung/` | OIDC Authorization Code + PKCE (`ASWebAuthenticationSession`), Schlüsselbund, Anmeldebildschirm |
 | `Dorf/Navigation/` | Startseite und Verdrahtung der Bereiche (`Ziel`) |
 | `Dorf/Bereiche/<Bereich>/` | Je Bereich ein Ordner. Ein Bereich fasst keinen fremden an |
-| `Dorf/Design/` | Ampel-Farben, Zahlen- und Datumsformate |
+| `Dorf/Design/` | Ampel-Farben, Zahlen- und Datumsformate, `Hinweistafel` (leere Seiten), `Color.trennlinie` |
 | `Dorf/Assets.xcassets/` | App-Icon (hell, dunkel, eingefärbt) und Akzentfarbe |
 | `DorfTests/` | Unit-Tests (swift-testing) |
 

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -7,7 +7,7 @@ name: Dorf
 options:
   bundleIdPrefix: de.roessing
   deploymentTarget:
-    iOS: "17.0"
+    iOS: "16.0"
   createIntermediateGroups: true
   groupSortPosition: top
   generateEmptyDirectories: true


### PR DESCRIPTION
Das Mindest-System sinkt von **iOS 17.0 auf iOS 16.0**. Damit kommen iPhone 8,
8 Plus und X dazu — Baujahr 2017.

Der Grund ist nicht technisch, sondern der Zweck der App: Wer im Dorf die
Blumenkästen gießt, ist selten der mit dem neuesten Telefon. iOS 17 setzt ein
iPhone XS oder neuer voraus (2018). Tiefer als 16 gehen wir bewusst **nicht**:
Ein iPhone 6s ist elf Jahre alt und tut sich mit der Vektorkarte schwer — da
verspräche man etwas, das dann ruckelt.

## Was umgebaut wurde

- **`@Observable` → `ObservableObject`** in 13 Klassen. Das
  Observation-Framework gibt es erst ab iOS 17. Übersetzungsregel: gespeicherte
  `var` → `@Published`, `@ObservationIgnored` → weg, `let` bleibt `let`.
  Echte `private` vars bekommen bewusst kein `@Published` — sie konnten auch
  vorher keine Ansicht neu zeichnen.
- **`ContentUnavailableView` → eigene `Hinweistafel`** (`Dorf/Design/`), an
  allen vier Fundstellen. Optisch gegen das Original gestellt: deckungsgleich.
- **`onChange` mit zwei Parametern** an **fünf** Stellen auf die iOS-16-Form.
- **`ShapeStyle.separator`** → eigene `Color.trennlinie` (derselbe Farbwert,
  auch im Dunkelmodus).
- **`navigationDestination(item:)`** → `navigationDestination(isPresented:)`.

**Nirgends steht ein `if #available`, und keine Funktion ist weggefallen** —
für jeden Fall gab es eine echte iOS-16-Entsprechung.

## Die Stelle, an der so ein Umbau still kaputtgeht

`ObservableObject` beobachtet **nicht durch verschachtelte Objekte hindurch**.
`WurzelView` liest `umgebung.anmeldung.sitzung`, `StartView` liest
`umgebung.orte.giessfaktor` und `.orte`. `AppUmgebung` reicht die Meldungen
ihrer beiden Modelle deshalb ausdrücklich weiter (`objectWillChange.sink`,
kommentiert in `Umgebung.swift`). **Ohne das wäre die Startseite tot gewesen —
und kein Test hätte es gemerkt**, weil die Tests die Modelle direkt prüfen.

Zwei weitere stille Fallen derselben Art: hereingereichte Modelle brauchen
`@ObservedObject` statt `let` (17 Stellen), und `@State` wird zu `@StateObject`
(6 Stellen).

## Geprüft

- **181 Tests in 11 Suiten grün** — unverändert, **keine Testdatei angefasst**;
  die Modelle behielten ihre Signaturen
- `IPHONEOS_DEPLOYMENT_TARGET = 16.0` im gebauten Produkt nachgesehen
- **Im Simulator durchgetippt** (lokales Backend, Beispieldaten,
  Entwickler-Login): Startseite mit Gruß, Hitzehinweis und „5 Orte warten auf
  dich" — alle drei lesen **durch** `umgebung` hindurch und beweisen damit,
  dass die Weiterleitung greift. Dazu Liste, Karte, Ortsdetail mit Historie,
  Profil, Rangliste, Veranstaltungen, Einstellungen, Dorfbewohner mit
  Hinweistafel, Anfragen, Verwaltung mit geladenem Hitzefaktor, Ideen mit
  Vorbelegung aus dem Profil
- `make -C ios pruefen` grün

## Was offen bleibt

- **Kein Lauf auf einer echten iOS-16-Laufzeit.** Diese VM hat nur iOS 26. Das
  Ziel ist gesenkt und übersetzt sauber, aber `List`, `NavigationStack` und
  `.searchable` verhalten sich unter 16 in Kleinigkeiten anders. Vermerkt in
  `ios/OFFEN.md`.
- **Vorbestehender Fund, nicht von diesem Umbau:** Das Blatt „Konto löschen"
  öffnet unter XCUITest nicht — der Knopf ist da, der Tipp geht durch, das
  Blatt bleibt aus. Gegen die Ursprungsfassung geprüft: dort genauso.
  Vermutlich, weil `.sheet` an einer `Section` innerhalb der `List` hängt.
- Die Mindestfassung am Store-Eintrag ist nicht angepasst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
