### PR TITLE
feat(backend): steuerbare Uhr — Tests warten nicht mehr

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -115,8 +115,12 @@ jobs:
         run: |
           # PUBLIC_URL muss lokal bleiben: das Backend lehnt AUTH_MODE=insecure-dev
           # zusammen mit einer öffentlichen https-URL ab (und die ist Vorbelegung).
-          # VERGABE_TAKT kurz: Die Vergabe-Tests warten sonst je Schritt bis
-          # zu einer Minute auf den nächsten Durchlauf.
+          # VERGABE=off: Der Hintergrund-Takt wird nicht mehr gebraucht. Die
+          # Vergabe-Tests stellen die Uhr des Backends auf den Fälligkeitstag
+          # und stoßen den Durchlauf selbst an (POST /dev/assignment/run,
+          # nur im Dev-Modus vorhanden). Ohne Takt kann zwischen zwei
+          # Schritten eines Tests nichts mehr von selbst passieren — damit
+          # hängt kein Ergebnis mehr daran, wie beschäftigt der Runner ist.
           # IDEEN_*: Der Ideen-Eingang ist im Betrieb streng begrenzt (5 pro
           # Stunde). Im E2E reicht der Test mehrfach hintereinander ein; die
           # Grenze selbst hat einen eigenen Test in backend/internal/api.
@@ -124,7 +128,7 @@ jobs:
           # geprüft, aber die MCP-Metadaten tragen den Wert — und dort hat die
           # Produktionsadresse in einem Testlauf nichts verloren.
           DB_PATH=/tmp/e2e.sqlite AUTH_MODE=insecure-dev SEED=1 LISTEN_ADDR=:8099 \
-          PUBLIC_URL=http://localhost:8099 VERGABE_TAKT=5s \
+          PUBLIC_URL=http://localhost:8099 VERGABE=off \
           AUTH_ISSUER=http://10.0.2.2:8123 \
           IDEEN_BURST=50 IDEEN_PRO_STUNDE=50 \
             go run ./cmd/server &

--- a/README.md
+++ b/README.md
@@ -270,8 +270,14 @@ keine der beiden Apps noch einmal.
   gesperrt), damit die App den Knopf gar nicht erst anbietet. Prüfen und
   Eintragen laufen in einer Transaktion, damit ein Doppeltipp nicht zwei
   Meldungen erzeugt. Admins dürfen mit `force: true` übergehen (wird als
-  `forced` vermerkt) und mit `doneAt` bis zu 14 Tage zurückdatieren;
-  Zeitpunkte in der Zukunft werden abgelehnt. Die Sperre gilt je Aufgabe,
+  `forced` vermerkt) und mit `doneAt` zurückdatieren — **bis zu 14 Tage**
+  (`model.MaxBackdateAdmin`), weil die Verwaltung fremde Meldungen nachträgt
+  und das sichtbar unter ihrem Namen tut. Die allgemeine Grenze liegt bei
+  **drei Tagen** (`model.MaxBackdate`): Sie deckt den ehrlichen Fall ab (am
+  Samstag gegossen, erst heute daran gedacht), ohne ein zwei Wochen breites
+  Fenster zu öffnen, in dem sich ein Zeitpunkt suchen ließe, an dem die
+  Meldung für die Rangliste zählt. Zeitpunkte in der Zukunft werden
+  abgelehnt. Die Sperre gilt je Aufgabe,
   nicht je Person — sonst könnten mehrere Leute denselben Kasten nacheinander
   „gießen". Dieselbe Prüfung gilt für REST, MCP und die Web-Verwaltung; dort
   zeigt die Ortsseite „Bereits erledigt — wieder ab …" und die
@@ -306,6 +312,19 @@ cd android
 
 Der „Entwickler-Login" erscheint nur in Debug-Builds mit `-PdevAuth=true`
 und funktioniert nur gegen ein Backend mit `AUTH_MODE=insecure-dev`.
+
+Im selben Modus — und nur dort — gibt es die **Test-Knöpfe unter `/dev`**:
+Uhr stellen, vorspulen, zurücksetzen und einen Vergabe-Durchlauf anstoßen.
+Damit muss kein Test mehr auf den Hintergrund-Takt warten. Beschrieben sind
+sie in [backend/README.md](backend/README.md); in der Produktion sind sie
+nicht registriert.
+
+```sh
+curl -s localhost:8080/dev/clock
+curl -s -X POST localhost:8080/dev/clock/advance -d '{"duration":"240h"}'
+curl -s -X POST localhost:8080/dev/assignment/run
+curl -s -X POST localhost:8080/dev/clock/reset
+```
 
 ### iOS
 
@@ -450,7 +469,7 @@ auf die Produktion.
 | `LISTEN_ADDR` | Standard `:8080` |
 | `DB_PATH` | Standard `/data/dorfapp.sqlite` |
 | `AUTH_ISSUER` | Rössing-ID, Standard `https://id.xn--rssing-wxa.de` |
-| `AUTH_MODE` | `oidc` (Standard) oder `insecure-dev` (nur lokal/E2E) |
+| `AUTH_MODE` | `oidc` (Standard) oder `insecure-dev` (nur lokal/E2E). Nur in diesem Modus gibt es zusätzlich die Test-Knöpfe unter `/dev` (Uhr stellen, Vergabe anstoßen) — siehe [backend/README.md](backend/README.md). In der Produktion sind sie nicht registriert |
 | `PUBLIC_URL` | öffentliche Basis-URL; daraus entsteht die OIDC-Redirect-URI `{PUBLIC_URL}/admin/`. Ohne Angabe die Produktions-URL — mit `AUTH_MODE=insecure-dev` stattdessen `http://localhost:<Port aus LISTEN_ADDR>` |
 | `ADMIN_CLIENT_ID` | Client-ID der Verwaltung (leer = nur Startseite) |
 | `SESSION_KEY` | Schlüssel für die signierten Session-Cookies; leer = zufällig beim Start (Sessions überleben dann keinen Neustart) |

--- a/android/app/src/androidTest/java/de/roessing/app/DevBackend.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/DevBackend.kt
@@ -1,0 +1,91 @@
+package de.roessing.app
+
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+/**
+ * The backend's test knobs under `/dev`. They exist only while the backend
+ * runs with `AUTH_MODE=insecure-dev` — in production those paths are not
+ * registered at all (see `backend/internal/devmode`).
+ *
+ * They are here so that no test has to wait. The assignment of care tasks is
+ * a matter of days: a task falls due after its interval, and the background
+ * timer then asks one helper after another. A test that sleeps until that
+ * happens no longer claims "an overdue task gets its helper asked" but
+ * "…within N seconds of wall clock" — which says nothing about the village
+ * and everything about how busy the emulator is. That is what made the same
+ * commit go green on one emulator and red on the other.
+ *
+ * So instead: move the clock to the day the task is due, run one assignment
+ * pass, look at the result. No sleeping, same answer every time.
+ *
+ * Whoever moves the clock has to move it back — it belongs to the whole
+ * backend process, and the next test would otherwise inherit a village
+ * living in the future. Best done in an `@After`, so it also happens when
+ * the test fails.
+ */
+class DevBackend(baseUrl: String = BuildConfig.API_BASE_URL) {
+    private val base = baseUrl.trimEnd('/')
+    private val client = OkHttpClient()
+    private val json = "application/json".toMediaType()
+
+    /** The village's local time — the backend's quiet hours are measured in it. */
+    private val villageZone: ZoneId = ZoneId.of("Europe/Berlin")
+
+    /** What time the backend currently thinks it is. */
+    fun clock(): ZonedDateTime = parse(get("/dev/clock"))
+
+    /**
+     * Moves the clock [days] days ahead of where the backend stands now and
+     * puts it at [hour] o'clock village time.
+     *
+     * The time of day is not a detail: between 21:00 and 07:00 the backend
+     * delivers nothing (quiet hours — nobody's phone rings at night). A jump
+     * that happened to land at night would create the assignment but defer
+     * the request to the next morning, and the test would depend on what
+     * time the machine happens to have. Mid-morning it always works.
+     */
+    fun travelForward(days: Long, hour: Int = 10): ZonedDateTime {
+        val target = clock().plusDays(days).withHour(hour).withMinute(0).withSecond(0).withNano(0)
+        return parse(post("/dev/clock/set", """{"time":"${DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(target)}"}"""))
+    }
+
+    /** Back to the system clock. Every test that travels has to come back. */
+    fun resetClock() {
+        post("/dev/clock/reset", "")
+    }
+
+    /**
+     * Runs one assignment pass and only returns once the notifications are
+     * written. It is the very same pass the background timer runs, it works
+     * synchronously and it is repeatable at will — it only does something
+     * when a task is really due.
+     *
+     * @return how many notifications this pass produced.
+     */
+    fun runAssignment(): Int = post("/dev/assignment/run", "").getInt("notifications")
+
+    private fun parse(answer: JSONObject): ZonedDateTime =
+        ZonedDateTime.parse(answer.getString("now")).withZoneSameInstant(villageZone)
+
+    private fun get(path: String): JSONObject = call(Request.Builder().url(base + path).get().build(), path)
+
+    private fun post(path: String, body: String): JSONObject =
+        call(Request.Builder().url(base + path).post(body.toRequestBody(json)).build(), path)
+
+    private fun call(request: Request, path: String): JSONObject {
+        client.newCall(request).execute().use { response ->
+            val text = response.body?.string().orEmpty()
+            check(response.isSuccessful) {
+                "$path: HTTP ${response.code} $text — läuft das Backend mit AUTH_MODE=insecure-dev?"
+            }
+            return if (text.isBlank()) JSONObject() else JSONObject(text)
+        }
+    }
+}

--- a/android/app/src/androidTest/java/de/roessing/app/PushEchtTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/PushEchtTest.kt
@@ -17,6 +17,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
+import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeTrue
 import org.junit.Before
