### PR TITLE
release: Version 0.1.10 für Android und iOS

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -31,8 +31,8 @@ android {
         // keinen Build mit kleinerer Nummer über einen größeren — sonst
         // müssten alle Tester die App erst deinstallieren. Ab hier wieder in
         // Einerschritten weiterzählen.
-        versionCode = 1000109
-        versionName = "0.1.9"
+        versionCode = 1000110
+        versionName = "0.1.10"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -66,7 +66,12 @@ targets:
         # scheitert `@testable import Dorf` in jedem Test.
         INFOPLIST_FILE: Dorf/Info.plist
         CURRENT_PROJECT_VERSION: "1"
-        MARKETING_VERSION: "0.1.0"
+        # Beide Apps tragen dieselbe Nummer: Sie sind ein Produkt in zwei
+        # Fassungen, und "Rössing 0.1.10" soll auf beiden Telefonen
+        # dasselbe bedeuten (siehe CLAUDE.md, "Android und iOS bleiben auf
+        # demselben Stand"). Die Buildnummer bleibt davon unberührt —
+        # sie zählt Auslieferungen, nicht Stände.
+        MARKETING_VERSION: "0.1.10"
         TARGETED_DEVICE_FAMILY: "1,2"
         # Ohne Apple-Entwicklerkonto lässt sich für den Simulator bauen; für
         # Gerät und TestFlight trägt DEVELOPMENT_TEAM die Team-ID nach.

--- a/store/metadata/android/de-DE/changelogs/1000110.txt
+++ b/store/metadata/android/de-DE/changelogs/1000110.txt
@@ -1,0 +1,3 @@
+Geändert: Orte und Aufgaben werden nicht mehr in der App gepflegt, sondern mit Claude über den Dorfserver oder in der Web-Verwaltung. Wer verwalten darf, findet beide Wege jetzt auf der Startseite.
+
+Der Grund: Claude kennt auf dem Telefon den Standort. Man kann vor dem Blumenkasten stehen und die Koordinaten übernehmen lassen – dafür braucht es die App nicht mehr.

--- a/store/metadata/android/en-US/changelogs/1000110.txt
+++ b/store/metadata/android/en-US/changelogs/1000110.txt
@@ -1,0 +1,3 @@
+Changed: Places and tasks are no longer maintained inside the app. Use Claude via the village server or the web admin instead. Administrators now find both routes on the home screen.
+
+The reason: on a phone, Claude knows your location. You can stand in front of the flower box and have the coordinates taken over – the app is no longer needed for that.


### PR DESCRIPTION
Bereitet den Android-Release nach. **Nach der neuen Regel in `CLAUDE.md` ist
ein Stand erst draußen, wenn er in beiden Kanälen liegt** — iOS hat den
heutigen Stand seit vier Builds in TestFlight, Android hat seit `v0.1.9`
nichts bekommen.

## Was drin ist

Seit `v0.1.9` hat die Android-App bekommen:

- Der Bereich **„Verwaltung" ist entfernt**; an seiner Stelle steht für
  Verwaltende ein Hinweis auf den MCP-Connector und die Web-Verwaltung
- Der **Auswahlmodus der Karte** ist mit weg (er diente nur der Verwaltung)
- Zwei Korrekturen an der Anmeldung, damit die E2E gegen ein **lokales**
  Zitadel laufen statt gegen die Produktion

## Änderungen hier

- `versionCode` 1000109 → **1000110**, `versionName` 0.1.9 → **0.1.10**
- Änderungshinweise in `de-DE` und `en-US` (367 bzw. 353 Zeichen, Grenze 500)

`python3 store/check_metadata.py` ist grün. Die Store-Beschreibungen mussten
**nicht** angefasst werden — sie bewarben die App-Verwaltung nirgends;
geprüft.

## Danach

Tag `v0.1.10` setzen. Der bestehende Release-Workflow signiert APK und AAB,
legt das GitHub-Release an, verteilt über Firebase an die Gruppe `tester` und
lädt in den Play-Track `internal`. Alle dafür nötigen Secrets liegen im Repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)