### PR TITLE
docs: Android und iOS bleiben auf demselben Stand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,22 @@ Flux deployt in den K3S-Cluster). Details: siehe `README.md`.
   eigener Zug — nicht nebenbei in einer fachlichen Änderung, sonst wird jeder
   Zweig unlesbar groß und kollidiert mit den anderen. Neuer Quelltext hält
   sich an die Regel, angefasster Bestand bleibt, wie er heißt.
+- **Android und iOS bleiben auf demselben Stand.** Die beiden Apps sind
+  **ein** Produkt in zwei Fassungen, nicht zwei Produkte. Was die eine kann,
+  kann die andere; was aus der einen verschwindet, verschwindet aus der
+  anderen. Eine fachliche Änderung ist **nicht fertig**, wenn sie nur in einer
+  App steht — dann gibt es zwei Dörfer, und wer das falsche Telefon hat, sieht
+  etwas anderes als der Nachbar. Wer eine Fassung ändert, ändert die andere
+  mit oder schreibt ausdrücklich hin, warum nicht, und legt die Nacharbeit an.
+  Das gilt auch fürs **Ausliefern**: Ein Stand ist erst draußen, wenn er in
+  **beiden** Kanälen liegt — Play-Track `internal` und TestFlight. Eine
+  Verbesserung, die nur eine Hälfte des Dorfes erreicht, ist eine halbe
+  Verbesserung, und der Unterschied fällt genau dann auf, wenn zwei Leute
+  nebeneinanderstehen und vergleichen.
+  Ausgenommen ist allein, was die Plattform selbst vorgibt: Push heißt auf
+  Android FCM und auf iOS APNs, die Anmeldung sieht anders aus, die
+  Bedienelemente gehören zum jeweiligen System. **Der Funktionsumfang ist
+  davon nicht betroffen.**
 - **Backend**: Nur Standard-Library-HTTP (`net/http`, Go 1.22-Routing),
   `modernc.org/sqlite` (CGO-frei!), keine schweren Frameworks. Vor jedem
   Commit: `gofmt -w . && go vet ./... && go test ./...`.


### PR DESCRIPTION
Die Regel fehlte in `CLAUDE.md` — und heute ist aufgefallen, warum das ein
Problem ist: Der Verwaltungsbereich wurde in beiden Apps zurückgebaut, weil ich
es beiden Agenten ausdrücklich gesagt habe. Stünde es nicht in einem Auftrag,
sondern nur in einem Kopf, wäre beim nächsten Mal eine Fassung stehengeblieben.

Neu als Regel:

- Die beiden Apps sind **ein Produkt in zwei Fassungen**. Was die eine kann,
  kann die andere; was aus der einen verschwindet, verschwindet aus der anderen.
- Eine fachliche Änderung ist **nicht fertig**, wenn sie nur in einer App steht.
  Wer eine Fassung ändert, ändert die andere mit — oder schreibt hin, warum
  nicht, und legt die Nacharbeit an.
- **Auch fürs Ausliefern:** Ein Stand ist erst draußen, wenn er in beiden
  Kanälen liegt — Play-Track `internal` und TestFlight.
- Ausgenommen ist nur, was die Plattform vorgibt: FCM gegen APNs, das Aussehen
  der Anmeldung, die Bedienelemente. **Der Funktionsumfang nicht.**

Nur Dokumentation, kein Quelltext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)