### PR TITLE
fix: MCP-Adresse wird kopiert, nicht geöffnet

### DIFF
--- a/android/app/src/androidTest/java/de/roessing/app/AdminHintUiTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/AdminHintUiTest.kt
@@ -1,14 +1,19 @@
 package de.roessing.app
 
+import android.content.ClipboardManager
+import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import de.roessing.app.ui.AdminAddress
 import de.roessing.app.ui.AdminHintCard
-import de.roessing.app.ui.AdminLink
 import de.roessing.app.ui.StartScreen
+import de.roessing.app.ui.copyAdminAddress
 import de.roessing.app.ui.theme.DorfAppTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -19,6 +24,11 @@ import org.junit.runner.RunWith
  * Administering runs on the MCP server and in the web administration. The
  * app no longer offers it — but whoever may administer must not run into an
  * empty spot: the start screen says where it happens and how to get there.
+ *
+ * The two addresses look alike and are used in opposite ways: the connector
+ * address is copied — `/mcp` is a protocol endpoint, a browser only shows an
+ * error there — while the web administration is opened. Mixing the two up is
+ * exactly the mistake this file guards against.
  */
 @RunWith(AndroidJUnit4::class)
 class AdminHintUiTest {
@@ -49,19 +59,18 @@ class AdminHintUiTest {
     @Test
     fun startScreen_staysQuietForMembers() {
         compose.setContent {
-            DorfAppTheme {
-                StartScreen(name = "Erna", faelligeOrte = 0, ladend = false, onBereich = {})
-            }
+            DorfAppTheme { StartScreen(name = "Erna", faelligeOrte = 0, ladend = false, onBereich = {}) }
         }
 
         compose.onNodeWithTag("admin-hint").assertDoesNotExist()
     }
 
     @Test
-    fun bothAddressesCanBeTapped() {
-        val opened = mutableListOf<AdminLink>()
+    fun theConnectorAddressIsCopiedAndTheWebAddressIsOpened() {
+        val copied = mutableListOf<AdminAddress>()
+        val opened = mutableListOf<AdminAddress>()
         compose.setContent {
-            DorfAppTheme { AdminHintCard(onOpen = { opened += it }) }
+            DorfAppTheme { AdminHintCard(onCopy = { copied += it }, onOpen = { opened += it }) }
         }
 
         // No performScrollTo() here: the card is rendered on its own, without a
@@ -72,6 +81,36 @@ class AdminHintUiTest {
         compose.onNodeWithTag("admin-hint-mcp").performClick()
         compose.onNodeWithTag("admin-hint-web").performClick()
 
-        assertEquals(listOf(AdminLink.MCP, AdminLink.WEB), opened)
+        assertEquals(listOf(AdminAddress.MCP), copied)
+        assertEquals(listOf(AdminAddress.WEB), opened)
+        // The connector address is never opened in a browser — that is the
+        // whole point of the change.
+        assertEquals(emptyList<AdminAddress>(), opened.filter { it == AdminAddress.MCP })
+    }
+
+    /** Both addresses stay legible for whoever types them off a second screen. */
+    @Test
+    fun bothAddressesAreSpelledOut() {
+        compose.setContent {
+            DorfAppTheme { AdminHintCard(onCopy = {}, onOpen = {}) }
+        }
+
+        compose.onNodeWithTag("admin-hint-mcp-url").assertIsDisplayed()
+        compose.onNodeWithTag("admin-hint-web-url").assertIsDisplayed()
+    }
+
+    @Test
+    fun copyingPutsTheConnectorAddressOnTheClipboard() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        // On the main thread: below Android 13 the copy also raises a Toast,
+        // and a Toast from a background thread throws.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            context.copyAdminAddress(AdminAddress.MCP)
+        }
+
+        val clipboard = context.getSystemService(ClipboardManager::class.java)
+        val clip = requireNotNull(clipboard.primaryClip) { "Nothing on the clipboard" }
+        assertEquals(AdminAddress.MCP.url, clip.getItemAt(0).text.toString())
     }
 }

--- a/android/app/src/androidTest/java/de/roessing/app/AdminHintUiTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/AdminHintUiTest.kt
@@ -2,6 +2,10 @@ package de.roessing.app
 
 import android.content.ClipboardManager
 import android.content.Context
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -70,16 +74,13 @@ class AdminHintUiTest {
         val copied = mutableListOf<AdminAddress>()
         val opened = mutableListOf<AdminAddress>()
         compose.setContent {
-            DorfAppTheme { AdminHintCard(onCopy = { copied += it }, onOpen = { opened += it }) }
+            DorfAppTheme {
+                Scrollbar { AdminHintCard(onCopy = { copied += it }, onOpen = { opened += it }) }
+            }
         }
 
-        // No performScrollTo() here: the card is rendered on its own, without a
-        // scrollable parent, so there is nothing to scroll — and asking for it
-        // fails with "Semantic Node has no parent layout with a Scroll
-        // SemanticsAction". The other tests place the card inside StartScreen,
-        // where scrolling is both possible and necessary.
-        compose.onNodeWithTag("admin-hint-mcp").performClick()
-        compose.onNodeWithTag("admin-hint-web").performClick()
+        compose.onNodeWithTag("admin-hint-mcp").performScrollTo().performClick()
+        compose.onNodeWithTag("admin-hint-web").performScrollTo().performClick()
 
         assertEquals(listOf(AdminAddress.MCP), copied)
         assertEquals(listOf(AdminAddress.WEB), opened)
@@ -92,11 +93,11 @@ class AdminHintUiTest {
     @Test
     fun bothAddressesAreSpelledOut() {
         compose.setContent {
-            DorfAppTheme { AdminHintCard(onCopy = {}, onOpen = {}) }
+            DorfAppTheme { Scrollbar { AdminHintCard(onCopy = {}, onOpen = {}) } }
         }
 
-        compose.onNodeWithTag("admin-hint-mcp-url").assertIsDisplayed()
-        compose.onNodeWithTag("admin-hint-web-url").assertIsDisplayed()
+        compose.onNodeWithTag("admin-hint-mcp-url").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithTag("admin-hint-web-url").performScrollTo().assertIsDisplayed()
     }
 
     @Test
@@ -113,4 +114,15 @@ class AdminHintUiTest {
         val clip = requireNotNull(clipboard.primaryClip) { "Nothing on the clipboard" }
         assertEquals(AdminAddress.MCP.url, clip.getItemAt(0).text.toString())
     }
+}
+
+/**
+ * The card on its own is taller than a small emulator screen, so the web row
+ * ends up below the fold: not displayed, not clickable. In the app the card
+ * sits inside a scrollable column — the test has to give it the same, or it
+ * tests a situation that never occurs.
+ */
+@androidx.compose.runtime.Composable
+private fun Scrollbar(content: @androidx.compose.runtime.Composable () -> Unit) {
+    Column(Modifier.verticalScroll(rememberScrollState())) { content() }
 }

--- a/android/app/src/main/java/de/roessing/app/ui/AdminHint.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/AdminHint.kt
@@ -1,32 +1,54 @@
 package de.roessing.app.ui
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import de.roessing.app.R
 
 /**
  * Where administration happens now that it has left the app: the MCP server
  * and the web administration. Both are addresses someone has to reach, so
- * both are spelled out and both can be tapped.
+ * both are spelled out — but they are reached in entirely different ways.
  */
-enum class AdminLink(val url: String) {
-    /** Entered in claude.ai as a custom connector. */
+enum class AdminAddress(val url: String) {
+    /**
+     * The MCP endpoint, entered in claude.ai as a custom connector.
+     *
+     * Copied, never opened: `/mcp` speaks MCP over Streamable HTTP and is no
+     * web page — a browser shows nothing there but an error message. The
+     * address is needed somewhere else entirely, in the settings of
+     * claude.ai and often on another device, so it belongs on the clipboard.
+     */
     MCP("https://app.xn--rssing-wxa.de/mcp"),
 
-    /** The web administration — the same things, to click. */
+    /** The web administration — a real page, so this one is opened. */
     WEB("https://app.xn--rssing-wxa.de/admin/"),
 }
 
@@ -45,13 +67,18 @@ enum class AdminLink(val url: String) {
 @Composable
 fun AdminHint(modifier: Modifier = Modifier) {
     val context = LocalContext.current
-    AdminHintCard(modifier = modifier, onOpen = { link -> context.openInCustomTab(link.url) })
+    AdminHintCard(
+        modifier = modifier,
+        onCopy = { address -> context.copyAdminAddress(address) },
+        onOpen = { address -> context.openInCustomTab(address.url) },
+    )
 }
 
 /** The display on its own — without a context, so it can be tested. */
 @Composable
 fun AdminHintCard(
-    onOpen: (AdminLink) -> Unit,
+    onCopy: (AdminAddress) -> Unit,
+    onOpen: (AdminAddress) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -87,7 +114,13 @@ fun AdminHintCard(
                 stringResource(R.string.admin_hint_claude_setup),
                 style = MaterialTheme.typography.bodyMedium,
             )
-            AddressButton(AdminLink.MCP, "admin-hint-mcp", onOpen)
+            AddressRow(
+                address = AdminAddress.MCP,
+                testTag = "admin-hint-mcp",
+                icon = Icons.Filled.ContentCopy,
+                action = R.string.admin_hint_copy,
+                onClick = onCopy,
+            )
             Text(
                 stringResource(R.string.admin_hint_claude_can),
                 style = MaterialTheme.typography.bodyMedium,
@@ -107,21 +140,76 @@ fun AdminHintCard(
                 stringResource(R.string.admin_hint_web_body),
                 style = MaterialTheme.typography.bodyMedium,
             )
-            AddressButton(AdminLink.WEB, "admin-hint-web", onOpen)
+            AddressRow(
+                address = AdminAddress.WEB,
+                testTag = "admin-hint-web",
+                icon = Icons.AutoMirrored.Filled.OpenInNew,
+                action = R.string.admin_hint_open,
+                onClick = onOpen,
+            )
         }
     }
 }
 
 /**
- * The address as it is: readable, so it can be typed off a second device,
- * and tappable, so it does not have to be.
+ * The address as it is — readable, so it can be typed off a second device —
+ * and underneath it the gesture that belongs to it. Icon and wording differ
+ * per row, because the two gestures differ: one copies, the other leaves the
+ * app.
  */
 @Composable
-private fun AddressButton(link: AdminLink, testTag: String, onOpen: (AdminLink) -> Unit) {
-    TextButton(
-        onClick = { onOpen(link) },
-        modifier = Modifier.testTag(testTag),
-    ) {
-        Text(link.url, style = MaterialTheme.typography.bodyMedium)
+private fun AddressRow(
+    address: AdminAddress,
+    testTag: String,
+    icon: ImageVector,
+    @StringRes action: Int,
+    onClick: (AdminAddress) -> Unit,
+) {
+    Column {
+        // Outside the button on purpose: whoever cannot tap — because
+        // claude.ai is open on another machine — still has to be able to read
+        // the address off the screen.
+        Text(
+            address.url,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = FontFamily.Monospace,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.testTag("$testTag-url"),
+        )
+        TextButton(onClick = { onClick(address) }, modifier = Modifier.testTag(testTag)) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(action))
+        }
     }
 }
+
+/**
+ * Puts an address on the clipboard and says so — but only where the system
+ * does not say it already.
+ *
+ * Without any feedback a tap is indistinguishable from a dead button: the
+ * clipboard is invisible. Two confirmations are just as bad, and that is the
+ * case from Android 13 on, where the platform shows its own note for every
+ * copy.
+ */
+internal fun Context.copyAdminAddress(address: AdminAddress) {
+    val clipboard = getSystemService(ClipboardManager::class.java) ?: return
+    val label = getString(R.string.admin_hint_clip_label)
+    clipboard.setPrimaryClip(ClipData.newPlainText(label, address.url))
+    if (needsCopyConfirmation(Build.VERSION.SDK_INT)) {
+        Toast.makeText(this, R.string.admin_hint_copied, Toast.LENGTH_SHORT).show()
+    }
+}
+
+/**
+ * Whether the app has to confirm a copy itself.
+ *
+ * Android 13 (API 33) shows a confirmation of its own for every write to the
+ * clipboard; a Toast on top of it would put the same sentence on screen
+ * twice. Below that, nothing happens visibly at all.
+ *
+ * The API level is a parameter so a plain unit test can ask both sides of the
+ * line — `Build.VERSION.SDK_INT` has no value outside a device.
+ */
+internal fun needsCopyConfirmation(sdkInt: Int): Boolean = sdkInt < Build.VERSION_CODES.TIRAMISU

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -183,6 +183,11 @@
     <string name="admin_hint_claude_benefit">Der Vorteil: Du kannst vor dem Blumenkasten stehen und Claude die Koordinaten deines Geräts übernehmen lassen.</string>
     <string name="admin_hint_web_title">Im Browser</string>
     <string name="admin_hint_web_body">Dieselben Dinge zum Klicken — mit einer Karte, auf der du den Punkt setzt.</string>
+    <string name="admin_hint_copy">Adresse kopieren</string>
+    <string name="admin_hint_copied">Adresse kopiert</string>
+    <!-- Beschriftung des Zwischenablage-Eintrags: Android zeigt sie in der Ablageleiste an. -->
+    <string name="admin_hint_clip_label">MCP-Adresse der Dorf-App</string>
+    <string name="admin_hint_open">Im Browser öffnen</string>
     <!-- Veranstaltungen: „Was ist los in Rössing" — Termine von der Website -->
     <string name="area_events_title">Was ist los?</string>
     <string name="area_events_subtitle">Termine im Dorf.</string>

--- a/android/app/src/test/java/de/roessing/app/AdminHintTest.kt
+++ b/android/app/src/test/java/de/roessing/app/AdminHintTest.kt
@@ -1,7 +1,9 @@
 package de.roessing.app
 
-import de.roessing.app.ui.AdminLink
+import de.roessing.app.ui.AdminAddress
+import de.roessing.app.ui.needsCopyConfirmation
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -18,8 +20,8 @@ import org.junit.Test
 class AdminHintTest {
     @Test
     fun `both addresses are encrypted and absolute`() {
-        AdminLink.entries.forEach { link ->
-            assertTrue(link.name, link.url.startsWith("https://"))
+        AdminAddress.entries.forEach { address ->
+            assertTrue(address.name, address.url.startsWith("https://"))
         }
     }
 
@@ -27,21 +29,47 @@ class AdminHintTest {
     fun `the connector points at the MCP endpoint`() {
         // No trailing slash: claude.ai passes the address on unchanged, and
         // the MCP endpoint is served without one.
-        assertTrue(AdminLink.MCP.url, AdminLink.MCP.url.endsWith("/mcp"))
+        assertTrue(AdminAddress.MCP.url, AdminAddress.MCP.url.endsWith("/mcp"))
     }
 
     @Test
     fun `the browser link points at the web administration`() {
         // With a trailing slash: the redirect URI registered in Zitadel ends
         // in one, and a redirect in the in-app browser looks like a failure.
-        assertTrue(AdminLink.WEB.url, AdminLink.WEB.url.endsWith("/admin/"))
+        assertTrue(AdminAddress.WEB.url, AdminAddress.WEB.url.endsWith("/admin/"))
     }
 
     @Test
     fun `both ways lead to the same server`() {
         // One deployment serves REST, MCP and the web administration. Whoever
         // moves the app to another host must move both addresses.
-        assertEquals(host(AdminLink.MCP.url), host(AdminLink.WEB.url))
+        assertEquals(host(AdminAddress.MCP.url), host(AdminAddress.WEB.url))
+    }
+
+    @Test
+    fun `the copied address is whole and not a fragment`() {
+        // It is pasted into an empty field in claude.ai: scheme and host have
+        // to travel with it.
+        assertTrue(AdminAddress.MCP.url, AdminAddress.MCP.url.startsWith("https://"))
+        assertTrue(AdminAddress.MCP.url, host(AdminAddress.MCP.url).isNotEmpty())
+    }
+
+    // MARK: Confirming the copy
+
+    @Test
+    fun `below Android 13 the app confirms the copy itself`() {
+        // Nothing on screen changes when the clipboard is written, so an
+        // unconfirmed copy is indistinguishable from a dead button.
+        assertTrue(needsCopyConfirmation(26))
+        assertTrue(needsCopyConfirmation(32))
+    }
+
+    @Test
+    fun `from Android 13 on the system confirms it and the app keeps quiet`() {
+        // The platform shows its own note for every copy; a Toast on top of
+        // it would put the same sentence on screen twice.
+        assertFalse(needsCopyConfirmation(33))
+        assertFalse(needsCopyConfirmation(36))
     }
 
     private fun host(url: String): String = url.removePrefix("https://").substringBefore('/')

--- a/ios/Dorf/Navigation/AdminHintSection.swift
+++ b/ios/Dorf/Navigation/AdminHintSection.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// The "Verwalten" section of the start page.
 ///
@@ -8,10 +9,22 @@ import SwiftUI
 /// tile would leave a gap exactly where someone with the `admin` role looks
 /// for it — so this section says where the work moved and how to get there.
 ///
+/// The two ways look alike — two https addresses — but they are used in
+/// entirely different ways, and the section shows that: the connector
+/// address is copied, the web admin is opened.
+///
 /// Shown to admins only. For everyone else the two addresses answer a
 /// question they never asked. That is politeness, not a safeguard: the rule
 /// is enforced by the backend, which rejects every change without the role.
 struct AdminHintSection: View {
+    /// How long "Adresse kopiert" stays before the row goes back to
+    /// offering the copy. Long enough to be read, short enough that nobody
+    /// takes it for the permanent state of the row.
+    private static let confirmationDuration: Duration = .seconds(3)
+
+    @State private var addressCopied = false
+    @State private var confirmationReset: Task<Void, Never>?
+
     var body: some View {
         Section {
             Text("Orte und Aufgaben anlegen, ändern, pausieren und löschen, "
@@ -22,26 +35,45 @@ struct AdminHintSection: View {
                 .foregroundStyle(.secondary)
                 .accessibilityIdentifier("admin-hint-intro")
 
-            Link(destination: Self.mcpAddress) {
+            // Deliberately a button and not a `Link`: `/mcp` is a protocol
+            // endpoint (MCP over Streamable HTTP), not a web page — whoever
+            // taps it in a browser sees nothing but an error message. The
+            // address is needed somewhere else entirely: it is entered in
+            // claude.ai under Einstellungen → Connectors, often from another
+            // device. So it belongs on the clipboard — and stays spelled out
+            // underneath, so it can be typed off as well.
+            Button(action: copyMcpAddress) {
                 AdminHintRow(
                     symbol: "text.bubble",
                     title: "Mit Claude",
                     text: "In claude.ai unter Einstellungen → Connectors einen eigenen "
                         + "Connector anlegen und diese Adresse eintragen:",
-                    address: Self.mcpAddress.absoluteString
+                    address: Self.mcpAddress.absoluteString,
+                    actionSymbol: addressCopied ? "checkmark.circle.fill" : "doc.on.doc",
+                    actionText: addressCopied ? "Adresse kopiert" : "Adresse kopieren",
+                    actionColor: addressCopied ? .green : .accentColor,
+                    actionIdentifier: addressCopied ? "admin-hint-copied" : "admin-hint-copy"
                 )
             }
-            // Without `.plain` the link tints its whole label, and the
+            // Without `.plain` the button tints its whole label, and the
             // explanation would read as if every word were tappable.
             .buttonStyle(.plain)
             .accessibilityIdentifier("admin-hint-mcp")
+            .accessibilityHint("Legt die Adresse in die Zwischenablage")
 
+            // This one is a real web page, so tapping it is the right thing.
             Link(destination: Self.adminAddress) {
                 AdminHintRow(
                     symbol: "macwindow",
                     title: "Im Browser",
                     text: "Dieselben Dinge zum Klicken, mit einer Karte zum Setzen des Punktes.",
-                    address: Self.adminAddress.absoluteString
+                    address: Self.adminAddress.absoluteString,
+                    // The arrow says what the chevron would not: this leaves
+                    // the app and opens a browser.
+                    actionSymbol: "arrow.up.right",
+                    actionText: "Im Browser öffnen",
+                    actionColor: .accentColor,
+                    actionIdentifier: "admin-hint-open"
                 )
             }
             .buttonStyle(.plain)
@@ -57,6 +89,33 @@ struct AdminHintSection: View {
         }
     }
 
+    /// Copies and confirms. Without the confirmation a tap looks exactly
+    /// like a dead button — nothing on screen would change.
+    private func copyMcpAddress() {
+        Self.copyMcpAddress()
+        confirmationReset?.cancel()
+        withAnimation { addressCopied = true }
+        confirmationReset = Task {
+            try? await Task.sleep(for: Self.confirmationDuration)
+            guard !Task.isCancelled else { return }
+            withAnimation { addressCopied = false }
+        }
+    }
+
+    /// Puts the connector address on the pasteboard and returns what was
+    /// written there.
+    ///
+    /// Split off from the button so a test can check what lands there: the
+    /// closure of a view is out of reach without a UI test target, and this
+    /// project has none. The pasteboard is a parameter for the same reason —
+    /// a test uses one of its own instead of the system's.
+    @discardableResult
+    static func copyMcpAddress(to pasteboard: UIPasteboard = .general) -> String {
+        let address = mcpAddress.absoluteString
+        pasteboard.string = address
+        return address
+    }
+
     // The addresses are derived from `Konfiguration.apiBasis`, not written
     // out here: CI and E2E point the app at a local backend, and an address
     // hard-coded in the source would send them to production.
@@ -69,12 +128,18 @@ struct AdminHintSection: View {
     }
 }
 
-/// One way in: what it is, what to do there, and the address to copy.
+/// One way in: what it is, what to do there, the address in plain text — and
+/// the gesture that belongs to it. Symbol and wording of that gesture differ
+/// per row, because the gestures differ.
 private struct AdminHintRow: View {
     let symbol: String
     let title: String
     let text: String
     let address: String
+    let actionSymbol: String
+    let actionText: String
+    let actionColor: Color
+    let actionIdentifier: String
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
@@ -89,18 +154,19 @@ private struct AdminHintRow: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+                // In plain text on purpose: whoever sits at a second screen
+                // has to be able to type the address off.
                 Text(address)
                     .font(.footnote.monospaced())
                     .foregroundStyle(.tint)
                     .fixedSize(horizontal: false, vertical: true)
+                Label(actionText, systemImage: actionSymbol)
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(actionColor)
+                    .accessibilityIdentifier(actionIdentifier)
+                    .padding(.top, 2)
             }
             Spacer(minLength: 8)
-            // The arrow says what the chevron would not: this leaves the app
-            // and opens a browser.
-            Image(systemName: "arrow.up.right")
-                .font(.footnote.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .accessibilityHidden(true)
         }
         .padding(.vertical, 4)
     }

--- a/ios/DorfTests/AdminHintTests.swift
+++ b/ios/DorfTests/AdminHintTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+import UIKit
+
+@testable import Dorf
+
+/// The "Verwalten" section: two addresses that look alike and are used in
+/// entirely different ways. The connector address goes on the clipboard —
+/// `/mcp` speaks a protocol, a browser only shows an error there — while the
+/// web administration stays a link that a browser can open.
+///
+/// Nothing here reaches a server: the addresses are read from the build
+/// settings of the running build, and all that happens to them is a copy and
+/// a shape check. Whichever backend the build points at, both shapes have to
+/// hold — otherwise nobody finds the way.
+@MainActor
+struct AdminHintTests {
+    // MARK: The connector address is copied
+
+    @Test func copyingPutsTheConnectorAddressOnThePasteboard() {
+        // A pasteboard of its own instead of the system's: a test must not
+        // overwrite what the person at the machine has copied.
+        let pasteboard = UIPasteboard.withUniqueName()
+        defer { UIPasteboard.remove(withName: pasteboard.name) }
+
+        let copied = AdminHintSection.copyMcpAddress(to: pasteboard)
+
+        #expect(copied == AdminHintSection.mcpAddress.absoluteString)
+        #expect(pasteboard.string == AdminHintSection.mcpAddress.absoluteString)
+    }
+
+    @Test func theCopiedAddressIsWholeAndNotAFragment() {
+        // Whoever pastes it into claude.ai pastes it into an empty field:
+        // scheme and host have to travel with it.
+        let pasteboard = UIPasteboard.withUniqueName()
+        defer { UIPasteboard.remove(withName: pasteboard.name) }
+
+        let copied = AdminHintSection.copyMcpAddress(to: pasteboard)
+
+        #expect(copied.hasPrefix("http"))
+        #expect(URL(string: copied)?.host?.isEmpty == false)
+    }
+
+    @Test func theConnectorAddressPointsAtTheMcpEndpoint() {
+        // No trailing slash: claude.ai passes the address on unchanged, and
+        // the MCP endpoint is served without one. Checked on the whole
+        // address, not on `path` — that one drops a trailing slash and would
+        // pass either way.
+        #expect(AdminHintSection.mcpAddress.absoluteString.hasSuffix("/mcp"))
+    }
+
+    // MARK: The web administration stays a link
+
+    @Test func theWebAddressCanBeOpenedByABrowser() {
+        // This row is still a `Link`, and `Link` needs a URL a browser can
+        // follow: a scheme it knows and a host to ask.
+        let address = AdminHintSection.adminAddress
+        #expect(address.scheme?.hasPrefix("http") == true)
+        #expect(address.host?.isEmpty == false)
+    }
+
+    @Test func theWebAddressKeepsItsTrailingSlash() {
+        // The redirect URI registered in Zitadel ends in one, and a redirect
+        // in the in-app browser looks like a failure. `path` is no witness
+        // here: it drops the very slash this is about.
+        #expect(AdminHintSection.adminAddress.absoluteString.hasSuffix("/admin/"))
+    }
+
+    // MARK: Both together
+
+    @Test func bothWaysLeadToTheSameServer() {
+        // One deployment serves REST, MCP and the web administration.
+        // Whoever moves the app to another host moves both addresses.
+        #expect(AdminHintSection.mcpAddress.host == AdminHintSection.adminAddress.host)
+    }
+
+    @Test func theTwoAddressesAreNotTheSame() {
+        // They differ, and so does what one does with them — copying the web
+        // address or opening the connector address would both be wrong.
+        #expect(AdminHintSection.mcpAddress != AdminHintSection.adminAddress)
+    }
+}


### PR DESCRIPTION
Die Adresse des MCP-Connectors war in beiden Apps ein **Link**. Wer darauf
tippt, landet im Browser auf einer Fehlermeldung — `…/mcp` ist kein Webauftritt,
sondern ein Protokoll-Endpunkt. Gebraucht wird die Adresse an ganz anderer
Stelle: Man trägt sie in claude.ai unter Einstellungen → Connectors ein, oft
sogar auf einem zweiten Gerät. Sie gehört also in die **Zwischenablage**.

## Was sich ändert

- Die MCP-Zeile ist ein **Kopier-Knopf**: iOS `UIPasteboard`, Android
  `ClipboardManager`
- **Rückmeldung**: Auf iOS wird „Adresse kopieren" für drei Sekunden zu
  „Adresse kopiert" mit Häkchen. Auf Android ab API 33 die **Systemmeldung** —
  und dann bewusst **kein** zusätzlicher Toast, sonst stünde es doppelt da;
  darunter der Toast.
- Die **Web-Verwaltung bleibt ein Link** — `/admin/` *ist* eine Webseite. Beide
  Zeilen zeigen jetzt sichtbar, was sie tun: Kopiersymbol gegen Pfeil.
- Die Adresse steht in beiden Fällen weiterhin **im Klartext** da, zum Abtippen.
- Im Quelltext steht, **warum** das kein Link ist — sonst macht der Nächste
  wieder einen daraus.

## Geprüft

- iOS: **161 Tests grün**, davon 7 neue. Im Simulator angesehen: Nach dem Tippen
  stand die Adresse tatsächlich in der Zwischenablage (`simctl pbpaste`), und
  das Bild nach den drei Sekunden ist byteweise identisch mit dem davor — die
  Meldung verschwindet also wirklich.
- Android: `assembleDebug` und `testDebugUnitTest` grün, 7 neue Unit-Tests.
- `pruefe_lokale_tests.py` grün.

**Nicht geprüft:** Die Instrumentierungstests auf Android liefen nicht — in
dieser Umgebung gibt es keinen Emulator. Sie übersetzen, mehr nicht. Die
Android-Oberfläche wurde aus demselben Grund nicht im Bild gesehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)