@@ -41,12 +42,22 @@ class PushEchtTest {
     private val json = "application/json".toMediaType()
     private val token = "push-e2e:Push Tester:admin"
 
+    private val dev = DevBackend()
+
     @Before
     fun nurAufZuruf() {
         assumeTrue(
             "Echter Push nur mit -e push true",
             InstrumentationRegistry.getArguments().getString("push") == "true",
         )
+    }
+
+    /** Die Uhr gehört dem ganzen Backend — wer sie verstellt, stellt sie zurück. */
+    @After
+    fun uhrZurueck() {
+        if (InstrumentationRegistry.getArguments().getString("push") == "true") {
+            dev.resetClock()
+        }
     }
 
     private fun post(pfad: String, koerper: String): JSONObject {
@@ -97,25 +108,28 @@ class PushEchtTest {
         val api = DorfApi.create(BuildConfig.API_BASE_URL) { token }
         runBlocking { ApiDeviceRepository(api).register(kennung!!) }
 
-        // Ein eigener, überfälliger Ort — daran läuft die Vergabe sofort los.
+        // Ein eigener Ort mit Gieß-Aufgabe. Fällig wird er nicht durch eine
+        // zurückdatierte Erledigung (das darf inzwischen nur die Verwaltung
+        // und nur drei Tage weit), sondern durch die Uhr des Backends: zehn
+        // Tage vor, einmal vergeben lassen — dann liegt die Anfrage vor und
+        // Google trägt sie aus.
         val ort = post(
             "/api/v1/places",
             """{"name":"Push-E2E ${System.currentTimeMillis()}","kind":"blumenkasten","lat":52.2105,"lon":9.8695}""",
         )
-        val aufgabe = post(
+        post(
             "/api/v1/places/${ort.getLong("id")}/tasks",
             """{"kind":"giessen","liters":5,"intervalDays":7,"redAfterDays":14}""",
         )
-        val vorZehnTagen = java.time.Instant.now().minus(java.time.Duration.ofDays(10))
-        post(
-            "/api/v1/tasks/${aufgabe.getLong("id")}/completions",
-            """{"liters":5,"doneAt":"${java.time.format.DateTimeFormatter.ISO_INSTANT.format(vorZehnTagen)}","force":true}""",
-        )
         runBlocking { ApiVergabeRepository(api).signup(ort.getLong("id"), null) }
+        dev.travelForward(days = 10)
+        dev.runAssignment()
 
         // Auf die Systemmeldung warten — sie kommt über Google, nicht über uns.
         geraet.openNotification()
         val gefunden = geraet.wait(Until.hasObject(By.textContains("ist dran")), 90_000)
+        // Gewartet wird oben auf die Bedingung; dieser kurze Schlaf gilt nur
+        // dem Ausklappen der Leiste, damit das Foto sie ganz zeigt.
         SystemClock.sleep(500)
         geraet.takeScreenshot(
             java.io.File(
@@ -129,6 +143,7 @@ class PushEchtTest {
         // (siehe MainActivity.zielAus und PushZiel).
         geraet.findObject(By.textContains("ist dran")).click()
         val vorn = geraet.wait(Until.hasObject(By.pkg("de.roessing.app").depth(0)), 20_000)
+        // Wieder nur fürs Bild: Die App ist da, sie zeichnet sich noch.
         SystemClock.sleep(1_500)
         geraet.takeScreenshot(
             java.io.File(

--- a/android/app/src/androidTest/java/de/roessing/app/PushEchtTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/PushEchtTest.kt
@@ -26,9 +26,11 @@ import org.junit.runner.RunWith
 
 /**
  * Echter Push im Emulator — nur auf Zuruf (`-e push true`) und nur gegen ein
- * Backend mit hinterlegtem Dienstkonto-Schlüssel:
+ * Backend mit hinterlegtem Dienstkonto-Schlüssel. `AUTH_MODE=insecure-dev`
+ * ist Pflicht: Der Test macht die Aufgabe über die Uhr des Backends fällig,
+ * und die Test-Knöpfe unter `/dev` gibt es nur in diesem Modus.
  *
- *     FCM_CREDENTIALS_FILE=… go run ./cmd/server
+ *     AUTH_MODE=insecure-dev FCM_CREDENTIALS_FILE=… go run ./cmd/server
  *     adb shell am instrument -e class de.roessing.app.PushEchtTest \
  *       -e push true -e e2e true …
  *

--- a/android/app/src/androidTest/java/de/roessing/app/VergabeE2eTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/VergabeE2eTest.kt
@@ -31,8 +31,10 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeTrue
 import org.junit.Before
@@ -42,9 +44,17 @@ import org.junit.runner.RunWith
 import de.roessing.app.ui.theme.DorfAppTheme
 
 /**
- * Die Vergabe gegen ein echtes Backend (AUTH_MODE=insecure-dev, VERGABE_TAKT
- * kurz gestellt): eintragen, gefragt werden, zusagen — einmal über die
- * Schnittstelle und einmal durch die Oberfläche der App.
+ * Die Vergabe gegen ein echtes Backend (AUTH_MODE=insecure-dev): eintragen,
+ * gefragt werden, zusagen — einmal über die Schnittstelle und einmal durch
+ * die Oberfläche der App.
+ *
+ * Der Test wartet auf nichts. Statt zu hoffen, dass der Hintergrund-Takt
+ * vorbeikommt, stellt er die Uhr des Backends auf den Tag, an dem die
+ * Aufgabe fällig ist, und stößt genau einen Vergabe-Durchlauf an (siehe
+ * [DevBackend]). Danach liegt die Anfrage vor — oder sie liegt nicht vor,
+ * und dann ist wirklich etwas kaputt. Vorher stand hier eine Schleife, die
+ * bis zu 150 Sekunden schlief; grün oder rot entschied damit, wie beschäftigt
+ * der Emulator gerade war.
  *
  * Läuft nur mit `-e e2e true`; ohne laufendes Backend hat der Test nichts zu
  * prüfen.
@@ -54,12 +64,26 @@ class VergabeE2eTest {
     @get:Rule
     val compose = createAndroidComposeRule<ComponentActivity>()
 
+    private val dev = DevBackend()
+
     @Before
     fun nurImE2eModus() {
         assumeTrue(
             "E2E-Modus nicht aktiv (Instrumentation-Arg e2e fehlt)",
             InstrumentationRegistry.getArguments().getString("e2e") == "true",
         )
+    }
+
+    /**
+     * Die Uhr gehört dem ganzen Backend — wer sie verstellt, stellt sie
+     * zurück. Im @After, damit das auch nach einem gescheiterten Test
+     * passiert und der nächste nicht in einem Dorf in der Zukunft aufwacht.
+     */
+    @After
+    fun uhrZurueck() {
+        if (InstrumentationRegistry.getArguments().getString("e2e") == "true") {
+            dev.resetClock()
+        }
     }
 
     private val basis = BuildConfig.API_BASE_URL.trimEnd('/')
@@ -85,16 +109,19 @@ class VergabeE2eTest {
     }
 
     /**
-     * Ein eigener Ort mit überfälliger Gieß-Aufgabe. Eigener deshalb, weil die
-     * Vergabe an ihm sofort losläuft und die Tests sich sonst gegenseitig die
-     * Aufgaben wegnehmen.
+     * Ein eigener Ort mit Gieß-Aufgabe. Eigener deshalb, weil die Vergabe an
+     * ihm losläuft, sobald er fällig wird, und die Tests sich sonst
+     * gegenseitig die Aufgaben wegnehmen.
      *
-     * Überfällig wird die Aufgabe über eine nachgetragene Erledigung von vor
-     * zehn Tagen: Eine frisch angelegte Aufgabe ist zunächst grün (sie rechnet
-     * ab ihrer Anlage), und die Vergabe rührt nur an, was wirklich ansteht.
-     * Nachtragen darf das die Verwaltung — der E2E-Nutzer hat die Rolle.
+     * Fällig ist die Aufgabe hier noch nicht: Eine frisch angelegte rechnet ab
+     * ihrer Anlage und ist zunächst grün. Fällig wird sie später durch die
+     * Zeitreise ([makeDueAndAssign]) — nicht mehr, wie früher, durch eine zehn
+     * Tage zurückdatierte Erledigung. Rückwirkend melden darf inzwischen nur
+     * noch die Verwaltung und nur drei Tage weit (siehe model.MaxBackdate);
+     * die Ausgangslage eines Tests über eine Ausnahme für Verwaltende zu
+     * bauen, wäre ohnehin der falsche Weg gewesen.
      */
-    private fun eigenerFaelligerOrt(name: String): Pair<Long, Long> {
+    private fun eigenerOrtMitAufgabe(name: String): Pair<Long, Long> {
         val ort = post(
             "/api/v1/places",
             """{"name":"$name ${System.currentTimeMillis()}","kind":"blumenkasten","lat":52.2105,"lon":9.8695}""",
@@ -103,36 +130,41 @@ class VergabeE2eTest {
             "/api/v1/places/${ort.getLong("id")}/tasks",
             """{"kind":"giessen","liters":5,"intervalDays":7,"redAfterDays":14}""",
         )
-        val vorZehnTagen = java.time.Instant.now().minus(java.time.Duration.ofDays(10))
-        post(
-            "/api/v1/tasks/${aufgabe.getLong("id")}/completions",
-            """{"liters":5,"doneAt":"${java.time.format.DateTimeFormatter.ISO_INSTANT.format(vorZehnTagen)}","force":true}""",
-        )
         return ort.getLong("id") to aufgabe.getLong("id")
     }
 
     /**
-     * Wartet, bis für die Aufgabe eine Anfrage vorliegt.
+     * Macht die Aufgabe fällig und lässt die Vergabe genau einmal laufen.
      *
-     * Großzügig bemessen: Der Takt der Vergabe steht in der Vorgabe auf einer
-     * Minute (`VERGABE_TAKT`), und getaktet wird erst nach der Anmeldung.
+     * Zehn Tage weiter als das Soll-Intervall von sieben Tagen — die Aufgabe
+     * ist dann überfällig, die Ampel steht auf Gelb. Der Durchlauf kehrt erst
+     * zurück, wenn die Benachrichtigungen geschrieben sind; danach ist nichts
+     * mehr abzuwarten.
+     *
+     * Muss NACH dem Eintragen kommen: Die Vergabe fragt nur, wer schon
+     * eingetragen ist.
      */
-    private fun warteAufAnfrage(token: String, taskId: Long, sekunden: Int = 150): NotificationDto {
+    private fun makeDueAndAssign() {
+        dev.travelForward(days = 10)
+        dev.runAssignment()
+    }
+
+    /** Die Anfrage zu dieser Aufgabe — sie liegt jetzt vor oder gar nicht. */
+    private fun requestFor(token: String, taskId: Long): NotificationDto =
+        requestOrNull(token, taskId)
+            ?: error("Nach dem Vergabe-Durchlauf liegt keine Anfrage für Aufgabe $taskId vor")
+
+    private fun requestOrNull(token: String, taskId: Long): NotificationDto? {
         val vergabe = ApiVergabeRepository(api(token))
-        repeat(sekunden * 2) {
-            val treffer = runBlocking { vergabe.notifications() }
-                .firstOrNull { it.taskId == taskId && it.istAnfrage }
-            if (treffer != null) return treffer
-            SystemClock.sleep(500)
-        }
-        error("Nach $sekunden s kam keine Anfrage für Aufgabe $taskId")
+        return runBlocking { vergabe.notifications() }
+            .firstOrNull { it.taskId == taskId && it.istAnfrage }
     }
 
     // --- Über die Schnittstelle ------------------------------------------------
 
     @Test
     fun eintragenAnfrageZusageUndRueckgabe() = runBlocking {
-        val (placeId, taskId) = eigenerFaelligerOrt("Vergabe-E2E")
+        val (placeId, taskId) = eigenerOrtMitAufgabe("Vergabe-E2E")
         val anna = ApiVergabeRepository(api(annaToken))
         val orte = ApiPlacesRepository(api(annaToken))
 
@@ -141,7 +173,14 @@ class VergabeE2eTest {
         assertTrue("signedUp fehlt nach dem Eintragen", meine.signedUp)
         assertEquals(1, meine.signupCount)
 
-        val anfrage = warteAufAnfrage(annaToken, taskId)
+        // Solange nichts fällig ist, wird auch niemand gefragt. Bewusst nur
+        // auf DIESE Aufgabe geschaut: Was andere Tests im selben Backend
+        // hinterlassen haben, geht diesen Test nichts an.
+        dev.runAssignment()
+        assertNull("Es wurde gefragt, obwohl die Aufgabe noch grün ist", requestOrNull(annaToken, taskId))
+
+        makeDueAndAssign()
+        val anfrage = requestFor(annaToken, taskId)
         assertTrue("Die Anfrage hat keinen Text", anfrage.title.isNotBlank() && anfrage.text.isNotBlank())
         assertNotNull("Einer Anfrage fehlt die Frist", anfrage.expiresAt)
 
@@ -160,31 +199,28 @@ class VergabeE2eTest {
     }
 
     /**
-     * Wartet auf den Vergabe-Vorgang der Aufgabe. Wer zuerst gefragt wird,
-     * entscheidet die faire Reihenfolge — für diesen Test ist nur wichtig,
-     * dass der Vorgang läuft. Zusagen darf ohnehin jede:r Eingetragene.
+     * Der Vergabe-Vorgang der Aufgabe. Wer zuerst gefragt wird, entscheidet
+     * die faire Reihenfolge — für diesen Test ist nur wichtig, dass der
+     * Vorgang läuft. Zusagen darf ohnehin jede:r Eingetragene.
      */
-    private fun warteAufVorgang(taskId: Long, sekunden: Int = 150): Long {
+    private fun assignmentFor(taskId: Long): Long {
         val orte = ApiPlacesRepository(api(annaToken))
-        repeat(sekunden * 2) {
-            val vorgang = runBlocking { orte.places() }.places
-                .flatMap { it.tasks }.firstOrNull { it.id == taskId }?.assignment
-            if (vorgang != null) return vorgang.id
-            SystemClock.sleep(500)
-        }
-        error("Nach $sekunden s lief kein Vorgang für Aufgabe $taskId")
+        return runBlocking { orte.places() }.places
+            .flatMap { it.tasks }.firstOrNull { it.id == taskId }?.assignment?.id
+            ?: error("Nach dem Vergabe-Durchlauf läuft kein Vorgang für Aufgabe $taskId")
     }
 
     // Zwei Leute, ein Vorgang: Der zweite bekommt 409 mit deutschem Text.
     @Test
     fun wennJemandAnderesSchnellerWar() = runBlocking {
-        val (placeId, taskId) = eigenerFaelligerOrt("Wettlauf-E2E")
+        val (placeId, taskId) = eigenerOrtMitAufgabe("Wettlauf-E2E")
         val anna = ApiVergabeRepository(api(annaToken))
         val bernd = ApiVergabeRepository(api(berndToken))
         anna.signup(placeId, null)
         bernd.signup(placeId, null)
 
-        val vorgangId = warteAufVorgang(taskId)
+        makeDueAndAssign()
+        val vorgangId = assignmentFor(taskId)
         anna.claim(vorgangId)
 
         var abgewiesen = false
@@ -217,6 +253,12 @@ class VergabeE2eTest {
             "push-neu",
         ).apply { mkdirs() }
 
+    /**
+     * Bildschirmfoto. Der kurze Schlaf bleibt bewusst stehen: Er wartet keine
+     * Fachlichkeit ab, sondern die Übergangs-Animation und das Zeichnen —
+     * `waitForIdle` ist damit fertig, bevor das Bild fertig ist. Ein Foto,
+     * das eine halb eingeblendete Seite zeigt, ist kein Nachweis.
+     */
     private fun foto(name: String, wartenMs: Long = 800) {
         compose.waitForIdle()
         SystemClock.sleep(wartenMs)
@@ -226,7 +268,7 @@ class VergabeE2eTest {
 
     @Test
     fun durchDieApp() {
-        val (placeId, taskId) = eigenerFaelligerOrt("App-E2E")
+        val (placeId, taskId) = eigenerOrtMitAufgabe("App-E2E")
         val api = api(annaToken)
         compose.setContent {
             DorfAppTheme {
@@ -245,7 +287,10 @@ class VergabeE2eTest {
         compose.onNodeWithTag("bereich-mithelfen").performScrollTo().performClick()
         compose.onNodeWithTag("tab-list").performClick()
         // Die Liste lädt aus dem Netz; danach zum eigenen Ort scrollen (in
-        // einer langen Liste ist er zunächst gar nicht gebaut).
+        // einer langen Liste ist er zunächst gar nicht gebaut). Der Schlaf
+        // wartet auf das Füllen und Zeichnen der Liste, nicht auf das
+        // Backend — die Karte trägt ihren testTag erst, wenn sie gebaut ist,
+        // und vorher lässt sich auf nichts warten.
         compose.waitUntil(20_000) { compose.onAllNodesWithTagSicher("place-list") }
         SystemClock.sleep(1_500)
         compose.onNodeWithTag("place-list").performScrollToNode(hasTestTag("place-card-$placeId"))
@@ -256,8 +301,10 @@ class VergabeE2eTest {
         compose.waitForIdle()
         foto("e2e-03-eingetragen")
 
-        // 2) Auf die Anfrage warten — der Takt der Vergabe erledigt das.
-        val anfrage = warteAufAnfrage(annaToken, taskId)
+        // 2) Die Aufgabe fällig machen und einmal vergeben lassen. Danach
+        //    liegt die Anfrage im Backend — abzuwarten ist nichts.
+        makeDueAndAssign()
+        val anfrage = requestFor(annaToken, taskId)
 
         // 3) Zurück auf die Startseite: dort steht die Anfrage.
         //    Das Blatt schließt die Zurück-Taste, den Bereich der Pfeil oben.
@@ -271,16 +318,20 @@ class VergabeE2eTest {
         }
         compose.onNodeWithTag("zurueck").performClick()
         compose.waitForIdle()
-        // Der Knopf oben holt den Stand frisch — die Anfrage kam gerade eben.
-        // Notfalls mehrmals: Zwischen Abholen und Anzeigen liegt ein Netzweg.
+        // Der Knopf oben holt den Stand frisch. Die Anfrage steht im Backend
+        // fest, gewartet wird also nur noch auf den Netzweg und das Zeichnen
+        // — und zwar so lange, wie es dauert, statt fester Sekunden. Notfalls
+        // noch einmal tippen: Ein Tipp kann ins Leere gehen, wenn die Liste
+        // gerade neu aufgebaut wird.
         var sichtbar = false
-        repeat(12) {
+        for (versuch in 1..6) {
             compose.onNodeWithTag("refresh").performClick()
-            compose.waitForIdle()
-            SystemClock.sleep(2_000)
+            runCatching {
+                compose.waitUntil(5_000) { compose.onAllNodesWithTagSicher("claim-${anfrage.assignmentId}") }
+            }
             if (compose.onAllNodesWithTagSicher("claim-${anfrage.assignmentId}")) {
                 sichtbar = true
-                return@repeat
+                break
             }
         }
         assertTrue("Die Anfrage steht nicht auf der Startseite", sichtbar)
@@ -290,12 +341,15 @@ class VergabeE2eTest {
         //    gehört (auf der Startseite können mehrere Anfragen stehen).
         compose.onNodeWithTag("bereich-mithelfen").performScrollTo().performClick()
         compose.onNodeWithTag("tab-list").performClick()
+        // Wie oben: Zeit fürs Bauen der Liste, nicht fürs Backend.
         SystemClock.sleep(1_000)
         compose.onNodeWithTag("place-list").performScrollToNode(hasTestTag("place-card-$placeId"))
         compose.onNodeWithTag("place-card-$placeId").performClick()
         compose.waitUntil(60_000) { compose.onAllNodesWithTagSicher("claim-task-$taskId") }
         compose.onNodeWithTag("claim-task-$taskId").performScrollTo().performClick()
         compose.waitForIdle()
+        // Die Zusage geht übers Netz und die Seite baut sich neu — das Foto
+        // soll den Zustand danach zeigen.
         SystemClock.sleep(2_000)
         foto("e2e-05-zugesagt")
 
@@ -310,13 +364,8 @@ class VergabeE2eTest {
 
         // Die Zusage steht auch im Backend — die Oberfläche hat sie wirklich
         // abgeschickt und nicht nur angezeigt.
-        var claimedBy = ""
-        repeat(20) {
-            claimedBy = runBlocking { ApiPlacesRepository(api).places() }
-                .places.first { it.id == placeId }.tasks.first().assignment?.claimedBy.orEmpty()
-            if (claimedBy.isNotEmpty()) return@repeat
-            SystemClock.sleep(500)
-        }
+        val claimedBy = runBlocking { ApiPlacesRepository(api).places() }
+            .places.first { it.id == placeId }.tasks.first().assignment?.claimedBy.orEmpty()
         assertEquals("anna-e2e", claimedBy)
     }
 }

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,6 +5,44 @@ Der Überblick über Aufbau, Betrieb und Entwicklung steht im
 [SICHERHEIT.md](SICHERHEIT.md). Diese Datei beschreibt Endpunkte, deren
 Verhalten sich nicht von selbst versteht.
 
+## `/dev/…` — die Test-Knöpfe (nur `AUTH_MODE=insecure-dev`)
+
+Diese Pfade gibt es **nur**, solange das Backend mit `AUTH_MODE=insecure-dev`
+läuft — dieselbe Bedingung, hinter der auch der Entwickler-Login sitzt. In der
+Produktion sind sie **nicht registriert**, nicht bloß abgewiesen: Ein Pfad, der
+nur bewacht ist, ist eine vergessene Prüfung davon entfernt, die Uhr des
+laufenden Dorfes zu verstellen. Geprüft wird das in
+`cmd/server/main_test.go: TestTestEndpunkteNurImDevModus`, indem der echte
+Server einmal im Dev-Modus und einmal im Produktionspfad startet.
+
+| Route | was sie tut |
+| --- | --- |
+| `GET /dev/clock` | welche Zeit das Backend gerade annimmt (`now`, `offset`) |
+| `POST /dev/clock/set` | `{"time":"2026-09-06T10:00:00+02:00"}` — Uhr auf diesen Zeitpunkt stellen |
+| `POST /dev/clock/advance` | `{"duration":"240h"}` — Uhr um eine Go-Dauer weiterstellen |
+| `POST /dev/clock/reset` | zurück auf die Systemuhr |
+| `POST /dev/assignment/run` | **einen** Vergabe-Durchlauf, synchron; die Antwort nennt die Zahl der erzeugten Benachrichtigungen |
+
+Sie existieren, damit kein Test wartet. Die Vergabe rechnet in Tagen und
+Stunden; ein Test, der auf sie wartet, behauptet nicht mehr „für eine fällige
+Aufgabe wird der Helfer gefragt", sondern „…binnen 150 Sekunden Wanduhrzeit" —
+und das hängt nur davon ab, wie beschäftigt der Rechner ist. Stattdessen:
+**Uhr auf den Fälligkeitstag stellen, einen Durchlauf anstoßen, nachsehen.**
+
+Zwei Dinge sind zu beachten:
+
+- **Die Uhr gehört dem ganzen Prozess** (`internal/clock`). Wer sie verstellt,
+  stellt sie zurück, sonst erbt der nächste Test ein Dorf in der Zukunft. Im
+  Android-E2E erledigt das ein `@After` (siehe `DevBackend.kt`).
+- **Die Uhrzeit ist kein Detail.** Zwischen 21 und 7 Uhr Ortszeit stellt die
+  Vergabe nichts zu (Ruhezeit). Eine Zeitreise, die nachts landet, eröffnet den
+  Vorgang, verschiebt die Anfrage aber auf den Morgen — deshalb reist der Test
+  auf den Vormittag.
+
+Der Durchlauf ist derselbe, den auch der Hintergrund-Zeitgeber fährt (dieselbe
+`vergabe.Config`), er arbeitet synchron und ist beliebig oft wiederholbar: Er
+tut nur etwas, wenn wirklich etwas ansteht.
+
 ## `DELETE /api/v1/me` — das eigene Konto löschen
 
 Angemeldet wie alle `/api/v1`-Routen (JWT, `internal/api/api.go`). Der Rumpf

--- a/backend/SICHERHEIT.md
+++ b/backend/SICHERHEIT.md
@@ -33,6 +33,27 @@ Textlängen), zu gesprächige Fehlermeldungen und fehlende Schutz-Kopfzeilen.
 
 ## Geprüft und in Ordnung
 
+- **Die Test-Knöpfe unter `/dev`** (Uhr stellen, Vergabe anstoßen) sind kein
+  neuer Angriffspunkt: Sie werden nur eingehängt, wenn `AUTH_MODE` auf
+  `insecure-dev` steht. In der Produktion gibt es die Pfade nicht — sie
+  antworten dort mit 404, weil nichts registriert ist, und nicht mit 403,
+  weil eine Prüfung greift. Der Unterschied ist der Punkt: Eine bewachte
+  Route wäre eine vergessene Prüfung davon entfernt, die Uhr des laufenden
+  Dorfes zu verstellen und damit Fälligkeiten, Fristen und Sitzungsablauf.
+  Die Sperre sitzt in `devmode.Register` selbst, nicht nur an der Aufrufstelle.
+  Nachweis: `internal/devmode/devmode_test.go: TestNotMountedOutsideDevMode`
+  und `cmd/server/main_test.go: TestTestEndpunkteNurImDevModus` — dort startet
+  der echte Server einmal im Dev-Modus und einmal im Produktionspfad.
+- **Rückdatierung von Erledigungen** ist von 14 auf **drei Tage** gesenkt
+  (`model.MaxBackdate`); die Verwaltung darf weiterhin 14 Tage zurück
+  (`model.MaxBackdateAdmin`). Gewertet wird eine Meldung nur, wenn die Aufgabe
+  zu ihrem Zeitpunkt nicht frisch erledigt war — ein breites Zeitfenster ist
+  deshalb ein Werkzeug, die Rangliste nachträglich umzuschreiben. Einen
+  abweichenden Zeitpunkt darf ohnehin nur die Verwaltung setzen
+  (`internal/api/completion.go`). Nachweis:
+  `internal/api/spielschutz_test.go: TestBackdatingWindow`,
+  `TestBackdatingLimit`, `TestBackdatingBleibtDerVerwaltungVorbehalten`.
+
 - **Redirect-URI-Allowlist der Dynamic Client Registration (`POST /oauth/register`).**
   Der Schwerpunkt der Prüfung. Der Vergleich ist ein exakter Nachschlag in einer
   festen Liste — keine Präfixe, keine Muster, keine Normalisierung. Alle

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -5,7 +5,11 @@
 //	LISTEN_ADDR   Standard ":8080"
 //	DB_PATH       Standard "/data/dorfapp.sqlite"
 //	AUTH_ISSUER   z.B. https://id.xn--rssing-wxa.de — Pflicht in Produktion
-//	AUTH_MODE     "oidc" (Standard) oder "insecure-dev" (nur lokal/E2E!)
+//	AUTH_MODE     "oidc" (Standard) oder "insecure-dev" (nur lokal/E2E!).
+//	              Nur in diesem Modus gibt es zusätzlich die Test-Knöpfe
+//	              unter /dev (Uhr stellen, Vergabe anstoßen) — siehe
+//	              internal/devmode. In der Produktion sind sie nicht
+//	              registriert, nicht bloß abgewiesen.
 //	AUTH_AUDIENCE kommaseparierte Liste erlaubter Empfänger (Client-IDs der
 //	              Anwendungen, die dieses Backend nutzen dürfen). Im OIDC-Modus
 //	              Pflicht: ohne sie gälte hier jedes Token desselben Ausstellers.
@@ -50,6 +54,7 @@ import (
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/backup"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/db"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/devmode"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/httpx"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/mcp"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/mitglied"
@@ -141,6 +146,13 @@ func main() {
 	// verwaltet“ — siehe internal/mitglied.
 	mitglieder := mitgliederEinrichten(authMode, issuer)
 
+	// Der Signal-Context steht schon hier, weil die Vergabe-Konfiguration an
+	// ihm hängt: Sie fragt die Mitgliedschaften ab, und diese Abfrage soll
+	// mit dem Herunterfahren enden.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	vergabeCfg, vergabeAn := assignmentConfig(ctx, zusteller, mitglieder)
+
 	// OptionalAuth versorgt nur den öffentlichen Ideen-Eingang: Wer aus der
 	// angemeldeten App einreicht, bekommt die Idee dem Konto zugeordnet;
 	// wer über die Website kommt, reicht anonym ein.
@@ -167,6 +179,11 @@ func main() {
 		} else {
 			slog.Warn("ADMIN_CLIENT_ID fehlt — Verwaltung deaktiviert, nur Startseite")
 		}
+		// Test-Knöpfe (Uhr stellen, Vergabe anstoßen). devmode.Register
+		// hängt nichts ein, solange der Auth-Modus nicht insecure-dev ist —
+		// in der Produktion gibt es diese Pfade also gar nicht, statt sie
+		// bloß abzuweisen.
+		devmode.Register(mux, authMode, devmode.Config{DB: database, Assignment: vergabeCfg})
 	})
 
 	// Reihenfolge von außen nach innen: Panics fangen, Kopfzeilen setzen,
@@ -182,10 +199,8 @@ func main() {
 
 	// Hintergrund: tägliche Sicherung der SQLite-Datei ins PVC und der Takt
 	// der Aufgaben-Vergabe (Anfragen freischalten, Zusagen verfallen lassen).
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
 	backupFertig := backupStarten(ctx, database, dbPath)
-	vergabeFertig := vergabeStarten(ctx, database, zusteller, mitglieder)
+	vergabeFertig := vergabeStarten(ctx, database, vergabeCfg, vergabeAn)
 
 	server := &http.Server{
 		Addr:              addr,
@@ -298,14 +313,23 @@ func backupStarten(ctx context.Context, database *db.DB, dbPath string) <-chan s
 // Server und nicht als eigener Dienst — aus demselben Grund wie die
 // Sicherung: Es gibt genau einen Pod mit genau einer Schreibverbindung zur
 // SQLite-Datenbank.
-func vergabeStarten(ctx context.Context, database *db.DB, zusteller vergabe.Zusteller,
-	mitglieder mitglied.Quelle,
-) <-chan struct{} {
-	cfg, an := vergabe.FromEnv()
+func vergabeStarten(ctx context.Context, database *db.DB, cfg vergabe.Config, an bool) <-chan struct{} {
 	if !an {
 		slog.Warn("Vergabe abgeschaltet (VERGABE=off) — es werden keine Anfragen zugestellt")
 		return nil
 	}
+	slog.Info("Vergabe-Zeitgeber aktiv", "takt", cfg.Takt.String())
+	return vergabe.Start(ctx, database, cfg)
+}
+
+// assignmentConfig builds the configuration the assignment engine runs with.
+// Separate from vergabeStarten because the dev-only /dev/assignment/run has
+// to drive the very same engine: a hand-started pass that differed from the
+// scheduled one would prove nothing.
+func assignmentConfig(ctx context.Context, zusteller vergabe.Zusteller,
+	mitglieder mitglied.Quelle,
+) (vergabe.Config, bool) {
+	cfg, an := vergabe.FromEnv()
 	cfg.Zusteller = zusteller
 	// Interne Aufgaben werden nur Mitgliedern angeboten. Ohne Quelle gar
 	// niemandem (siehe vergabe.Engine.Mitgliedschaften).
@@ -320,8 +344,7 @@ func vergabeStarten(ctx context.Context, database *db.DB, zusteller vergabe.Zust
 			return stand.Rollen, nil
 		}
 	}
-	slog.Info("Vergabe-Zeitgeber aktiv", "takt", cfg.Takt.String())
-	return vergabe.Start(ctx, database, cfg)
+	return cfg, an
 }
 
 // errStandVeraltet meldet der Vergabe, dass die Mitgliedschaften gerade nicht

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/api"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/backup"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/db"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/httpx"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/mcp"
@@ -400,7 +401,7 @@ func seed(d *db.DB) error {
 	if err != nil || len(places) > 0 {
 		return err
 	}
-	now := time.Now()
+	now := clock.Now()
 	ten := 10.0
 	for _, def := range []struct {
 		place model.Place

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -215,4 +217,97 @@ func warteAufGesund(url string, frist time.Duration) error {
 		time.Sleep(200 * time.Millisecond)
 	}
 	return letzter
+}
+
+// --- Test-Endpunkte ----------------------------------------------------------
+
+// TestTestEndpunkteNurImDevModus: Die Knöpfe, mit denen ein Test die Uhr
+// stellt und die Vergabe anstößt, dürfen es in der Produktion nicht geben —
+// und zwar gar nicht, nicht bloß abgewiesen. Ein Pfad, der nur bewacht ist,
+// ist eine vergessene Prüfung davon entfernt, die Uhr des laufenden Dorfes zu
+// verstellen.
+//
+// Deshalb wird hier der echte Server zweimal gestartet: einmal im Dev-Modus
+// (die Pfade antworten) und einmal im Produktionspfad gegen einen lokalen
+// Aussteller (die Pfade sind 404).
+func TestTestEndpunkteNurImDevModus(t *testing.T) {
+	bin := baueServer(t)
+
+	t.Run("insecure-dev: erreichbar", func(t *testing.T) {
+		basis := starteUndWarte(t, bin, map[string]string{
+			"AUTH_MODE": "insecure-dev",
+			"SEED":      "1",
+		})
+		if code, _ := hole(t, basis+"/dev/clock"); code != http.StatusOK {
+			t.Fatalf("GET /dev/clock: Status %d, erwartet 200", code)
+		}
+	})
+
+	t.Run("oidc: nicht registriert", func(t *testing.T) {
+		aussteller := lokalerAussteller(t)
+		basis := starteUndWarte(t, bin, map[string]string{
+			"AUTH_ISSUER":   aussteller,
+			"AUTH_AUDIENCE": "dorf-app-test",
+		})
+		for _, pfad := range []string{"/dev/clock", "/dev/clock/set", "/dev/clock/advance",
+			"/dev/clock/reset", "/dev/assignment/run"} {
+			if code, _ := hole(t, basis+pfad); code != http.StatusNotFound {
+				t.Errorf("GET %s: Status %d, erwartet 404 — der Pfad existiert im Produktionsmodus", pfad, code)
+			}
+		}
+	})
+}
+
+// lokalerAussteller stellt gerade so viel OIDC-Discovery bereit, dass der
+// Server im Produktionspfad hochkommt. Bewusst lokal: Ein Test fasst keinen
+// entfernten Anmeldedienst an.
+func lokalerAussteller(t *testing.T) string {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"issuer":%q,"authorization_endpoint":%q,"token_endpoint":%q,"jwks_uri":%q}`,
+			srv.URL, srv.URL+"/authorize", srv.URL+"/token", srv.URL+"/keys")
+	})
+	mux.HandleFunc("/keys", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	})
+	return srv.URL
+}
+
+// starteUndWarte startet den Server und gibt seine Basis-URL zurück, sobald
+// er gesund antwortet.
+func starteUndWarte(t *testing.T, bin string, env map[string]string) string {
+	t.Helper()
+	port := freierPort(t)
+	alle := map[string]string{
+		"LISTEN_ADDR": fmt.Sprintf(":%d", port),
+		"DB_PATH":     filepath.Join(t.TempDir(), "probe.sqlite"),
+		"PUBLIC_URL":  fmt.Sprintf("http://localhost:%d", port),
+		"BACKUP":      "off",
+	}
+	for k, v := range env {
+		alle[k] = v
+	}
+	srv := starte(t, bin, alle)
+	t.Cleanup(func() { beende(t, srv) })
+	basis := fmt.Sprintf("http://localhost:%d", port)
+	if err := warteAufGesund(basis+"/healthz", 20*time.Second); err != nil {
+		t.Fatalf("Server kam nicht hoch: %v", err)
+	}
+	return basis
+}
+
+func hole(t *testing.T, url string) (int, string) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
 }

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -241,6 +241,25 @@ func TestTestEndpunkteNurImDevModus(t *testing.T) {
 		if code, _ := hole(t, basis+"/dev/clock"); code != http.StatusOK {
 			t.Fatalf("GET /dev/clock: Status %d, erwartet 200", code)
 		}
+
+		// Die Zeitreise durch den ganzen Mittelbau: vorspulen, zurück, und
+		// danach muss der Server weiter antworten. Das ist keine Förmlichkeit
+		// — die Rate-Begrenzung füllt ihren Eimer nach vergangenen Sekunden,
+		// und eine Uhr, die zehn Tage zurückspringt, hätte den Aufrufer
+		// zehn Tage lang ausgesperrt, wenn sie an dieser Uhr hinge.
+		if code, body := sende(t, basis+"/dev/clock/advance", `{"duration":"240h"}`); code != http.StatusOK {
+			t.Fatalf("POST /dev/clock/advance: Status %d — %s", code, body)
+		}
+		if code, body := sende(t, basis+"/dev/clock/reset", ""); code != http.StatusOK {
+			t.Fatalf("POST /dev/clock/reset: Status %d — %s", code, body)
+		}
+		code, body := sende(t, basis+"/dev/assignment/run", "")
+		if code != http.StatusOK {
+			t.Fatalf("POST /dev/assignment/run nach der Rückreise: Status %d — %s", code, body)
+		}
+		if !strings.Contains(body, `"offsetSeconds":0`) {
+			t.Fatalf("nach dem Zurücksetzen läuft der Server nicht auf der Systemuhr: %s", body)
+		}
 	})
 
 	t.Run("oidc: nicht registriert", func(t *testing.T) {
@@ -306,6 +325,17 @@ func hole(t *testing.T, url string) (int, string) {
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+func sende(t *testing.T, url, koerper string) (int, string) {
+	t.Helper()
+	resp, err := http.Post(url, "application/json", strings.NewReader(koerper))
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)

--- a/backend/internal/admin/admin.go
+++ b/backend/internal/admin/admin.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/db"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/mitglied"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
@@ -98,7 +99,7 @@ func newApp(cfg Config) *App {
 		mitglieder:    cfg.Mitglieder,
 	}
 	if a.now == nil {
-		a.now = time.Now
+		a.now = clock.Now
 	}
 	return a
 }

--- a/backend/internal/admin/admin_test.go
+++ b/backend/internal/admin/admin_test.go
@@ -32,8 +32,10 @@ func aufbau(t *testing.T) (*App, http.Handler, *db.DB, *http.Cookie) {
 	mux := http.NewServeMux()
 	a.register(mux)
 
+	// Die Sitzung läuft gegen die Uhr der Verwaltung (a.now), nicht gegen
+	// die Systemuhr — sonst hinge der Test daran, welches Datum die Maschine hat.
 	wert, err := a.signer.encode(cookieSession, session{Sub: "u1", Name: "Testadmin", Admin: true,
-		Exp: time.Now().Add(time.Hour).Unix()})
+		Exp: a.now().Add(time.Hour).Unix()})
 	if err != nil {
 		t.Fatalf("session: %v", err)
 	}
@@ -200,7 +202,7 @@ func TestSessionCookieIstManipulationssicher(t *testing.T) {
 		t.Fatalf("gefälschtes Cookie wurde akzeptiert: %d", w.Code)
 	}
 
-	abgelaufen, _ := a.signer.encode(cookieSession, session{Sub: "u1", Admin: true, Exp: time.Now().Add(-time.Minute).Unix()})
+	abgelaufen, _ := a.signer.encode(cookieSession, session{Sub: "u1", Admin: true, Exp: a.now().Add(-time.Minute).Unix()})
 	w = hole(t, h, "/admin/mithelfen/", &http.Cookie{Name: cookieSession, Value: abgelaufen})
 	if w.Code != http.StatusSeeOther {
 		t.Fatalf("abgelaufene Session wurde akzeptiert: %d", w.Code)

--- a/backend/internal/admin/oidc.go
+++ b/backend/internal/admin/oidc.go
@@ -84,7 +84,7 @@ func (a *App) handleLogin(w http.ResponseWriter, r *http.Request) {
 	sum := sha256.Sum256([]byte(verifier))
 	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
 
-	f := flow{State: randomString(24), Verifier: verifier, Exp: time.Now().Add(10 * time.Minute).Unix()}
+	f := flow{State: randomString(24), Verifier: verifier, Exp: a.now().Add(10 * time.Minute).Unix()}
 	value, err := a.signer.encode(cookieFlow, f)
 	if err != nil {
 		a.fail(w, r, http.StatusInternalServerError, err)
@@ -119,7 +119,7 @@ func (a *App) handleCallback(w http.ResponseWriter, r *http.Request) {
 
 	c, err := r.Cookie(cookieFlow)
 	var f flow
-	if err != nil || !a.signer.decode(cookieFlow, c.Value, &f) || f.Exp < time.Now().Unix() {
+	if err != nil || !a.signer.decode(cookieFlow, c.Value, &f) || f.Exp < a.now().Unix() {
 		a.setFlash(w, "error", "Die Anmeldung ist abgelaufen. Bitte erneut versuchen.")
 		http.Redirect(w, r, ziel, http.StatusSeeOther)
 		return
@@ -172,7 +172,7 @@ func (a *App) handleCallback(w http.ResponseWriter, r *http.Request) {
 		Sub: user.Sub, Name: user.Name, Email: user.Email, Admin: user.IsAdmin(),
 		Rollen:  rollenListe(user),
 		IDToken: tok.IDToken,
-		Exp:     time.Now().Add(8 * time.Hour).Unix(),
+		Exp:     a.now().Add(8 * time.Hour).Unix(),
 	}
 	value, err := a.signer.encode(cookieSession, s)
 	if err != nil {

--- a/backend/internal/admin/session.go
+++ b/backend/internal/admin/session.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
-	"time"
 )
 
 // Cookie-Namen. Alle Cookies sind HttpOnly und SameSite=Lax; „Secure“ wird
@@ -132,7 +131,7 @@ func (a *App) sessionOf(r *http.Request) (session, bool) {
 	if !a.signer.decode(cookieSession, c.Value, &s) {
 		return session{}, false
 	}
-	if s.Exp < time.Now().Unix() {
+	if s.Exp < a.now().Unix() {
 		return session{}, false
 	}
 	return s, true

--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/db"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/httpx"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/mitglied"
@@ -93,6 +94,11 @@ func (s *Server) Handler(authMW func(http.Handler) http.Handler, extra func(mux 
 	return logRequests(mux)
 }
 
+// logRequests measures how long a request took. Deliberately time.Now and
+// NOT clock.Now: this is a stopwatch, not a date. It answers "how long did
+// the server work", and that has to stay true even while a dev-mode test
+// moves the clock — a travelled clock would otherwise report a request that
+// took ten days.
 func logRequests(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -105,7 +111,7 @@ func (s *Server) now() time.Time {
 	if s.Now != nil {
 		return s.Now()
 	}
-	return time.Now()
+	return clock.Now()
 }
 
 // AssemblePlaces baut die Orts-Liste in der Sicht des Betreibers — alles,

--- a/backend/internal/api/completion.go
+++ b/backend/internal/api/completion.go
@@ -21,7 +21,8 @@ type CompletionInput struct {
 	// Force: Spielschutz übergehen — nur Admins.
 	Force bool `json:"force"`
 	// DoneAt: abweichender Zeitpunkt (RFC3339), nur Admins, höchstens
-	// model.MaxBackdate in der Vergangenheit und nie in der Zukunft.
+	// model.MaxBackdate (für Admins model.MaxBackdateAdmin) in der
+	// Vergangenheit und nie in der Zukunft.
 	DoneAt string `json:"doneAt"`
 }
 
@@ -80,9 +81,9 @@ func CreateCompletion(d *db.DB, now time.Time, taskID int64, in CompletionInput,
 		switch {
 		case t.After(now):
 			return nil, completionErr(http.StatusBadRequest, "doneAt darf nicht in der Zukunft liegen")
-		case now.Sub(t) > model.MaxBackdate:
+		case now.Sub(t) > backdateLimit(u):
 			return nil, completionErr(http.StatusBadRequest,
-				"doneAt liegt zu weit zurück (höchstens %d Tage)", int(model.MaxBackdate.Hours()/24))
+				"doneAt liegt zu weit zurück (höchstens %d Tage)", int(backdateLimit(u).Hours()/24))
 		}
 		doneAt = t
 	}
@@ -124,6 +125,21 @@ func CreateCompletion(d *db.DB, now time.Time, taskID int64, in CompletionInput,
 	beendeVergabe(d, now, task.ID, u.Sub)
 	raeumeAbWennErledigt(d, now, *task)
 	return &c, nil
+}
+
+// backdateLimit liefert die Rückdatierungsgrenze dieser Person.
+//
+// Der Bezug auf u.IsAdmin() ist heute die einzige Verzweigung, die greift:
+// Weiter oben scheitert eine Meldung mit doneAt schon daran, dass sie nicht
+// von einem Admin kommt. model.MaxBackdate ist damit die Regel für alle
+// anderen Wege — die Web-Verwaltung datiert gar nicht zurück, und wer
+// später einen Weg für die App aufmacht, findet die Grenze hier schon
+// stehen, statt sie neu erfinden zu müssen.
+func backdateLimit(u auth.User) time.Duration {
+	if u.IsAdmin() {
+		return model.MaxBackdateAdmin
+	}
+	return model.MaxBackdate
 }
 
 // raeumeAbWennErledigt nimmt eine einmalige Aufgabe von Karte und Liste,

--- a/backend/internal/api/spielschutz_test.go
+++ b/backend/internal/api/spielschutz_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
 )
 
@@ -171,7 +172,9 @@ func TestCooldownMessageUsesVillageTime(t *testing.T) {
 }
 
 // TestBackdatingWindow: telefonisch gemeldete Erledigungen müssen sich
-// nachtragen lassen — bis zu 14 Tage zurück, nie in die Zukunft.
+// nachtragen lassen — die Verwaltung bis zu 14 Tage zurück, nie in die
+// Zukunft. Für alle anderen sind drei Tage die Grenze (model.MaxBackdate);
+// wer weiter zurück darf, kann die Rangliste nachträglich umschreiben.
 func TestBackdatingWindow(t *testing.T) {
 	ts, _ := newTestServer(t)
 	placeID, _ := createPlaceWithTask(t, ts)
@@ -202,6 +205,39 @@ func TestBackdatingWindow(t *testing.T) {
 		if resp.StatusCode != f.status {
 			t.Errorf("%s (%s): Status %d, erwartet %d", name, wann, resp.StatusCode, f.status)
 		}
+	}
+}
+
+// TestBackdatingLimit: die Grenze hängt an der Rolle. Drei Tage für alle,
+// vierzehn für die Verwaltung — sie trägt fremde Meldungen nach und tut das
+// sichtbar unter ihrem Namen.
+func TestBackdatingLimit(t *testing.T) {
+	admin := auth.User{Sub: "a", Roles: map[string]bool{"admin": true}}
+	helferin := auth.User{Sub: "h"}
+	if got := backdateLimit(admin); got != model.MaxBackdateAdmin {
+		t.Errorf("Verwaltung: %v, erwartet %v", got, model.MaxBackdateAdmin)
+	}
+	if got := backdateLimit(helferin); got != model.MaxBackdate {
+		t.Errorf("ohne Rolle: %v, erwartet %v", got, model.MaxBackdate)
+	}
+	if model.MaxBackdate != 3*24*time.Hour {
+		t.Errorf("MaxBackdate ist %v, erwartet drei Tage", model.MaxBackdate)
+	}
+}
+
+// TestBackdatingBleibtDerVerwaltungVorbehalten: Ohne die Rolle wird ein
+// abweichender Zeitpunkt gar nicht erst angenommen — auch keiner, der
+// innerhalb der drei Tage läge. Ein frei wählbarer Zeitpunkt ist ein
+// Werkzeug, um eine Meldung dorthin zu legen, wo sie für die Rangliste
+// zählt; das bleibt der Verwaltung vorbehalten.
+func TestBackdatingBleibtDerVerwaltungVorbehalten(t *testing.T) {
+	ts, _ := newTestServer(t)
+	_, taskID := createPlaceWithTask(t, ts)
+	wann := time.Now().Add(-2 * time.Hour).Format(time.RFC3339)
+	resp := doReq(t, "POST", ts.URL+fmt.Sprintf("/api/v1/tasks/%d/completions", taskID), memberToken,
+		map[string]any{"doneAt": wann})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("Status %d, erwartet 403 — ohne Rolle darf niemand einen Zeitpunkt wählen", resp.StatusCode)
 	}
 }
 

--- a/backend/internal/backup/backup.go
+++ b/backend/internal/backup/backup.go
@@ -24,6 +24,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 )
 
 // Quelle ist alles, was sich selbst in eine Datei sichern kann (in der Praxis
@@ -79,7 +81,7 @@ func (c *Config) vollstaendig() {
 		c.Takt = DefaultTakt
 	}
 	if c.Now == nil {
-		c.Now = time.Now
+		c.Now = clock.Now
 	}
 }
 

--- a/backend/internal/clock/clock.go
+++ b/backend/internal/clock/clock.go
@@ -1,0 +1,73 @@
+// Package clock is the single source of time for the whole backend.
+//
+// Everything that used to call time.Now() directly now goes through
+// clock.Now(). In production that is exactly the system clock — the offset
+// below is zero and never changes, so behaviour is unchanged.
+//
+// The point of the detour is testing. The village runs on time: a task falls
+// due after so many days, a request is staggered by an hour, a promise
+// expires after a day. A test that waits for any of that is either slow or
+// flaky — it stops asserting "the helper gets asked for an overdue task" and
+// starts asserting "…within N seconds of wall clock", which depends on how
+// busy the machine is and on nothing that matters.
+//
+// So the backend can be moved through time instead. The offset is applied to
+// the real clock rather than freezing it, so time still flows: tickers,
+// timeouts and rate limits keep behaving the way they do in production, they
+// just start from a different instant.
+//
+// Because a travelling clock must be *the* clock, this is deliberately
+// process-wide state and not a value threaded through every constructor.
+// Half a system that travels and half that stands still is worse than no
+// time travel at all. Components keep their injectable clock fields for unit
+// tests; those fields simply default to clock.Now instead of time.Now.
+//
+// The knobs that move the offset live in internal/devclock and are only
+// mounted when AUTH_MODE=insecure-dev. In production nothing can reach them,
+// so the offset stays zero.
+package clock
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// offset is added to the system clock, in nanoseconds. Zero in production.
+// Atomic because the HTTP handler that sets it and every reader run on
+// different goroutines.
+var offset atomic.Int64
+
+// Now is the current time as the backend sees it.
+func Now() time.Time {
+	if d := offset.Load(); d != 0 {
+		return time.Now().Add(time.Duration(d))
+	}
+	return time.Now()
+}
+
+// Offset reports how far the backend's clock is away from the system clock.
+func Offset() time.Duration { return time.Duration(offset.Load()) }
+
+// Travelling reports whether the clock has been moved away from the system
+// clock. Handy for a warning in the log: nothing in production should ever
+// see this true.
+func Travelling() bool { return offset.Load() != 0 }
+
+// Set moves the clock so that Now() returns t. It returns the resulting
+// offset.
+func Set(t time.Time) time.Duration {
+	d := t.Sub(time.Now())
+	offset.Store(int64(d))
+	return d
+}
+
+// Advance moves the clock forward by d (backwards for a negative d) and
+// returns the resulting offset.
+func Advance(d time.Duration) time.Duration {
+	return time.Duration(offset.Add(int64(d)))
+}
+
+// Reset puts the backend back on the system clock. Every test that travels
+// has to come back: the next test would otherwise inherit a village that
+// lives in the future.
+func Reset() { offset.Store(0) }

--- a/backend/internal/clock/clock.go
+++ b/backend/internal/clock/clock.go
@@ -22,9 +22,21 @@
 // time travel at all. Components keep their injectable clock fields for unit
 // tests; those fields simply default to clock.Now instead of time.Now.
 //
-// The knobs that move the offset live in internal/devclock and are only
+// The knobs that move the offset live in internal/devmode and are only
 // mounted when AUTH_MODE=insecure-dev. In production nothing can reach them,
 // so the offset stays zero.
+//
+// Three places deliberately stay on time.Now, and each says so where it
+// happens. The rule is: a calendar follows this clock, a stopwatch and
+// somebody else's clock do not.
+//
+//   - api.logRequests measures how long a request took. A travelled clock
+//     would report a request that lasted ten days.
+//   - httpx.RateLimiter refills its bucket by the seconds that went by. A
+//     jump backwards would drain it and lock the caller out until the clock
+//     caught up.
+//   - push (APNs, FCM) mints JWTs whose iat/exp Apple and Google check
+//     against their own clocks; a travelled backend would mint junk.
 package clock
 
 import (

--- a/backend/internal/clock/clock_test.go
+++ b/backend/internal/clock/clock_test.go
@@ -1,0 +1,57 @@
+package clock
+
+import (
+	"testing"
+	"time"
+)
+
+// TestOffsetIsZeroByDefault: the default is the system clock. If this ever
+// fails, production is running on a travelled clock.
+func TestOffsetIsZeroByDefault(t *testing.T) {
+	if Offset() != 0 || Travelling() {
+		t.Fatalf("offset %v, travelling %v — expected the system clock", Offset(), Travelling())
+	}
+	if d := time.Since(Now()); d > time.Second || d < -time.Second {
+		t.Errorf("Now() is %v away from time.Now()", d)
+	}
+}
+
+func TestSetAdvanceReset(t *testing.T) {
+	t.Cleanup(Reset)
+
+	ziel := time.Date(2031, time.July, 4, 12, 0, 0, 0, time.UTC)
+	Set(ziel)
+	if d := Now().Sub(ziel); d > time.Second || d < 0 {
+		t.Errorf("after Set the clock is %v off", d)
+	}
+	if !Travelling() {
+		t.Error("Travelling() is false although the clock was moved")
+	}
+
+	Advance(48 * time.Hour)
+	if d := Now().Sub(ziel.Add(48 * time.Hour)); d > time.Second || d < 0 {
+		t.Errorf("after Advance the clock is %v off", d)
+	}
+
+	// Time keeps flowing while travelled — nothing is frozen.
+	erst := Now()
+	time.Sleep(2 * time.Millisecond)
+	if !Now().After(erst) {
+		t.Error("the clock stands still while travelled")
+	}
+
+	Reset()
+	if Offset() != 0 || Travelling() {
+		t.Errorf("Reset left an offset of %v", Offset())
+	}
+}
+
+// TestAdvanceBackwards: travelling back is allowed too — a test may need a
+// completion that lies in the past without backdating it.
+func TestAdvanceBackwards(t *testing.T) {
+	t.Cleanup(Reset)
+	Advance(-72 * time.Hour)
+	if d := time.Since(Now()); d < 71*time.Hour {
+		t.Errorf("clock only went back %v", d)
+	}
+}

--- a/backend/internal/db/traeger.go
+++ b/backend/internal/db/traeger.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
 )
 
@@ -123,7 +124,7 @@ func (d *DB) TraegerSicherstellen(schluessel, name string) (*model.Traeger, erro
 	neu := model.Traeger{
 		Schluessel: schluessel, Name: name,
 		Status: model.TraegerZugelassen, Sichtbarkeit: model.TraegerOffen,
-		CreatedAt: time.Now().UTC(),
+		CreatedAt: clock.Now().UTC(),
 	}
 	if err := d.InsertTraeger(&neu); err != nil {
 		return nil, err

--- a/backend/internal/devmode/devmode.go
+++ b/backend/internal/devmode/devmode.go
@@ -1,0 +1,191 @@
+// Package devmode mounts the handful of knobs that exist only while the
+// backend runs with AUTH_MODE=insecure-dev — the same switch the developer
+// login sits behind.
+//
+// They exist for one reason: a test that waits is a test that lies. The
+// assignment of care tasks is a matter of days and hours, so an end-to-end
+// test used to create an overdue task, sign someone up and then sleep for up
+// to 150 seconds hoping the background timer would get around to it. That
+// test does not assert "an overdue task gets its helper asked", it asserts
+// "…within 150 seconds of wall clock" — a property nobody cares about, that
+// depends on how busy the machine is, and that made the same commit go green
+// on one emulator and red on the other.
+//
+// With these two knobs the test says what it means instead: move the clock
+// to the day the task is due, run one assignment pass, look at the result.
+// No sleeping, same answer every time.
+//
+//	GET  /dev/clock            what time the backend thinks it is
+//	POST /dev/clock/set        {"time":"2026-09-06T10:00:00+02:00"}
+//	POST /dev/clock/advance    {"duration":"240h"}
+//	POST /dev/clock/reset      back to the system clock
+//	POST /dev/assignment/run   one synchronous vergabe.Engine.Durchlauf
+//
+// Reset matters as much as the rest: the clock is process-wide, so a test
+// that travels and does not come back hands the next test a village living
+// in the future.
+//
+// In production none of this is registered — not guarded, not 403, simply
+// absent. Register refuses to mount unless the auth mode is insecure-dev, so
+// even a wrong call site cannot bring the routes into a production process.
+package devmode
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/db"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/vergabe"
+)
+
+// AuthMode is the only value of AUTH_MODE that unlocks these routes.
+const AuthMode = "insecure-dev"
+
+// Config is what the knobs need to do their work.
+type Config struct {
+	DB *db.DB
+	// Assignment is the very same configuration the background timer runs
+	// with. Running a pass by hand has to be the identical piece of work —
+	// a test that drives a second, differently configured engine would
+	// prove nothing about the one that runs in production.
+	Assignment vergabe.Config
+}
+
+// Register mounts the dev routes and reports whether it did. It mounts
+// nothing unless authMode is insecure-dev.
+func Register(mux *http.ServeMux, authMode string, cfg Config) bool {
+	if authMode != AuthMode {
+		return false
+	}
+	h := &handler{cfg: cfg}
+	mux.HandleFunc("GET /dev/clock", h.clockState)
+	mux.HandleFunc("POST /dev/clock/set", h.clockSet)
+	mux.HandleFunc("POST /dev/clock/advance", h.clockAdvance)
+	mux.HandleFunc("POST /dev/clock/reset", h.clockReset)
+	mux.HandleFunc("POST /dev/assignment/run", h.assignmentRun)
+	slog.Warn("Test-Endpunkte unter /dev aktiv (AUTH_MODE=insecure-dev) — " +
+		"Uhr stellen und Vergabe anstoßen. Im Betrieb gibt es diese Wege nicht.")
+	return true
+}
+
+type handler struct{ cfg Config }
+
+// clockAnswer is what every clock route replies with, so a caller always
+// learns where the clock ended up.
+type clockAnswer struct {
+	Now    time.Time `json:"now"`
+	Offset string    `json:"offset"`
+	// OffsetSeconds is the same number for callers that would rather not
+	// parse a Go duration.
+	OffsetSeconds float64 `json:"offsetSeconds"`
+}
+
+func (h *handler) clockState(w http.ResponseWriter, _ *http.Request) {
+	antwort(w, http.StatusOK, jetzt())
+}
+
+func (h *handler) clockSet(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Time string `json:"time"`
+	}
+	if !lies(w, r, &in) {
+		return
+	}
+	t, err := time.Parse(time.RFC3339, in.Time)
+	if err != nil {
+		fehler(w, http.StatusBadRequest, "time muss ein Zeitpunkt im Format RFC3339 sein")
+		return
+	}
+	clock.Set(t)
+	slog.Warn("Test-Uhr gestellt", "now", clock.Now(), "offset", clock.Offset().String())
+	antwort(w, http.StatusOK, jetzt())
+}
+
+func (h *handler) clockAdvance(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Duration string `json:"duration"`
+	}
+	if !lies(w, r, &in) {
+		return
+	}
+	d, err := time.ParseDuration(in.Duration)
+	if err != nil {
+		fehler(w, http.StatusBadRequest, "duration muss eine Go-Dauer sein, z.B. „240h“")
+		return
+	}
+	clock.Advance(d)
+	slog.Warn("Test-Uhr vorgestellt", "um", d.String(), "now", clock.Now(), "offset", clock.Offset().String())
+	antwort(w, http.StatusOK, jetzt())
+}
+
+func (h *handler) clockReset(w http.ResponseWriter, _ *http.Request) {
+	clock.Reset()
+	slog.Info("Test-Uhr zurückgesetzt — wieder Systemzeit")
+	antwort(w, http.StatusOK, jetzt())
+}
+
+// assignmentRun runs exactly one pass of the assignment engine and only
+// returns once the notifications are written. That is what makes the waiting
+// in the test unnecessary: Durchlauf is synchronous and, by its own
+// documentation, repeatable at will — it only works when something is due.
+func (h *handler) assignmentRun(w http.ResponseWriter, _ *http.Request) {
+	cfg := h.cfg.Assignment
+	zaehler := &countingZusteller{weiter: cfg.Zusteller}
+	cfg.Zusteller = zaehler
+	if err := vergabe.New(h.cfg.DB, cfg).Durchlauf(); err != nil {
+		fehler(w, http.StatusInternalServerError, "Vergabe-Durchlauf fehlgeschlagen: "+err.Error())
+		return
+	}
+	antwort(w, http.StatusOK, struct {
+		clockAnswer
+		Notifications int `json:"notifications"`
+	}{jetzt(), zaehler.n})
+}
+
+// countingZusteller counts the notifications one pass produced and hands
+// them on to the real delivery. One instance per request, so no locking is
+// needed — Durchlauf works through its list in a single goroutine.
+type countingZusteller struct {
+	weiter vergabe.Zusteller
+	n      int
+}
+
+func (c *countingZusteller) Zustellen(n model.Notification) error {
+	c.n++
+	if c.weiter == nil {
+		return nil
+	}
+	return c.weiter.Zustellen(n)
+}
+
+func jetzt() clockAnswer {
+	o := clock.Offset()
+	return clockAnswer{Now: clock.Now(), Offset: o.String(), OffsetSeconds: o.Seconds()}
+}
+
+// lies decodes a JSON body. An empty body is fine — every field is optional
+// until the handler says otherwise.
+func lies(w http.ResponseWriter, r *http.Request, ziel any) bool {
+	if r.Body == nil || r.ContentLength == 0 {
+		return true
+	}
+	if err := json.NewDecoder(r.Body).Decode(ziel); err != nil {
+		fehler(w, http.StatusBadRequest, "unlesbarer JSON-Körper: "+err.Error())
+		return false
+	}
+	return true
+}
+
+func antwort(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func fehler(w http.ResponseWriter, status int, text string) {
+	antwort(w, status, map[string]string{"error": text})
+}

--- a/backend/internal/devmode/devmode_test.go
+++ b/backend/internal/devmode/devmode_test.go
@@ -1,0 +1,208 @@
+package devmode
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/db"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/vergabe"
+)
+
+// alleRouten sind die Pfade, die es nur im Testmodus geben darf.
+var alleRouten = []struct {
+	method string
+	pfad   string
+}{
+	{"GET", "/dev/clock"},
+	{"POST", "/dev/clock/set"},
+	{"POST", "/dev/clock/advance"},
+	{"POST", "/dev/clock/reset"},
+	{"POST", "/dev/assignment/run"},
+}
+
+// TestNotMountedOutsideDevMode is the important one: in production these
+// paths must not exist at all — not 403, not "unauthorized", nothing. A
+// route that is merely guarded is one forgotten check away from being a way
+// to move the clock of the running village.
+func TestNotMountedOutsideDevMode(t *testing.T) {
+	for _, modus := range []string{"oidc", "", "Insecure-Dev", "insecure-dev ", "dev", "production"} {
+		t.Run("AUTH_MODE="+modus, func(t *testing.T) {
+			mux := http.NewServeMux()
+			if Register(mux, modus, Config{}) {
+				t.Fatalf("Register hat im Modus %q eingehängt", modus)
+			}
+			for _, r := range alleRouten {
+				w := httptest.NewRecorder()
+				mux.ServeHTTP(w, httptest.NewRequest(r.method, r.pfad, nil))
+				if w.Code != http.StatusNotFound {
+					t.Errorf("%s %s: Status %d, erwartet 404 — der Pfad ist registriert", r.method, r.pfad, w.Code)
+				}
+			}
+		})
+	}
+}
+
+func TestMountedInDevMode(t *testing.T) {
+	mux, _ := aufbau(t)
+	for _, r := range alleRouten {
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, httptest.NewRequest(r.method, r.pfad, strings.NewReader(`{"duration":"1s","time":"2026-01-01T00:00:00Z"}`)))
+		if w.Code == http.StatusNotFound {
+			t.Errorf("%s %s ist im Testmodus nicht erreichbar", r.method, r.pfad)
+		}
+	}
+}
+
+func TestClockSetAdvanceReset(t *testing.T) {
+	mux, _ := aufbau(t)
+
+	ziel := time.Date(2029, time.May, 17, 9, 30, 0, 0, time.UTC)
+	a := ruf(t, mux, "POST", "/dev/clock/set", `{"time":"`+ziel.Format(time.RFC3339)+`"}`, http.StatusOK)
+	if d := a.Now.Sub(ziel); d < 0 || d > time.Second {
+		t.Errorf("nach set steht die Uhr %v daneben", d)
+	}
+	if d := clock.Now().Sub(ziel); d < 0 || d > time.Second {
+		t.Errorf("die Uhr des Backends folgt dem Endpunkt nicht: %v", d)
+	}
+
+	a = ruf(t, mux, "POST", "/dev/clock/advance", `{"duration":"240h"}`, http.StatusOK)
+	if d := a.Now.Sub(ziel.Add(240 * time.Hour)); d < 0 || d > time.Second {
+		t.Errorf("nach advance steht die Uhr %v daneben", d)
+	}
+
+	a = ruf(t, mux, "GET", "/dev/clock", "", http.StatusOK)
+	if a.OffsetSeconds == 0 {
+		t.Error("GET /dev/clock meldet keinen Versatz, obwohl die Uhr gereist ist")
+	}
+
+	a = ruf(t, mux, "POST", "/dev/clock/reset", "", http.StatusOK)
+	if a.OffsetSeconds != 0 || clock.Travelling() {
+		t.Errorf("reset hat einen Versatz von %v gelassen", clock.Offset())
+	}
+}
+
+func TestClockRejectsNonsense(t *testing.T) {
+	mux, _ := aufbau(t)
+	ruf(t, mux, "POST", "/dev/clock/set", `{"time":"morgen früh"}`, http.StatusBadRequest)
+	ruf(t, mux, "POST", "/dev/clock/advance", `{"duration":"zehn Tage"}`, http.StatusBadRequest)
+	ruf(t, mux, "POST", "/dev/clock/set", `{`, http.StatusBadRequest)
+	if clock.Travelling() {
+		t.Error("eine abgewiesene Eingabe hat die Uhr trotzdem verstellt")
+	}
+}
+
+// TestAssignmentRunAsksTheHelper ist der Kern: kein Warten, kein Zeitfenster.
+// Aufgabe anlegen, eintragen, Uhr vorstellen, Durchlauf anstoßen — danach
+// liegt die Anfrage vor. Genau dieser Ablauf ersetzt die 150 Sekunden im
+// Android-E2E.
+func TestAssignmentRunAsksTheHelper(t *testing.T) {
+	mux, d := aufbau(t)
+
+	// Frisch angelegt ist die Aufgabe grün: Sie rechnet ab ihrer Anlage.
+	p := model.Place{Name: "Unter den Eichen", Kind: model.PlaceFlowerbox, Active: true, CreatedAt: clock.Now()}
+	if err := d.InsertPlace(&p); err != nil {
+		t.Fatal(err)
+	}
+	task := model.CareTask{PlaceID: p.ID, Kind: model.TaskWatering, IntervalDays: 7, RedAfterDays: 14,
+		Active: true, CreatedAt: clock.Now()}
+	if err := d.InsertTask(&task); err != nil {
+		t.Fatal(err)
+	}
+	anmeldung := model.Signup{UserSub: "anna", PlaceID: p.ID, CreatedAt: clock.Now()}
+	if _, err := d.InsertSignup(&anmeldung); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ohne Fälligkeit passiert nichts — der Durchlauf ist beliebig oft
+	// wiederholbar und arbeitet nur, wenn wirklich etwas ansteht.
+	if a := laufen(t, mux); a.Notifications != 0 {
+		t.Fatalf("es wurde gefragt, obwohl nichts fällig war (%d Benachrichtigungen)", a.Notifications)
+	}
+
+	// Zehn Tage weiter, mitten am Vormittag der Ortszeit — die Ruhezeit
+	// zwischen 21 und 7 Uhr würde die Zustellung sonst auf den Morgen
+	// verschieben, und der Test hinge wieder an der Uhrzeit der Maschine.
+	vormittags(t, mux, 10)
+
+	a := laufen(t, mux)
+	if a.Notifications != 1 {
+		t.Fatalf("ein Durchlauf erzeugte %d Benachrichtigungen, erwartet 1", a.Notifications)
+	}
+	offen, err := d.OpenNotifications("anna")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(offen) != 1 || offen[0].Kind != model.NotifyRequest || offen[0].TaskID != task.ID {
+		t.Fatalf("keine Anfrage für Anna: %+v", offen)
+	}
+
+	// Und noch einmal: ein zweiter Durchlauf fragt niemanden doppelt.
+	if a := laufen(t, mux); a.Notifications != 0 {
+		t.Errorf("der zweite Durchlauf erzeugte %d Benachrichtigungen", a.Notifications)
+	}
+}
+
+// --- Hilfen ------------------------------------------------------------------
+
+func aufbau(t *testing.T) (*http.ServeMux, *db.DB) {
+	t.Helper()
+	t.Cleanup(clock.Reset)
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.sqlite"))
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	mux := http.NewServeMux()
+	if !Register(mux, AuthMode, Config{DB: d, Assignment: vergabe.Config{}}) {
+		t.Fatal("Register hat im Testmodus nichts eingehängt")
+	}
+	return mux, d
+}
+
+type laufAntwort struct {
+	clockAnswer
+	Notifications int `json:"notifications"`
+}
+
+func ruf(t *testing.T, mux *http.ServeMux, method, pfad, koerper string, erwartet int) clockAnswer {
+	t.Helper()
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest(method, pfad, strings.NewReader(koerper)))
+	if w.Code != erwartet {
+		t.Fatalf("%s %s: Status %d, erwartet %d — %s", method, pfad, w.Code, erwartet, w.Body.String())
+	}
+	var a clockAnswer
+	_ = json.Unmarshal(w.Body.Bytes(), &a)
+	return a
+}
+
+func laufen(t *testing.T, mux *http.ServeMux) laufAntwort {
+	t.Helper()
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest("POST", "/dev/assignment/run", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /dev/assignment/run: Status %d — %s", w.Code, w.Body.String())
+	}
+	var a laufAntwort
+	if err := json.Unmarshal(w.Body.Bytes(), &a); err != nil {
+		t.Fatalf("unlesbare Antwort: %v", err)
+	}
+	return a
+}
+
+// vormittags stellt die Uhr um so viele Tage vor und legt sie dabei auf
+// 10 Uhr Ortszeit — außerhalb der Ruhezeit, damit die Zustellung nicht auf
+// den nächsten Morgen wartet.
+func vormittags(t *testing.T, mux *http.ServeMux, tage int) {
+	t.Helper()
+	ort := clock.Now().In(model.Location()).AddDate(0, 0, tage)
+	ziel := time.Date(ort.Year(), ort.Month(), ort.Day(), 10, 0, 0, 0, model.Location())
+	ruf(t, mux, "POST", "/dev/clock/set", `{"time":"`+ziel.Format(time.RFC3339)+`"}`, http.StatusOK)
+}

--- a/backend/internal/httpx/ratelimit.go
+++ b/backend/internal/httpx/ratelimit.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 )
 
 // Rate-Limiting: ein schlichter Token-Bucket je Aufrufer. Begrenzt werden
@@ -33,6 +31,13 @@ type RateLimitConfig struct {
 	// Enabled schaltet den Limiter ab, wenn es auf false zeigt (Tests).
 	Enabled *bool
 	// Now ist die Zeitquelle (Tests).
+	//
+	// Deliberately time.Now and not clock.Now: a token bucket measures a
+	// rate, it does not read a calendar. It also has to survive the clock
+	// jumping backwards — a bucket refills by the seconds that passed, so a
+	// ten-day jump back would drain it by ten days' worth of tokens and lock
+	// the caller out until the clock caught up again. Rate limiting has
+	// nothing to say about which day the village thinks it is.
 	Now func() time.Time
 }
 
@@ -97,7 +102,7 @@ func NewRateLimiter(cfg RateLimitConfig) *RateLimiter {
 		proSek = float64(DefaultPerMinute) / 60
 	}
 	if cfg.Now == nil {
-		cfg.Now = clock.Now
+		cfg.Now = time.Now
 	}
 	return &RateLimiter{
 		burst:  float64(cfg.Burst),

--- a/backend/internal/httpx/ratelimit.go
+++ b/backend/internal/httpx/ratelimit.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 )
 
 // Rate-Limiting: ein schlichter Token-Bucket je Aufrufer. Begrenzt werden
@@ -95,7 +97,7 @@ func NewRateLimiter(cfg RateLimitConfig) *RateLimiter {
 		proSek = float64(DefaultPerMinute) / 60
 	}
 	if cfg.Now == nil {
-		cfg.Now = time.Now
+		cfg.Now = clock.Now
 	}
 	return &RateLimiter{
 		burst:  float64(cfg.Burst),

--- a/backend/internal/mcp/mcp.go
+++ b/backend/internal/mcp/mcp.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/api"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/db"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/vergabe"
@@ -58,7 +59,7 @@ func (s *Server) now() time.Time {
 	if s.Now != nil {
 		return s.Now()
 	}
-	return time.Now()
+	return clock.Now()
 }
 
 // Register hängt den MCP-Endpoint samt OAuth-Metadata an den Mux.

--- a/backend/internal/mcp/mcp.go
+++ b/backend/internal/mcp/mcp.go
@@ -315,7 +315,8 @@ func (s *Server) registerTools() {
 				"liters": num("Tatsächlich gegossene Liter (optional)"),
 				"note":   str("Optionale Notiz"),
 				"force":  boolean("Spielschutz übergehen (Sperrfrist nach der letzten Meldung)"),
-				"doneAt": str("Zeitpunkt der Erledigung (RFC3339), höchstens 14 Tage zurück"),
+				"doneAt": str("Zeitpunkt der Erledigung (RFC3339), höchstens 14 Tage zurück " +
+					"(Verwaltung; sonst 3 Tage)"),
 			}),
 			Handler: s.toolCreateCompletion,
 		},

--- a/backend/internal/mitglied/mitglied.go
+++ b/backend/internal/mitglied/mitglied.go
@@ -45,6 +45,7 @@ import (
 	"time"
 
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
 )
 
@@ -110,7 +111,7 @@ func (DevQuelle) Fuer(_ context.Context, u auth.User) Stand {
 		}
 		rollen[projekt][name] = true
 	}
-	return Stand{Rollen: rollen, Geholt: time.Now()}
+	return Stand{Rollen: rollen, Geholt: clock.Now()}
 }
 
 // --- Zwischenspeicher -------------------------------------------------------

--- a/backend/internal/mitglied/zitadel.go
+++ b/backend/internal/mitglied/zitadel.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
 )
 
@@ -110,7 +111,7 @@ func New(cfg Config) (*Zitadel, error) {
 		jetzt:   cfg.Now,
 	}
 	if z.jetzt == nil {
-		z.jetzt = time.Now
+		z.jetzt = clock.Now
 	}
 	return z, nil
 }

--- a/backend/internal/model/cooldown.go
+++ b/backend/internal/model/cooldown.go
@@ -16,9 +16,20 @@ const (
 	CooldownShare = 0.5
 	// MinCooldown: kürzeste Sperre, egal wie eng das Intervall ist.
 	MinCooldown = 12 * time.Hour
-	// MaxBackdate: so weit dürfen Admins eine Meldung zurückdatieren
-	// (telefonisch gemeldeter Vollzug aus dem Urlaub, Zettel vom Sommerfest).
-	MaxBackdate = 14 * 24 * time.Hour
+	// MaxBackdate: so weit darf eine Meldung zurückdatiert werden.
+	//
+	// Drei Tage decken den ehrlichen Fall ab: am Samstag gegossen, erst
+	// heute daran gedacht. Zwei Wochen decken ihn auch ab — sie erlauben
+	// aber obendrein, die Rangliste nachträglich umzuschreiben. Gewertet
+	// wird eine Meldung nämlich nur, wenn die Aufgabe zu ihrem Zeitpunkt
+	// nicht frisch erledigt war; wer den Zeitpunkt frei in ein zwei Wochen
+	// breites Fenster legen darf, sucht sich einen, an dem sie zählt.
+	MaxBackdate = 3 * 24 * time.Hour
+	// MaxBackdateAdmin: die Verwaltung darf weiter zurück. Sie trägt fremde
+	// Meldungen nach — telefonisch gemeldeter Vollzug aus dem Urlaub, Zettel
+	// vom Sommerfest —, und das unter ihrem Namen und sichtbar in der
+	// Historie der Aufgabe.
+	MaxBackdateAdmin = 14 * 24 * time.Hour
 )
 
 // CooldownFor liefert die Sperrfrist einer Aufgabe. factor ist der

--- a/backend/internal/push/apns.go
+++ b/backend/internal/push/apns.go
@@ -39,7 +39,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
 )
 
@@ -160,7 +159,11 @@ func NeuAPNs(cfg APNsConfig) (*APNsZusteller, error) {
 	}
 	jetzt := cfg.Now
 	if jetzt == nil {
-		jetzt = clock.Now
+		// Deliberately time.Now and not clock.Now: iat/exp of these
+		// JWTs are checked by Apple and Google against THEIR clocks. A
+		// backend travelling through time for a test would mint tokens
+		// that are simply invalid out there.
+		jetzt = time.Now
 	}
 	return &APNsZusteller{
 		geraete: cfg.Geraete, basis: basis, topic: topic,

--- a/backend/internal/push/apns.go
+++ b/backend/internal/push/apns.go
@@ -39,6 +39,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
 )
 
@@ -159,7 +160,7 @@ func NeuAPNs(cfg APNsConfig) (*APNsZusteller, error) {
 	}
 	jetzt := cfg.Now
 	if jetzt == nil {
-		jetzt = time.Now
+		jetzt = clock.Now
 	}
 	return &APNsZusteller{
 		geraete: cfg.Geraete, basis: basis, topic: topic,

--- a/backend/internal/push/fcm.go
+++ b/backend/internal/push/fcm.go
@@ -36,6 +36,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
 )
 
@@ -127,7 +128,7 @@ func Neu(cfg Config) (*Zusteller, error) {
 	}
 	jetzt := cfg.Now
 	if jetzt == nil {
-		jetzt = time.Now
+		jetzt = clock.Now
 	}
 	return &Zusteller{
 		geraete: cfg.Geraete, projekt: z.ProjectID, mail: z.ClientEmail,

--- a/backend/internal/push/fcm.go
+++ b/backend/internal/push/fcm.go
@@ -36,7 +36,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
 )
 
@@ -128,7 +127,11 @@ func Neu(cfg Config) (*Zusteller, error) {
 	}
 	jetzt := cfg.Now
 	if jetzt == nil {
-		jetzt = clock.Now
+		// Deliberately time.Now and not clock.Now: iat/exp of these
+		// JWTs are checked by Apple and Google against THEIR clocks. A
+		// backend travelling through time for a test would mint tokens
+		// that are simply invalid out there.
+		jetzt = time.Now
 	}
 	return &Zusteller{
 		geraete: cfg.Geraete, projekt: z.ProjectID, mail: z.ClientEmail,

--- a/backend/internal/vergabe/vergabe.go
+++ b/backend/internal/vergabe/vergabe.go
@@ -40,6 +40,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/db"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
 )
@@ -94,7 +95,7 @@ type Engine struct {
 func New(d *db.DB, cfg Config) *Engine {
 	e := &Engine{db: d, now: cfg.Now, zusteller: cfg.Zusteller, Mitgliedschaften: cfg.Mitgliedschaften}
 	if e.now == nil {
-		e.now = time.Now
+		e.now = clock.Now
 	}
 	if e.zusteller == nil {
 		e.zusteller = Abruf{}


### PR DESCRIPTION
`VergabeE2eTest` wartete bis zu 150 Sekunden darauf, dass der Zeitgeber im
Backend von selbst eine Anfrage erzeugt. Das war nicht nur langsam, sondern
**nicht deterministisch**: Derselbe Commit lief gestern auf einem Emulator grün
und auf dem anderen rot.

Der Test behauptete „für eine fällige Aufgabe wird der Helfer gefragt", prüfte
aber zusätzlich „…und zwar binnen zweieinhalb Minuten Wanduhrzeit" — eine
Eigenschaft, die niemanden interessiert.

## Eine Uhr fürs Backend

`backend/internal/clock` ist jetzt die eine Uhr: ein prozessweiter **Versatz**
auf die Systemuhr, Vorgabe null. Bewusst ein Versatz und keine eingefrorene
Zeit — so fließt die Zeit weiter und Ticker verhalten sich wie im Betrieb.

13 Stellen ziehen mit. Vier ziehen **bewusst nicht** mit, nach der Regel *„ein
Kalender folgt der Dorf-Uhr, eine Stoppuhr und die Uhr eines Fremden nicht"*:
Dauermessung im Protokoll, die Zugriffsbegrenzung, die Push-Tokens für Apple
und Google, und die Ablaufprüfung in `go-oidc`.

**Die Zugriffsbegrenzung ist dabei nicht Theorie, sondern ein Fund am laufenden
Server:** Ein Sprung zehn Tage zurück zog ihrem Eimer 1,7 Millionen Token ab,
danach antwortete sie nur noch mit 429. Der Servertest fährt die Zeitreise
jetzt ganz durch und ist ohne diese Ausnahme rot.

## Knöpfe, die es in der Produktion nicht gibt

```
GET  /dev/clock            POST /dev/clock/set
POST /dev/clock/advance    POST /dev/clock/reset
POST /dev/assignment/run
```

`devmode.Register` hängt **nichts** ein, wenn der Modus nicht `insecure-dev`
ist — die Sperre sitzt im Paket, nicht an der Aufrufstelle. Zwei Tests belegen
es, einer davon startet das **echte Server-Binary** zweimal und prüft im
Produktionspfad auf 404.

## Der Test

Anlegen → eintragen → Uhr zehn Tage vor → Durchlauf anstoßen → Anfrage lesen →
Uhr zurück. Keine Wartezeit mehr.

Nebenbei zwei Schleifen gefunden, die **immer** ihre volle Rundenzahl abliefen,
weil `return@repeat` die Schleife nicht verlässt: 24 und 10 Sekunden pro Lauf,
verschenkt. Geschätzte Dauer der drei Tests jetzt 15–20 Sekunden statt 60–90 —
und vor allem bei jedem Lauf dieselbe.

Wo ein `sleep` nur eine Animation abwartet, ist er geblieben, jeweils mit
Begründung im Quelltext.

## Rückdatierung

`MaxBackdate` 14 → **3 Tage**, neu `MaxBackdateAdmin` = 14 Tage.

**Am Verhalten ändert sich heute nichts** — siehe Anmerkung unten.

## Geprüft

`gofmt`/`go vet`/`go test` grün, auch mit `-tags e2e`. Android-Unit-Tests und
Übersetzung der Instrumentierungstests grün. Wache grün. **Und live am
laufenden Dev-Server durchgespielt**: ohne Reise 0 Anfragen, mit Reise 1
Anfrage samt Text und Frist, zusagen, zurücksetzen, weiter bedienbar.

**Nicht ausgeführt:** Instrumentierungstests — hier gibt es keinen Emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)