### PR TITLE
fix(ios): Absturz bei jedem Tipp auf eine Meldung — und die Terminliste lesbar gemacht

### DIFF
--- a/ios/Dorf/Bereiche/Veranstaltungen/TerminDetailView.swift
+++ b/ios/Dorf/Bereiche/Veranstaltungen/TerminDetailView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+/// Ein Termin des Dorfes, ausführlich — ohne die App zu verlassen.
+///
+/// Bewusst nur für **eigene** Termine: Verweist ein Eintrag auf eine fremde
+/// Primärquelle, führt der Tipp dorthin. Denselben Inhalt an zwei Stellen zu
+/// erzählen heißt, dass eine der beiden irgendwann falsch ist — dieselbe
+/// Regel, nach der die Termine überhaupt nur auf rössing.de gepflegt werden.
+struct TerminDetailView: View {
+    let termin: Termin
+
+    var body: some View {
+        List {
+            Section {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(termin.datumText)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.tint)
+                    Text(termin.name)
+                        .font(.title3.weight(.semibold))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.vertical, 4)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(termin.name). \(termin.vorlesetext)")
+            }
+
+            Section("Wann") {
+                Beschriftet(symbol: "calendar", titel: "Tag", wert: termin.datumText)
+                // Ganztägig heißt: Es gibt keine Uhrzeit — und es wird auch
+                // keine erfunden.
+                Beschriftet(symbol: "clock", titel: "Uhrzeit",
+                            wert: termin.zeitText ?? "Ganztägig")
+            }
+
+            if termin.ortName != nil || termin.veranstalter != nil {
+                Section("Wo und von wem") {
+                    if let ortName = termin.ortName {
+                        Beschriftet(symbol: "mappin.and.ellipse", titel: "Ort", wert: ortName)
+                    }
+                    if let adresse = termin.ortAdresse {
+                        Beschriftet(symbol: nil, titel: "Adresse", wert: adresse)
+                    }
+                    if let veranstalter = termin.veranstalter {
+                        Beschriftet(symbol: "person.2", titel: "Veranstalter", wert: veranstalter)
+                    }
+                }
+            }
+
+            if !termin.beschreibung.isEmpty {
+                Section("Worum es geht") {
+                    Text(termin.beschreibung)
+                        .font(.body)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.vertical, 2)
+                        .accessibilityIdentifier("termin-beschreibung")
+                }
+            }
+
+            if let adresse = termin.adresse {
+                Section {
+                    Link(destination: adresse) {
+                        Label("Auf rössing.de ansehen", systemImage: "safari")
+                    }
+                    .accessibilityIdentifier("termin-quelle")
+                } footer: {
+                    Text("Gepflegt wird der Termin auf rössing.de. Dort steht "
+                        + "immer der neueste Stand.")
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Termin")
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("termin-detail")
+    }
+}
+
+/// Eine Zeile „Titel — Wert" mit Symbol, damit Wann und Wo gleich aussehen.
+private struct Beschriftet: View {
+    let symbol: String?
+    let titel: String
+    let wert: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Group {
+                if let symbol { Image(systemName: symbol) } else { Color.clear }
+            }
+            .font(.footnote)
+            .frame(width: 18)
+            .foregroundStyle(.secondary)
+            .accessibilityHidden(true)
+            Text(titel).foregroundStyle(.secondary)
+            Spacer(minLength: 12)
+            Text(wert)
+                .multilineTextAlignment(.trailing)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(titel): \(wert)")
+    }
+}

