### PR TITLE
docs: wie Aufträge an Agenten aussehen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,43 @@ Flux deployt in den K3S-Cluster). Details: siehe `README.md`.
 - **Keine Secrets committen.** Der MCP-Endpoint nutzt OAuth (Rössing-ID,
   admin-Rolle) — es gibt bewusst kein statisches Token.
 
+## Arbeit an Agenten übergeben
+
+Wer eine Aufgabe an einen Agenten gibt, schreibt **Absicht, Konzepte und harte
+Bedingungen** — sonst nichts.
+
+**Nicht in den Auftrag gehören** eigene Diagnosen, Lösungsskizzen und Warnungen
+der Art „achte auf X". Wer schon weiß, wo der Fehler sitzt, braucht keinen
+Agenten; wer es nur vermutet, macht aus seiner Vermutung dessen Vorgabe. Alles,
+was über die Absicht hinausgeht, **wird ungewollt zur Anforderung**: Der Agent
+optimiert dann auf die Hypothese statt auf die Sache, und ist sie falsch, ist
+der Fehler eingebaut statt gefunden.
+
+Der Anlass ist nicht theoretisch. Beim Absenken des iOS-Mindestsystems stand im
+Auftrag eine ausführliche Warnung vor einer bestimmten Falle. Der Agent fand
+eine **andere**, gefährlichere — die Warnung war Rauschen, seine eigene
+Untersuchung das Ergebnis. Beim Umbau der Backend-Uhr standen im Auftrag drei
+„Befunde", die zehn Minuten altes Halbwissen waren; sie hätten stillschweigend
+den Lösungsraum verengt.
+
+**In den Auftrag gehören:**
+
+- **Absicht** — warum das gemacht wird, und woran man erkennt, dass es stimmt.
+  („Ein Test, der wartet, prüft das Falsche" trägt weiter als „bau einen
+  Endpunkt, der den Durchlauf anstößt".)
+- **Konzepte** des Projekts, die er nicht erraten kann — die Allmende, ein
+  Träger, warum Regeln im Backend stehen und nicht in den Clients.
+- **Harte Bedingungen**, die wirklich nicht verhandelbar sind: keine
+  Fremdbibliotheken, kein Test fasst einen entfernten Server an, Bezeichner
+  englisch und Oberfläche deutsch, nicht selbst nach `main` mergen.
+- **Umstände der Umgebung** als Tatsache, nicht als Rat — etwa, dass hier kein
+  Android-Emulator läuft und Instrumentierungstests nur übersetzt werden können.
+- **Dateigrenzen**, solange mehrere Agenten parallel arbeiten. Das ist keine
+  fachliche Vorgabe, sondern verhindert, dass sich Zweige gegenseitig zerlegen.
+
+Wird ein Befund doch mitgegeben, weil er Zeit spart, dann ausdrücklich als
+**unverbindlicher Zwischenstand**, den der Agent prüfen und verwerfen darf.
+
 ## Träger (Vereine und Gruppen)
 
 Die Dorf-App verwaltet die **Allmende**, sie vermittelt nicht zwischen


### PR DESCRIPTION
Neuer Abschnitt in `CLAUDE.md`: **Absicht, Konzepte und harte Bedingungen — sonst
nichts.**

Eigene Diagnosen, Lösungsskizzen und „achte auf X"-Warnungen gehören nicht in
einen Auftrag. Wer schon weiß, wo der Fehler sitzt, braucht keinen Agenten; wer
es nur vermutet, macht aus seiner Vermutung dessen Vorgabe. Alles über die
Absicht hinaus **wird ungewollt zur Anforderung**.

Zweimal an einem Tag belegt:

- Beim Absenken des iOS-Mindestsystems stand eine ausführliche Warnung vor einer
  bestimmten Falle im Auftrag. Der Agent fand eine **andere**, gefährlichere.
  Die Warnung war Rauschen.
- Beim Umbau der Backend-Uhr standen drei „Befunde" im Auftrag, die zehn Minuten
  altes Halbwissen waren — und die stillschweigend die Lösung vorwegnahmen
  („injizierbare Uhr"), statt das Ziel zu beschreiben.

Was hineingehört, steht im Abschnitt: Absicht, Projektkonzepte, harte
Bedingungen, Umstände der Umgebung als Tatsache, und Dateigrenzen bei
parallelen Läufen. Ein Befund darf mitgegeben werden, wenn er Zeit spart — aber
ausdrücklich als unverbindlicher Zwischenstand.

Nur Dokumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)