--- a/ios/Dorf/Bereiche/Veranstaltungen/VeranstaltungenView.swift
+++ b/ios/Dorf/Bereiche/Veranstaltungen/VeranstaltungenView.swift
@@ -86,45 +86,52 @@ private struct TerminZeile: View {
     let termin: Termin
 
     var body: some View {
-        Gruppierung(ziel: termin.adresse) {
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 6) {
-                    Text(termin.datumText)
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.tint)
-                    if termin.extern {
-                        Image(systemName: "arrow.up.forward.square")
-                            .font(.footnote)
+        Gruppierung(termin: termin) {
+            HStack(alignment: .top, spacing: 14) {
+                Datumsmarke(termin: termin)
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(termin.name)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    // Ganztägig heißt: Es gibt keine Uhrzeit. Dann wird auch
+                    // keine erfunden, sondern schlicht „Ganztägig" gesagt.
+                    Angabe(symbol: "clock", text: termin.zeitText ?? "Ganztägig")
+                    if let ortName = termin.ortName {
+                        Angabe(symbol: "mappin.and.ellipse", text: ortName)
+                        if let adresse = termin.ortAdresse {
+                            Angabe(symbol: nil, text: adresse)
+                        }
+                    }
+                    if let veranstalter = termin.veranstalter {
+                        Angabe(symbol: "person.2", text: veranstalter)
+                    }
+
+                    if !termin.beschreibung.isEmpty {
+                        Text(termin.beschreibung)
+                            .font(.subheadline)
                             .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                            .padding(.top, 1)
+                    }
+                    if termin.extern, let gastgeber = termin.veranstalter ?? termin.ortName {
+                        Text("Mehr bei \(gastgeber)")
+                            .font(.caption)
+                            .foregroundStyle(.tint)
+                            .padding(.top, 1)
                     }
                 }
 
-                Text(termin.name).font(.headline)
+                Spacer(minLength: 0)
 
-                // Ganztägig heißt: Es gibt keine Uhrzeit. Dann wird auch keine
-                // erfunden, sondern schlicht „Ganztägig" gesagt.
-                Angabe(symbol: "clock", text: termin.zeitText ?? "Ganztägig")
-                if let ortName = termin.ortName {
-                    Angabe(symbol: "mappin.and.ellipse", text: ortName)
-                    if let adresse = termin.ortAdresse {
-                        Angabe(symbol: nil, text: adresse)
-                    }
-                }
-                if let veranstalter = termin.veranstalter {
-                    Angabe(symbol: "person.2", text: veranstalter)
-                }
-
-                if !termin.beschreibung.isEmpty {
-                    Text(termin.beschreibung)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(3)
-                }
-                if termin.extern {
-                    Text("Zur Seite des Veranstalters")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                // Ein Termin, der nach draußen führt, sagt das mit dem Symbol,
+                // das iOS dafür benutzt — nicht mit einer anderen Textfarbe.
+                Image(systemName: termin.extern ? "arrow.up.forward.app" : "chevron.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+                    .padding(.top, 3)
             }
             .padding(.vertical, 4)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -133,7 +140,7 @@ private struct TerminZeile: View {
         .accessibilityLabel(vorlesetext)
         .accessibilityHint(termin.extern
             ? "Öffnet die Seite des Veranstalters."
-            : "Öffnet die Seite auf rössing.de.")
+            : "Zeigt den Termin ausführlich.")
         .accessibilityIdentifier("termin-\(termin.id)")
     }
 
@@ -147,17 +154,60 @@ private struct TerminZeile: View {
     }
 }
 
-/// Ein Termin ohne brauchbare Adresse bekommt keinen Knopf ins Leere, sondern
-/// bleibt schlicht eine Zeile.
+/// Datum als kleine Marke statt als grüner Fließtext: Wochentag, Tag, Monat
+/// untereinander. Das ist die einzige Stelle der Zeile, die Farbe trägt — so
+/// findet das Auge beim Blättern die Daten, ohne dass alles bunt ist.
+private struct Datumsmarke: View {
+    let termin: Termin
+
+    private static func teil(_ muster: String, _ datum: Date) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "de_DE")
+        f.timeZone = Zeitpunkt.dorfZone
+        f.dateFormat = muster
+        return f.string(from: datum)
+    }
+
+    var body: some View {
+        VStack(spacing: 1) {
+            Text(Self.teil("EEEEEE", termin.beginn).uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(Self.teil("d", termin.beginn))
+                .font(.title2.weight(.bold))
+                .foregroundStyle(.tint)
+            Text(Self.teil("MMM", termin.beginn))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .frame(width: 46)
+        .padding(.vertical, 8)
+        .background(Color.accentColor.opacity(0.10), in: RoundedRectangle(cornerRadius: 10))
+        .accessibilityHidden(true)
+    }
+}
+
+/// Wohin ein Tipp führt: bei einer fremden Primärquelle nach draußen, sonst
+/// auf die eigene Detailseite.
 private struct Gruppierung<Inhalt: View>: View {
-    let ziel: URL?
+    let termin: Termin
     @ViewBuilder let inhalt: () -> Inhalt
 
     var body: some View {
-        if let ziel {
+        if termin.extern, let ziel = termin.adresse {
+            // Fremde Primärquelle: Der Tipp führt dorthin, wo der Termin zu
+            // Hause ist. Ihn hier nachzuerzählen hieße, eine zweite Fassung in
+            // die Welt zu setzen, die irgendwann von der ersten abweicht.
+            //
+            // .plain ist dabei der springende Punkt: Ohne ihn färbt Link
+            // seinen *gesamten* Inhalt mit der Akzentfarbe — Titel, Ort,
+            // Veranstalter, alles grün.
             Link(destination: ziel) { inhalt() }
+                .buttonStyle(.plain)
         } else {
-            inhalt()
+            // Termin des Dorfes: Alles, was wir dazu haben, steht schon in der
+            // Datei. Dafür muss niemand die App verlassen.
+            NavigationLink { TerminDetailView(termin: termin) } label: { inhalt() }
         }
     }
 }

--- a/ios/Dorf/Push/PushDelegat.swift
+++ b/ios/Dorf/Push/PushDelegat.swift
@@ -47,7 +47,7 @@ final class PushDelegat: NSObject, UIApplicationDelegate, UNUserNotificationCent
     /// Eine Meldung trifft ein, während die App im Vordergrund läuft. Ohne
     /// diese Antwort zeigt iOS gar nichts an — wer gerade die Ortsliste
     /// ansieht, bekäme die Anfrage sonst nicht mit.
-    nonisolated func userNotificationCenter(
+    func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
@@ -56,18 +56,27 @@ final class PushDelegat: NSObject, UIApplicationDelegate, UNUserNotificationCent
 
     /// Jemand hat auf die Meldung getippt.
     ///
+    /// **Diese Methode muss auf dem Hauptthread laufen.** Sie war einmal
+    /// `nonisolated` — dann erledigt Swift den Rückweg auf einem beliebigen
+    /// Nebenläufigkeits-Thread, und UIKit ruft den daraus erzeugten
+    /// Abschluss-Baustein ebenfalls dort auf. `UIApplication` prüft das mit
+    /// einer Assertion und bricht die App ab (`EXC_CRASH (SIGABRT)` in
+    /// `_performBlockAfterCATransactionCommitSynchronizes`). Das traf **jede**
+    /// angetippte Meldung, nicht nur solche mit ungewöhnlicher Nutzlast.
+    ///
+    /// Ohne `nonisolated` ist die Methode `MainActor`-isoliert (Vorbelegung
+    /// des Ziels, siehe `project.yml`), und der Rückweg stimmt.
+    ///
     /// Die Nutzlast wird noch hier ausgelesen: `UNNotificationResponse` darf
     /// die Isolationsgrenze nicht überqueren, `PushZiel` schon — es ist
     /// `Sendable` und trägt genau die Zeichenketten, die das Backend
     /// mitgeschickt hat.
-    nonisolated func userNotificationCenter(
+    func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {
         let ziel = PushZiel.ausDaten(response.notification.request.content.userInfo)
         guard let ziel else { return }
-        await MainActor.run {
-            Benachrichtigungen.gemeinsam.beiTipp?(ziel)
-        }
+        Benachrichtigungen.gemeinsam.beiTipp?(ziel)
     }
 }


### PR DESCRIPTION
Zwei Dinge am Bereich „Was ist los in Rössing" — und ein Absturz, der beim
Ausprobieren auffiel.

## Die App stürzte bei **jedem** Tipp auf eine Meldung ab

Nicht nur bei ungewöhnlicher Nutzlast: bei jeder. Belegt am Absturzprotokoll
eines iPad (7. Generation, iOS 18.7.7) aus TestFlight:

```
Exception Type:  EXC_CRASH (SIGABRT)
Triggered by Thread: 14
14  Dorf       @objc closure #1 in PushDelegat.userNotificationCenter(_:didReceive:)
11  UIKitCore  -[UIApplication _performBlockAfterCATransactionCommitSynchronizes:]
10  Foundation -[NSAssertionHandler handleFailureInMethod:…]
```

**Thread 14, nicht Thread 0** — das ist der Befund. Die beiden Delegat-Methoden
waren `nonisolated` und `async`; damit erledigt Swift den Rückweg auf einem
beliebigen Nebenläufigkeits-Thread, und UIKit ruft den daraus erzeugten
Abschluss-Baustein ebenfalls dort auf. `UIApplication` prüft das mit einer
Assertion und bricht ab.

Ohne `nonisolated` sind beide Methoden `MainActor`-isoliert (Vorbelegung des
Ziels), und der Rückweg stimmt. Die Begründung steht im Quelltext, damit es
niemand zurückdreht.

**Im Simulator fällt das nicht auf** — dort ist die Zustellung eine andere.
Gefunden wurde es, weil eine Meldung von Hand über APNs an ein echtes Gerät
ging und die App beim Antippen starb.

## Die Terminliste war komplett grün

Titel, Ort, Veranstalter — alles. Keine Stilentscheidung, sondern eine
SwiftUI-Voreinstellung: `Link` färbt seinen *gesamten* Inhalt mit der
Akzentfarbe. `.buttonStyle(.plain)` gibt jedem Text seine eigene zurück; grün
bleibt nur, wo es etwas bedeutet.

Dazu eine Zeile, die man überfliegen kann: Datum als Marke links (Wochentag,
Tag, Monat untereinander), Titel und Angaben rechts, am Rand ein Symbol, das
sagt, wohin der Tipp führt.

## Detailseite für eigene Termine

Termine des Dorfes öffnen jetzt eine Seite **in der App**: Wann, Wo und von
wem, die vollständige Beschreibung, unten der Verweis auf rössing.de.

**Nur die eigenen.** Verweist ein Eintrag auf eine fremde Primärquelle, führt
der Tipp weiterhin dorthin. Denselben Inhalt an zwei Stellen zu erzählen heißt,
dass eine der beiden irgendwann falsch ist — dieselbe Regel, nach der die
Termine überhaupt nur auf rössing.de gepflegt werden.

## Geprüft

181 Tests in 11 Suiten grün, `pruefe_lokale_tests.py` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
