### PR TITLE
fix: die Anmeldung überlebt Aktualisierung und Funkloch

### DIFF
--- a/android/app/src/androidTest/java/de/roessing/app/BackendE2eTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/BackendE2eTest.kt
@@ -2,6 +2,7 @@ package de.roessing.app
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import de.roessing.app.auth.TokenResult
 import de.roessing.app.data.ApiPlacesRepository
 import de.roessing.app.data.ApiProfileRepository
 import de.roessing.app.data.ApiStatsRepository
@@ -41,7 +42,9 @@ class BackendE2eTest {
         )
     }
 
-    private fun api() = DorfApi.create(BuildConfig.API_BASE_URL) { "e2e-user:E2E Tester:admin" }
+    private fun api() = DorfApi.create(BuildConfig.API_BASE_URL) {
+        TokenResult.Token("e2e-user:E2E Tester:admin")
+    }
 
     private fun repo() = ApiPlacesRepository(api())
 

--- a/android/app/src/androidTest/java/de/roessing/app/GeraetekennungE2eTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/GeraetekennungE2eTest.kt
@@ -3,6 +3,7 @@ package de.roessing.app
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import de.roessing.app.auth.TokenResult
 import de.roessing.app.data.ApiDeviceRepository
 import de.roessing.app.data.DorfApi
 import de.roessing.app.push.Anmeldespeicher
@@ -164,7 +165,7 @@ class GeraetekennungE2eTest {
      */
     private fun abgleich() = Geraeteabgleich(
         speicher = speicher,
-        geraete = ApiDeviceRepository(DorfApi.create(BuildConfig.API_BASE_URL) { token }),
+        geraete = ApiDeviceRepository(DorfApi.create(BuildConfig.API_BASE_URL) { TokenResult.Token(token) }),
         kennung = { kennungAbgefragt++; kennung },
         kennungVerwerfen = {},
     )

--- a/android/app/src/androidTest/java/de/roessing/app/IdeenBackendE2eTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/IdeenBackendE2eTest.kt
@@ -2,6 +2,7 @@ package de.roessing.app
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import de.roessing.app.auth.TokenResult
 import de.roessing.app.data.ApiIdeenRepository
 import de.roessing.app.data.DorfApi
 import de.roessing.app.data.IdeeInput
@@ -33,7 +34,7 @@ class IdeenBackendE2eTest {
     }
 
     private fun repo() = ApiIdeenRepository(
-        DorfApi.create(BuildConfig.API_BASE_URL) { "e2e-idee:E2E Ideengeber:member" },
+        DorfApi.create(BuildConfig.API_BASE_URL) { TokenResult.Token("e2e-idee:E2E Ideengeber:member") },
     )
 
     @Test

--- a/android/app/src/androidTest/java/de/roessing/app/PushEchtTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/PushEchtTest.kt
@@ -7,6 +7,7 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.google.firebase.messaging.FirebaseMessaging
+import de.roessing.app.auth.TokenResult
 import de.roessing.app.data.ApiDeviceRepository
 import de.roessing.app.data.ApiVergabeRepository
 import de.roessing.app.data.DorfApi
@@ -94,7 +95,7 @@ class PushEchtTest {
             "Keine Gerätekennung — dieses Systemabbild hat keine Google-Play-Dienste",
             kennung != null,
         )
-        val api = DorfApi.create(BuildConfig.API_BASE_URL) { token }
+        val api = DorfApi.create(BuildConfig.API_BASE_URL) { TokenResult.Token(token) }
         runBlocking { ApiDeviceRepository(api).register(kennung!!) }
 
         // Ein eigener, überfälliger Ort — daran läuft die Vergabe sofort los.

--- a/android/app/src/androidTest/java/de/roessing/app/VergabeE2eTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/VergabeE2eTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.performScrollToNode
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import de.roessing.app.auth.TokenResult
 import de.roessing.app.data.ApiPlacesRepository
 import de.roessing.app.data.ApiIdeenRepository
 import de.roessing.app.data.ApiProfileRepository
@@ -66,7 +67,7 @@ class VergabeE2eTest {
     private val client = OkHttpClient()
     private val json = "application/json".toMediaType()
 
-    private fun api(token: String) = DorfApi.create(BuildConfig.API_BASE_URL) { token }
+    private fun api(token: String) = DorfApi.create(BuildConfig.API_BASE_URL) { TokenResult.Token(token) }
 
     private val annaToken = "anna-e2e:Anna E2E:admin"
     private val berndToken = "bernd-e2e:Bernd E2E:"

--- a/android/app/src/main/java/de/roessing/app/DorfApp.kt
+++ b/android/app/src/main/java/de/roessing/app/DorfApp.kt
@@ -40,7 +40,7 @@ class DorfApp : Application() {
 
 class AppContainer(context: Context) {
     val authManager = AuthManager(context.applicationContext)
-    private val api = DorfApi.create(BuildConfig.API_BASE_URL) { authManager.freshAccessToken() }
+    private val api = DorfApi.create(BuildConfig.API_BASE_URL) { authManager.freshToken() }
     val repository: PlacesRepository = ApiPlacesRepository(api)
     val statsRepository: StatsRepository = ApiStatsRepository(api)
     val profileRepository: ProfileRepository = ApiProfileRepository(api)

--- a/android/app/src/main/java/de/roessing/app/auth/AuthManager.kt
+++ b/android/app/src/main/java/de/roessing/app/auth/AuthManager.kt
@@ -49,6 +49,24 @@ const val ROLLEN_SCOPE = "urn:zitadel:iam:org:projects:roles"
  */
 val LOGIN_SCOPES = listOf("openid", "profile", "email", "offline_access", ROLLEN_SCOPE)
 
+/**
+ * Was die App gerade als Access-Token anbieten kann.
+ *
+ * Der Unterschied zwischen [LoggedOut] und [Unreachable] ist der ganze Punkt:
+ * „Der Server sagt nein" ist eine Entscheidung, „ich konnte den Server nicht
+ * fragen" ein Umstand. Nur das Erste beendet eine Anmeldung. Solange beides
+ * `null` hieß, kostete jedes Funkloch die Anmeldung.
+ */
+sealed interface TokenResult {
+    data class Token(val value: String) : TokenResult
+
+    /** Niemand ist angemeldet. */
+    data object LoggedOut : TokenResult
+
+    /** Jemand ist angemeldet, aber das Token ließ sich gerade nicht erneuern. */
+    data object Unreachable : TokenResult
+}
+
 /** Login-Zustand der App. */
 sealed interface SessionState {
     data object Loading : SessionState
@@ -218,23 +236,53 @@ class AuthManager(private val context: Context) {
         _session.value = SessionState.LoggedIn(devMode = true)
     }
 
-    /** Liefert ein gültiges Access-Token (refresht bei Bedarf) oder null. */
-    suspend fun freshAccessToken(): String? {
-        devToken?.let { return it }
-        val state = authState ?: return null
+    /**
+     * Liefert die Tokenlage: ein gültiges Access-Token (refresht bei Bedarf),
+     * „niemand angemeldet" oder „gerade nicht erreichbar".
+     *
+     * Um die gleichzeitigen Erneuerungen muss sich hier niemand kümmern:
+     * [AuthState.performActionWithFreshTokens] bündelt sie selbst (es reiht
+     * weitere Aufrufe in `mPendingActions` ein, solange eine Erneuerung
+     * läuft). Ohne das schickte jeder Abruf beim Kaltstart seine eigene
+     * Erneuerung los — und Zitadel gibt bei jeder ein neues Refresh-Token aus
+     * und weist das alte danach ab.
+     */
+    suspend fun freshToken(): TokenResult {
+        devToken?.let { return TokenResult.Token(it) }
+        val state = authState ?: return TokenResult.LoggedOut
         return suspendCancellableCoroutine { cont ->
             state.performActionWithFreshTokens(authService) { accessToken, _, ex ->
-                if (ex != null) {
-                    // Refresh fehlgeschlagen (z.B. Token widerrufen) → ausloggen.
-                    scope.launch { logout() }
-                    cont.resume(null)
-                } else {
-                    scope.launch { persist() }
-                    cont.resume(accessToken)
+                when {
+                    ex == null && accessToken != null -> {
+                        scope.launch { persist() }
+                        cont.resume(TokenResult.Token(accessToken))
+                    }
+                    // Ohne Refresh-Token gibt es nichts mehr zu erneuern —
+                    // das ist wirklich das Ende der Sitzung, kein Umstand.
+                    state.refreshToken == null || isSessionEnded(ex?.type, ex?.error) -> {
+                        Log.w(TAG, "Die Rössing-ID hat die Sitzung beendet (${ex?.error})")
+                        scope.launch { logout() }
+                        cont.resume(TokenResult.LoggedOut)
+                    }
+                    else -> {
+                        // Nicht fragen zu können ist kein Nein: Die Anmeldung
+                        // bleibt stehen, der nächste Abruf versucht es erneut.
+                        Log.i(TAG, "Erneuerung gerade nicht möglich (${ex?.type}.${ex?.code})")
+                        cont.resume(TokenResult.Unreachable)
+                    }
                 }
             }
         }
     }
+
+    /**
+     * Liefert ein gültiges Access-Token oder null.
+     *
+     * Bleibt für den E2E-Lauf, der nur wissen will, ob eines herauskommt. Der
+     * Unterschied zwischen „abgemeldet" und „nicht erreichbar" geht dabei
+     * verloren — wer ihn braucht, nimmt [freshToken].
+     */
+    suspend fun freshAccessToken(): String? = (freshToken() as? TokenResult.Token)?.value
 
     /**
      * Das zuletzt erhaltene ID-Token — nur zur Diagnose im Login-Test.
@@ -261,6 +309,28 @@ class AuthManager(private val context: Context) {
         private const val TAG = "AuthManager"
 
         fun isDevAuthAllowed(): Boolean = BuildConfig.DEBUG && BuildConfig.DEV_AUTH
+
+        /**
+         * Ob eine gescheiterte Erneuerung das Ende der Sitzung bedeutet.
+         *
+         * RFC 6749 lässt den Token-Endpunkt eine abgelehnte Zuteilung mit
+         * einem Kürzel beantworten. `invalid_grant` ist das einzige, das
+         * „diese Sitzung ist vorbei" heißt — widerrufenes Refresh-Token,
+         * gesperrtes Konto, geändertes Passwort. Alles andere ist entweder
+         * ein Fehler in unserer Einrichtung (`invalid_client`) oder der
+         * Zustand des Netzes bzw. des Servers, und beides darf keine gültige
+         * Anmeldung kosten: Nach `invalid_client` scheiterte die neue
+         * Anmeldung an derselben Stelle wieder, und nach einem Funkloch war
+         * nie etwas mit der Sitzung.
+         *
+         * Bewusst als reine Funktion ohne Android-Abhängigkeiten, damit sie
+         * im JVM-Unit-Test abgedeckt werden kann.
+         *
+         * @param type AppAuth-Fehlertyp (AuthorizationException.TYPE_*), oder null.
+         * @param error OAuth-Fehlerkürzel aus der Antwort, oder null.
+         */
+        fun isSessionEnded(type: Int?, error: String?): Boolean =
+            type == AuthorizationException.TYPE_OAUTH_TOKEN_ERROR && error == "invalid_grant"
 
         /**
          * Übersetzt eine AppAuth-Fehlerkennung in ein [LoginResult].

--- a/android/app/src/main/java/de/roessing/app/data/Api.kt
+++ b/android/app/src/main/java/de/roessing/app/data/Api.kt
@@ -1,9 +1,11 @@
 package de.roessing.app.data
 
+import de.roessing.app.auth.TokenResult
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.http.Body
@@ -14,6 +16,7 @@ import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
+import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 interface DorfApi {
@@ -90,10 +93,31 @@ interface DorfApi {
         }
 
         /**
-         * Baut den API-Client. tokenProvider liefert ein frisches Access-Token
-         * (oder null, wenn nicht eingeloggt) und wird pro Request aufgerufen.
+         * Hängt die Autorisierung an eine Anfrage — oder bricht ab.
+         *
+         * Der dritte Fall ist der wichtige: Besteht eine Anmeldung, ließ sie
+         * sich aber gerade nicht erneuern, geht die Anfrage **nicht** ohne
+         * Kopfzeile hinaus. Sonst käme ein 401 zurück, und die App machte
+         * daraus „nicht angemeldet" — falsch, und es kostet eine Anmeldung,
+         * die noch gilt. Eine IOException ist die Wahrheit: Es ist ein
+         * Netzproblem, und die Bereiche zeigen dafür längst „offline" an.
+         *
+         * Als reine Funktion, damit sie sich ohne Netz prüfen lässt.
          */
-        fun create(baseUrl: String, tokenProvider: suspend () -> String?): DorfApi {
+        fun autorisiert(request: Request, token: TokenResult): Request = when (token) {
+            is TokenResult.Token ->
+                request.newBuilder().header("Authorization", "Bearer ${token.value}").build()
+            // Ein paar Endpunkte (Ideen) nehmen die Anfrage auch ohne an.
+            TokenResult.LoggedOut -> request
+            TokenResult.Unreachable ->
+                throw IOException("Die Anmeldung ließ sich gerade nicht erneuern")
+        }
+
+        /**
+         * Baut den API-Client. tokenProvider liefert die Tokenlage und wird
+         * pro Request aufgerufen.
+         */
+        fun create(baseUrl: String, tokenProvider: suspend () -> TokenResult): DorfApi {
             val client = OkHttpClient.Builder()
                 .connectTimeout(10, TimeUnit.SECONDS)
                 .readTimeout(20, TimeUnit.SECONDS)
@@ -101,11 +125,7 @@ interface DorfApi {
                     // OkHttp-Interceptoren sind synchron; der Tokenabruf ist
                     // lokal (Cache/Refresh) und läuft auf dem IO-Dispatcher.
                     val token = runBlocking { tokenProvider() }
-                    val req = if (token != null) {
-                        chain.request().newBuilder()
-                            .header("Authorization", "Bearer $token").build()
-                    } else chain.request()
-                    chain.proceed(req)
+                    chain.proceed(autorisiert(chain.request(), token))
                 }
                 .build()
             return Retrofit.Builder()

--- a/android/app/src/main/java/de/roessing/app/ui/HomeScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/HomeScreen.kt
@@ -129,6 +129,9 @@ fun HomeScreen(
 
     val savedMsg = stringResource(R.string.watered_success)
     val failMsg = stringResource(R.string.error_network)
+    // Beim Ausfall eines Abrufs steht ausdrücklich dabei, dass die Anmeldung
+    // hält — sonst liest sich „keine Verbindung" wie „du bist raus".
+    val offlineMsg = stringResource(R.string.error_offline_signed_in)
     val deniedMsg = stringResource(R.string.location_denied)
     val zusageMsg = stringResource(R.string.assignment_claimed_toast)
     val rueckgabeMsg = stringResource(R.string.assignment_released_toast)
@@ -241,7 +244,7 @@ fun HomeScreen(
         }
     }
     LaunchedEffect(state.offline) {
-        if (state.offline) snackbar.showSnackbar(failMsg)
+        if (state.offline) snackbar.showSnackbar(offlineMsg)
     }
     LaunchedEffect(abgelehnt) {
         // Einmal freundlich erklären, dann nie wieder nörgeln.

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -60,6 +60,7 @@
     <string name="delete">Löschen</string>
     <string name="cancel">Abbrechen</string>
     <string name="error_network">Keine Verbindung zum Server. Es werden ggf. alte Daten angezeigt.</string>
+    <string name="error_offline_signed_in">Keine Verbindung zum Server. Du bleibst angemeldet — es geht weiter, sobald die Verbindung wieder steht.</string>
     <!-- Bestätigung vor dem Melden einer Erledigung -->
     <string name="confirm_completion_watering">Hast du wirklich gegossen?</string>
     <string name="confirm_completion_weeding">Hast du wirklich gejätet?</string>

--- a/android/app/src/test/java/de/roessing/app/TokenRefreshTest.kt
+++ b/android/app/src/test/java/de/roessing/app/TokenRefreshTest.kt
@@ -1,0 +1,97 @@
+package de.roessing.app
+
+import de.roessing.app.auth.AuthManager
+import de.roessing.app.auth.TokenResult
+import de.roessing.app.data.DorfApi
+import net.openid.appauth.AuthorizationException
+import okhttp3.Request
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Dass eine einmal erteilte Anmeldung hält.
+ *
+ * Der Kern ist ein einziger Unterschied: **„Der Server sagt nein" ist etwas
+ * anderes als „ich konnte den Server nicht fragen."** Das Erste ist eine
+ * Entscheidung der Rössing-ID — widerrufenes Refresh-Token, gesperrtes Konto,
+ * geändertes Passwort —, das Zweite ein Funkloch. Solange beides zum selben
+ * Ergebnis führte, kostete jeder schlechte Augenblick im Mobilfunknetz die
+ * Anmeldung, und die Person stand ohne Grund wieder vor dem Login-Screen.
+ *
+ * Kein Test hier fasst einen Server an: Geprüft werden zwei reine Funktionen.
+ */
+class TokenRefreshTest {
+
+    // --- Was die Rössing-ID wirklich entschieden hat -------------------------
+
+    @Test
+    fun einWiderrufenesRefreshTokenBeendetDieSitzung() {
+        val ex = AuthorizationException.TokenRequestErrors.INVALID_GRANT
+        assertTrue(AuthManager.isSessionEnded(ex.type, ex.error))
+    }
+
+    // --- Was bloß ein Umstand war -------------------------------------------
+
+    @Test
+    fun einFunklochBeendetKeineSitzung() {
+        val ex = AuthorizationException.GeneralErrors.NETWORK_ERROR
+        assertFalse(AuthManager.isSessionEnded(ex.type, ex.error))
+    }
+
+    @Test
+    fun eineUnlesbareAntwortBeendetKeineSitzung() {
+        val ex = AuthorizationException.GeneralErrors.JSON_DESERIALIZATION_ERROR
+        assertFalse(AuthManager.isSessionEnded(ex.type, ex.error))
+    }
+
+    @Test
+    fun einFehlerInUnsererEinrichtungBeendetKeineSitzung() {
+        // `invalid_client` heißt: An unserer Anmeldung ist etwas falsch. Wer
+        // deswegen ausloggt, wirft eine gültige Sitzung weg — und die neue
+        // Anmeldung scheiterte an derselben Stelle wieder.
+        val ex = AuthorizationException.TokenRequestErrors.INVALID_CLIENT
+        assertFalse(AuthManager.isSessionEnded(ex.type, ex.error))
+    }
+
+    @Test
+    fun einServerfehlerBeendetKeineSitzung() {
+        // 5xx ist der Zustand des Servers, nicht sein Urteil über die Sitzung.
+        assertFalse(AuthManager.isSessionEnded(AuthorizationException.TYPE_GENERAL_ERROR, "server_error"))
+    }
+
+    @Test
+    fun garKeineAngabeBeendetKeineSitzung() {
+        assertFalse(AuthManager.isSessionEnded(null, null))
+    }
+
+    // --- Was daraus für die Anfrage folgt -----------------------------------
+
+    private val anfrage = Request.Builder().url("http://127.0.0.1:8099/api/v1/me").build()
+
+    @Test
+    fun mitTokenGehtDieKopfzeileMit() {
+        val fertig = DorfApi.autorisiert(anfrage, TokenResult.Token("abc"))
+        assertEquals("Bearer abc", fertig.header("Authorization"))
+    }
+
+    @Test
+    fun ohneAnmeldungGehtDieAnfrageOhneKopfzeileHinaus() {
+        val fertig = DorfApi.autorisiert(anfrage, TokenResult.LoggedOut)
+        assertNull(fertig.header("Authorization"))
+    }
+
+    @Test
+    fun eineNichtErneuerbareAnmeldungGehtGarNichtErstHinaus() {
+        // Ohne Kopfzeile käme ein 401 zurück, und die App machte daraus
+        // „nicht angemeldet". Eine IOException ist die Wahrheit: ein
+        // Netzproblem — und die Bereiche zeigen dafür „offline".
+        assertThrows(IOException::class.java) {
+            DorfApi.autorisiert(anfrage, TokenResult.Unreachable)
+        }
+    }
+}

--- a/ios/Dorf/Anmeldung/Anmeldung.swift
+++ b/ios/Dorf/Anmeldung/Anmeldung.swift
@@ -32,6 +32,20 @@ enum Anmeldeergebnis: Equatable, Sendable {
     case fehlgeschlagen(kuerzel: String)
 }
 
+/// Was die App gerade als Zugangstoken anbieten kann.
+///
+/// Der Unterschied zwischen den beiden letzten Fällen ist der ganze Punkt:
+/// „Der Server sagt nein" ist eine Entscheidung, „ich konnte den Server nicht
+/// fragen" ein Umstand. Nur das Erste beendet eine Anmeldung. Solange beides
+/// gleich hieß (`nil`), kostete jedes Funkloch die Anmeldung.
+enum Tokenlage: Equatable, Sendable {
+    case token(String)
+    /// Niemand ist angemeldet.
+    case abgemeldet
+    /// Jemand ist angemeldet, aber das Token ließ sich gerade nicht erneuern.
+    case nichtErreichbar
+}
+
 /// Die Endpunkte der Rössing-ID, wie sie die Discovery meldet.
 struct OidcEndpunkte: Codable, Sendable {
     let authorization_endpoint: URL
@@ -60,7 +74,36 @@ final class Anmeldung: NSObject, ObservableObject {
     private var endpunkte: OidcEndpunkte?
     private var laufendeAnmeldung: ASWebAuthenticationSession?
 
-    override init() {
+    /// Die gerade laufende Erneuerung, falls es eine gibt.
+    ///
+    /// Vor **jeder** Anfrage wird ein Token verlangt, und beim Kaltstart
+    /// verlangen mehrere Abrufe es im selben Augenblick (Profil, Orte,
+    /// Gerätekennung). Ohne diese Stelle schickte jeder von ihnen seine
+    /// eigene Erneuerung mit demselben Erneuerungstoken los — und Zitadel
+    /// gibt bei jeder Erneuerung ein neues aus und weist das alte von da an
+    /// ab. Der erste Abruf gewänne, alle übrigen bekämen `invalid_grant`,
+    /// und das hat bis hierher abgemeldet. Genau das war nach einer
+    /// Aktualisierung zu sehen. Jetzt warten alle auf dieselbe Erneuerung.
+    private var laufendeErneuerung: Task<Tokensatz, Error>?
+
+    private let sitzungsNetz: URLSession
+    private let aussteller: URL
+    private let clientId: String
+    private let ruecksprung: String
+    private let ablage: Tokenablage
+
+    /// Die Vorbelegungen sind die der App; ein Test reicht seine eigenen
+    /// herein und fasst damit weder das Netz noch den echten Schlüsselbund an.
+    init(sitzung: URLSession = .dorfSitzung,
+         aussteller: URL = Konfiguration.oidcAussteller,
+         clientId: String = Konfiguration.oidcClientId,
+         ruecksprung: String = Konfiguration.oidcRuecksprung,
+         ablage: Tokenablage = .schluesselbund) {
+        self.sitzungsNetz = sitzung
+        self.aussteller = aussteller
+        self.clientId = clientId
+        self.ruecksprung = ruecksprung
+        self.ablage = ablage
         super.init()
         wiederherstellen()
     }
@@ -74,7 +117,7 @@ final class Anmeldung: NSObject, ObservableObject {
             sitzung = .angemeldet(entwicklerModus: true)
             return
         }
-        if let satz = Schluesselbund.lesen() {
+        if let satz = ablage.lesen() {
             tokensatz = satz
             letztesIdToken = satz.idToken
             // Auch ein abgelaufenes Zugangstoken zählt als angemeldet, solange
@@ -88,32 +131,65 @@ final class Anmeldung: NSObject, ObservableObject {
         sitzung = .abgemeldet
     }
 
-    /// Liefert ein gültiges Zugangstoken (erneuert bei Bedarf) oder `nil`.
+    /// Liefert die Tokenlage: ein gültiges Zugangstoken (erneuert bei Bedarf),
+    /// „niemand angemeldet" oder „gerade nicht erreichbar".
     /// Wird vor **jeder** API-Anfrage aufgerufen.
-    func frischesToken() async -> String? {
-        if let entwicklerToken { return entwicklerToken }
-        guard let satz = tokensatz else { return nil }
-        if satz.gueltig() { return satz.zugangstoken }
-        guard let erneuerung = satz.erneuerungstoken else {
+    func frischesToken() async -> Tokenlage {
+        if let entwicklerToken { return .token(entwicklerToken) }
+        guard let satz = tokensatz else { return .abgemeldet }
+        if satz.gueltig() { return .token(satz.zugangstoken) }
+        guard let erneuerungstoken = satz.erneuerungstoken else {
+            // Ohne Erneuerungstoken gibt es nichts mehr zu erneuern — das ist
+            // wirklich das Ende der Sitzung und kein Umstand.
             abmelden()
-            return nil
+            return .abgemeldet
         }
         do {
-            let neu = try await erneuern(mit: erneuerung)
-            uebernehmen(neu)
-            return neu.zugangstoken
-        } catch {
-            // Erneuerung endgültig gescheitert (z.B. Token widerrufen):
-            // abmelden ist ehrlicher, als weiter 401 zu sammeln.
+            return .token(try await erneuerungAbwarten(mit: erneuerungstoken).zugangstoken)
+        } catch Anmeldefehler.abgewiesen(let kuerzel) where Self.istSitzungsende(kuerzel) {
+            // Die Rössing-ID hat die Sitzung beendet: Token widerrufen, Konto
+            // gesperrt, Passwort geändert. Hier ist Abmelden die Wahrheit.
             abmelden()
-            return nil
+            return .abgemeldet
+        } catch {
+            // Alles andere heißt nur: gerade nicht gefragt werden können.
+            // Die Anmeldung bleibt stehen, der nächste Abruf versucht es neu.
+            return .nichtErreichbar
         }
+    }
+
+    /// Ob eine abgewiesene Erneuerung das Ende der Sitzung bedeutet.
+    ///
+    /// RFC 6749 lässt den Token-Endpunkt eine abgelehnte Zuteilung mit 400 und
+    /// einem Kürzel beantworten. `invalid_grant` ist das einzige, das „diese
+    /// Sitzung ist vorbei" heißt — widerrufenes Erneuerungstoken, gesperrtes
+    /// Konto, geändertes Passwort. `invalid_client`, `invalid_request` und
+    /// Verwandtes sind Fehler in **unserer** Einrichtung; wer daraufhin
+    /// abmeldet, wirft eine gültige Anmeldung wegen eines eigenen Fehlers weg,
+    /// und die neue Anmeldung scheiterte an derselben Stelle wieder.
+    ///
+    /// Als reine Funktion, damit sie sich ohne Netz prüfen lässt.
+    static func istSitzungsende(_ kuerzel: String) -> Bool {
+        kuerzel == "invalid_grant"
+    }
+
+    /// Erneuert — oder hängt sich an die Erneuerung, die schon läuft.
+    private func erneuerungAbwarten(mit erneuerungstoken: String) async throws -> Tokensatz {
+        if let laufendeErneuerung { return try await laufendeErneuerung.value }
+        // Die Aufgabe wird **vor** dem ersten `await` hinterlegt: Erst dadurch
+        // findet der nächste Aufrufer sie vor, statt eine zweite loszuschicken.
+        let aufgabe = Task { try await self.erneuern(mit: erneuerungstoken) }
+        laufendeErneuerung = aufgabe
+        defer { laufendeErneuerung = nil }
+        let neu = try await aufgabe.value
+        uebernehmen(neu)
+        return neu
     }
 
     private func uebernehmen(_ satz: Tokensatz) {
         tokensatz = satz
         letztesIdToken = satz.idToken ?? letztesIdToken
-        Schluesselbund.sichern(satz)
+        ablage.sichern(satz)
         sitzung = .angemeldet(entwicklerModus: false)
     }
 
@@ -121,7 +197,7 @@ final class Anmeldung: NSObject, ObservableObject {
         tokensatz = nil
         entwicklerToken = nil
         letztesIdToken = nil
-        Schluesselbund.loeschen()
+        ablage.loeschen()
         UserDefaults.standard.removeObject(forKey: "entwicklerToken")
         sitzung = .abgemeldet
     }
@@ -138,6 +214,12 @@ final class Anmeldung: NSObject, ObservableObject {
 
     // MARK: Anmeldefluss
 
+    /// Das Schema, unter dem der Browser zurück in die App springt
+    /// (`de.roessing.app` aus `de.roessing.app:/oauth2redirect`).
+    private var ruecksprungSchema: String {
+        String(ruecksprung.prefix(while: { $0 != ":" }))
+    }
+
     func anmelden() async -> Anmeldeergebnis {
         do {
             let ziele = try await endpunkteHolen()
@@ -147,9 +229,9 @@ final class Anmeldung: NSObject, ObservableObject {
 
             var bau = URLComponents(url: ziele.authorization_endpoint, resolvingAgainstBaseURL: false)!
             bau.queryItems = [
-                .init(name: "client_id", value: Konfiguration.oidcClientId),
+                .init(name: "client_id", value: clientId),
                 .init(name: "response_type", value: "code"),
-                .init(name: "redirect_uri", value: Konfiguration.oidcRuecksprung),
+                .init(name: "redirect_uri", value: ruecksprung),
                 .init(name: "scope", value: ANMELDE_SCOPES.joined(separator: " ")),
                 .init(name: "state", value: zustand),
                 .init(name: "code_challenge", value: herausforderung),
@@ -189,28 +271,36 @@ final class Anmeldung: NSObject, ObservableObject {
         }
     }
 
+    /// Warum ein Anmelde- oder Erneuerungsschritt nicht durchkam.
+    ///
+    /// Die Trennung ist die Sache selbst: `abgewiesen` heißt, die Rössing-ID
+    /// hat geantwortet und Nein gesagt. `nichtErreichbar` heißt, sie hat gar
+    /// nicht geantwortet — kein Netz, Zeitüberschreitung, 5xx, unlesbare
+    /// Antwort. Nur das Erste darf eine Anmeldung kosten.
     private enum Anmeldefehler: Error, Equatable {
         case abgebrochen
-        case discovery
-        case tokenTausch(String)
+        /// Ihr OAuth-Kürzel: `invalid_grant`, `invalid_client`, `access_denied` …
+        case abgewiesen(String)
+        case nichtErreichbar(String)
 
         var kuerzel: String {
             switch self {
             case .abgebrochen: return "abgebrochen"
-            case .discovery: return "discovery"
-            case .tokenTausch(let k): return k
+            case .abgewiesen(let k): return k
+            case .nichtErreichbar(let k): return k
             }
         }
     }
 
     private func endpunkteHolen() async throws -> OidcEndpunkte {
         if let endpunkte { return endpunkte }
-        let adresse = Konfiguration.oidcAussteller
-            .appending(path: ".well-known/openid-configuration")
-        guard let (daten, antwort) = try? await URLSession.dorfSitzung.data(from: adresse),
+        let adresse = aussteller.appending(path: ".well-known/openid-configuration")
+        guard let (daten, antwort) = try? await sitzungsNetz.data(from: adresse),
               let http = antwort as? HTTPURLResponse, http.statusCode == 200,
               let gelesen = try? JSONDecoder().decode(OidcEndpunkte.self, from: daten)
-        else { throw Anmeldefehler.discovery }
+        // Die Discovery ist ein Netzabruf wie jeder andere: Scheitert sie,
+        // konnten wir nicht fragen — das ist kein Nein der Rössing-ID.
+        else { throw Anmeldefehler.nichtErreichbar("discovery") }
         endpunkte = gelesen
         return gelesen
     }
@@ -219,7 +309,7 @@ final class Anmeldung: NSObject, ObservableObject {
         try await withCheckedThrowingContinuation { fortsetzung in
             let sitzung = ASWebAuthenticationSession(
                 url: adresse,
-                callbackURLScheme: Konfiguration.ruecksprungSchema
+                callbackURLScheme: ruecksprungSchema
             ) { rueckweg, fehler in
                 if let rueckweg {
                     fortsetzung.resume(returning: rueckweg)
@@ -241,8 +331,8 @@ final class Anmeldung: NSObject, ObservableObject {
         try await tokenAnfrage(ziel: ziel, felder: [
             "grant_type": "authorization_code",
             "code": code,
-            "redirect_uri": Konfiguration.oidcRuecksprung,
-            "client_id": Konfiguration.oidcClientId,
+            "redirect_uri": ruecksprung,
+            "client_id": clientId,
             "code_verifier": pruefer,
         ])
     }
@@ -252,7 +342,7 @@ final class Anmeldung: NSObject, ObservableObject {
         var neu = try await tokenAnfrage(ziel: ziele.token_endpoint, felder: [
             "grant_type": "refresh_token",
             "refresh_token": erneuerungstoken,
-            "client_id": Konfiguration.oidcClientId,
+            "client_id": clientId,
         ])
         // Zitadel schickt bei der Erneuerung nicht zwingend ein neues
         // Erneuerungstoken mit — dann gilt das alte weiter.
@@ -267,6 +357,11 @@ final class Anmeldung: NSObject, ObservableObject {
         let expires_in: Double?
     }
 
+    /// Die Fehlerantwort des Token-Endpunkts nach RFC 6749.
+    private struct TokenFehlerAntwort: Decodable {
+        let error: String?
+    }
+
     private func tokenAnfrage(ziel: URL, felder: [String: String]) async throws -> Tokensatz {
         var anfrage = URLRequest(url: ziel)
         anfrage.httpMethod = "POST"
@@ -276,21 +371,31 @@ final class Anmeldung: NSObject, ObservableObject {
             .joined(separator: "&")
             .data(using: .utf8)
 
-        guard let (daten, antwort) = try? await URLSession.dorfSitzung.data(for: anfrage),
+        guard let (daten, antwort) = try? await sitzungsNetz.data(for: anfrage),
               let http = antwort as? HTTPURLResponse
-        else { throw Anmeldefehler.tokenTausch("netz") }
-        guard http.statusCode == 200,
-              let gelesen = try? JSONDecoder().decode(TokenAntwort.self, from: daten)
-        else {
-            let kuerzel = (try? JSONDecoder().decode([String: String].self, from: daten))?["error"]
-            throw Anmeldefehler.tokenTausch(kuerzel ?? "http_\(http.statusCode)")
+        else { throw Anmeldefehler.nichtErreichbar("netz") }
+
+        if http.statusCode == 200 {
+            guard let gelesen = try? JSONDecoder().decode(TokenAntwort.self, from: daten) else {
+                throw Anmeldefehler.nichtErreichbar("antwort_unlesbar")
+            }
+            return Tokensatz(
+                zugangstoken: gelesen.access_token,
+                erneuerungstoken: gelesen.refresh_token,
+                idToken: gelesen.id_token,
+                laeuftAbAm: Date().addingTimeInterval(gelesen.expires_in ?? 3600)
+            )
         }
-        return Tokensatz(
-            zugangstoken: gelesen.access_token,
-            erneuerungstoken: gelesen.refresh_token,
-            idToken: gelesen.id_token,
-            laeuftAbAm: Date().addingTimeInterval(gelesen.expires_in ?? 3600)
-        )
+
+        // Eine Entscheidung ist nur, was auch wie eine aussieht: 4xx **mit**
+        // dem Kürzel, das RFC 6749 dafür vorschreibt. Ein 5xx, ein 429 oder
+        // eine Antwort ohne Kürzel ist der Zustand des Servers, nicht sein
+        // Urteil über diese Sitzung — und darf sie deshalb nicht beenden.
+        let kuerzel = (try? JSONDecoder().decode(TokenFehlerAntwort.self, from: daten))?.error
+        if (400 ..< 500).contains(http.statusCode), let kuerzel, !kuerzel.isEmpty {
+            throw Anmeldefehler.abgewiesen(kuerzel)
+        }
+        throw Anmeldefehler.nichtErreichbar(kuerzel ?? "http_\(http.statusCode)")
     }
 
     // MARK: PKCE

--- a/ios/Dorf/Anmeldung/Schluesselbund.swift
+++ b/ios/Dorf/Anmeldung/Schluesselbund.swift
@@ -65,3 +65,21 @@ enum Schluesselbund {
         SecItemDelete(suche as CFDictionary)
     }
 }
+
+/// Wo der Tokensatz zwischen zwei Starts liegt.
+///
+/// A small bundle of closures instead of a protocol: `Anmeldung` needs
+/// exactly three calls, and a test hands in its own three — otherwise every
+/// run would write into the real keychain of the machine it runs on.
+struct Tokenablage {
+    var lesen: () -> Tokensatz?
+    var sichern: (Tokensatz) -> Void
+    var loeschen: () -> Void
+
+    /// Der echte Schlüsselbund — die Vorbelegung der App.
+    static let schluesselbund = Tokenablage(
+        lesen: { Schluesselbund.lesen() },
+        sichern: { Schluesselbund.sichern($0) },
+        loeschen: { Schluesselbund.loeschen() }
+    )
+}

--- a/ios/Dorf/Anmeldung/Schluesselbund.swift
+++ b/ios/Dorf/Anmeldung/Schluesselbund.swift
@@ -27,18 +27,33 @@ enum Schluesselbund {
     private static let dienst = "de.roessing.app.anmeldung"
     private static let konto = "tokensatz"
 
-    static func sichern(_ satz: Tokensatz) {
-        guard let daten = try? JSONEncoder().encode(satz) else { return }
+    /// Schreibt den Satz — ohne den alten vorher wegzuwerfen.
+    ///
+    /// Vorher stand hier `SecItemDelete` und danach `SecItemAdd`. Zwischen
+    /// beiden Zeilen gibt es einen Augenblick ohne Eintrag, und scheitert das
+    /// Hinzufügen (das Gerät ist noch nie entsperrt worden, der Schlüsselbund
+    /// ist gerade nicht ansprechbar), bleibt es dabei: Die laufende Sitzung
+    /// merkt nichts, aber der nächste Start findet nichts mehr vor und steht
+    /// vor dem Anmeldeknopf. Ein Schreibfehler darf keine gültige Anmeldung
+    /// kosten — deshalb erst aktualisieren und nur anlegen, wenn wirklich
+    /// nichts da ist.
+    @discardableResult
+    static func sichern(_ satz: Tokensatz) -> Bool {
+        guard let daten = try? JSONEncoder().encode(satz) else { return false }
         let suche: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: dienst,
             kSecAttrAccount as String: konto,
         ]
-        SecItemDelete(suche as CFDictionary)
+        let stand = SecItemUpdate(suche as CFDictionary,
+                                  [kSecValueData as String: daten] as CFDictionary)
+        if stand == errSecSuccess { return true }
+        guard stand == errSecItemNotFound else { return false }
+
         var eintrag = suche
         eintrag[kSecValueData as String] = daten
         eintrag[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-        SecItemAdd(eintrag as CFDictionary, nil)
+        return SecItemAdd(eintrag as CFDictionary, nil) == errSecSuccess
     }
 
     static func lesen() -> Tokensatz? {
@@ -79,7 +94,7 @@ struct Tokenablage {
     /// Der echte Schlüsselbund — die Vorbelegung der App.
     static let schluesselbund = Tokenablage(
         lesen: { Schluesselbund.lesen() },
-        sichern: { Schluesselbund.sichern($0) },
+        sichern: { _ = Schluesselbund.sichern($0) },
         loeschen: { Schluesselbund.loeschen() }
     )
 }

--- a/ios/Dorf/Bereiche/Ideen/IdeenView.swift
+++ b/ios/Dorf/Bereiche/Ideen/IdeenView.swift
@@ -166,7 +166,7 @@ struct IdeenView: View {
     .environmentObject(
         AppUmgebung(
             anmeldung: Anmeldung(),
-            api: DorfApi(tokenGeber: { nil }),
+            api: DorfApi(tokenGeber: { .abgemeldet }),
             ich: Ich(sub: "1", name: "Anna Beispiel", email: "anna@example.org")
         )
     )

--- a/ios/Dorf/Bereiche/Profil/DorfbewohnerView.swift
+++ b/ios/Dorf/Bereiche/Profil/DorfbewohnerView.swift
@@ -235,7 +235,7 @@ private struct NurVerwaltungsmarke: View {
     }
     .environmentObject(AppUmgebung(
         anmeldung: Anmeldung(),
-        api: DorfApi(tokenGeber: { nil }),
+        api: DorfApi(tokenGeber: { .abgemeldet }),
         ich: Ich(sub: "abc", name: "Anna Beispiel")
     ))
 }

--- a/ios/Dorf/Bereiche/Profil/ProfilView.swift
+++ b/ios/Dorf/Bereiche/Profil/ProfilView.swift
@@ -281,7 +281,7 @@ private struct Profilfeld: View {
     }
     .environmentObject(AppUmgebung(
         anmeldung: Anmeldung(),
-        api: DorfApi(tokenGeber: { nil }),
+        api: DorfApi(tokenGeber: { .abgemeldet }),
         ich: Ich(sub: "abc", name: "Anna Beispiel", email: "anna@example.org")
     ))
 }

--- a/ios/Dorf/Daten/DorfApi.swift
+++ b/ios/Dorf/Daten/DorfApi.swift
@@ -52,11 +52,11 @@ nonisolated enum DorfFehler: Error, Sendable {
 nonisolated final class DorfApi: Sendable {
     private let basis: URL
     private let sitzung: URLSession
-    private let tokenGeber: @Sendable () async -> String?
+    private let tokenGeber: @Sendable () async -> Tokenlage
 
     init(basis: URL = Konfiguration.apiBasis,
          sitzung: URLSession = .dorfSitzung,
-         tokenGeber: @escaping @Sendable () async -> String?) {
+         tokenGeber: @escaping @Sendable () async -> Tokenlage) {
         self.basis = basis
         self.sitzung = sitzung
         self.tokenGeber = tokenGeber
@@ -150,8 +150,20 @@ nonisolated final class DorfApi: Sendable {
             versand.setValue("application/json", forHTTPHeaderField: "Content-Type")
             versand.httpBody = try JSONEncoder().encode(rumpf)
         }
-        if let token = await tokenGeber() {
+        switch await tokenGeber() {
+        case .token(let token):
             versand.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        case .abgemeldet:
+            // Ohne Anmeldung geht die Anfrage ohne Kopfzeile hinaus — ein paar
+            // Endpunkte (Ideen) nehmen sie auch so an.
+            break
+        case .nichtErreichbar:
+            // Die Anmeldung besteht, sie ließ sich nur gerade nicht erneuern.
+            // Ohne Kopfzeile käme ein 401 zurück, und die App behauptete
+            // „Die Anmeldung ist abgelaufen. Bitte neu anmelden." — falsch,
+            // und der Satz kostet die Person eine Anmeldung, die noch gilt.
+            // Es ist ein Netzproblem, und so heißt es hier auch.
+            throw DorfFehler.netz("Die Anmeldung ließ sich gerade nicht erneuern.")
         }
         return versand
     }

--- a/ios/Dorf/Konfiguration.swift
+++ b/ios/Dorf/Konfiguration.swift
@@ -33,11 +33,6 @@ nonisolated enum Konfiguration {
         #endif
     }
 
-    /// Das Schema, unter dem der Browser zurück in die App springt
-    /// (`de.roessing.app` aus `de.roessing.app:/oauth2redirect`).
-    static var ruecksprungSchema: String {
-        String(oidcRuecksprung.prefix(while: { $0 != ":" }))
-    }
 
     private static func text(_ schluessel: String, vorgabe: String) -> String {
         guard let roh = Bundle.main.object(forInfoDictionaryKey: schluessel) as? String,

--- a/ios/Dorf/Navigation/StartView.swift
+++ b/ios/Dorf/Navigation/StartView.swift
@@ -21,6 +21,24 @@ struct StartView: View {
                     .accessibilityIdentifier("start-gruss")
                 }
 
+                // Wenn gerade nichts geht, steht hier warum. Ohne das sähe
+                // die Seite aus wie eine, in der nichts los ist — und wer
+                // eben noch angemeldet war, sucht den Fehler bei sich.
+                if let stoerung = umgebung.stoerungshinweis {
+                    Section {
+                        Label(stoerung, systemImage: "wifi.slash")
+                            .font(.subheadline)
+                            .accessibilityIdentifier("start-stoerungshinweis")
+                        Button("Erneut versuchen") {
+                            Task { await umgebung.erneutVersuchen() }
+                        }
+                        .accessibilityIdentifier("start-erneut")
+                    } footer: {
+                        Text("Du bleibst angemeldet — sobald die Verbindung wieder steht, "
+                            + "geht es weiter, wo du warst.")
+                    }
+                }
+
                 if let hitze = Startseitentexte.hitzehinweis(giessfaktor: umgebung.orte.giessfaktor) {
                     Section {
                         Label(hitze, systemImage: "thermometer.sun.fill")

--- a/ios/Dorf/Umgebung.swift
+++ b/ios/Dorf/Umgebung.swift
@@ -86,6 +86,20 @@ final class AppUmgebung: ObservableObject {
         }
     }
 
+    /// Was die Startseite meldet, wenn gerade nichts geht.
+    ///
+    /// Eine App, die stumm nichts lädt, ist so schlecht wie eine, die
+    /// abmeldet: In beiden Fällen weiß niemand, woran es liegt. Der Satz
+    /// kommt aus `DorfFehler` und redet deshalb von der Verbindung — nicht
+    /// von der Anmeldung, denn die gilt weiter.
+    var stoerungshinweis: String? { ichFehler ?? orte.hinweis }
+
+    /// Noch einmal versuchen — was der Hinweis auf der Startseite anbietet.
+    func erneutVersuchen() async {
+        await ichLaden()
+        await orte.laden()
+    }
+
     func profilUebernehmen(_ profil: Profil) {
         guard var stand = ich else { return }
         stand.profile = profil

--- a/ios/DorfTests/AnmeldungTests.swift
+++ b/ios/DorfTests/AnmeldungTests.swift
@@ -229,6 +229,29 @@ struct AnmeldungTests {
         #expect(anfrage.value(forHTTPHeaderField: "Authorization") == "Bearer abc")
     }
 
+    @Test func ohneVerbindungSagtDieStartseiteWoranEsLiegt() async {
+        let (anmeldung, _) = Self.aufbau(Self.abgelaufen(), [.netzausfall])
+        let api = DorfApi(basis: URL(string: "http://127.0.0.1:8099")!,
+                          tokenGeber: { await anmeldung.frischesToken() })
+        let orte = OrteModell(quelle: OrteQuelle(
+            orte: { throw DorfFehler.netz("nicht erreichbar") },
+            erledigungen: { _ in [] },
+            melden: { _, _, _ in throw DorfFehler.netz("nicht erreichbar") },
+            zuruecknehmen: { _ in }
+        ))
+        let umgebung = AppUmgebung(anmeldung: anmeldung, api: api, ich: nil, orte: orte)
+
+        #expect(umgebung.stoerungshinweis == nil, "Vor dem ersten Abruf steht da nichts")
+        await orte.laden()
+
+        // Es steht da, dass die Verbindung fehlt — und ausdrücklich nicht,
+        // dass man sich neu anmelden soll.
+        #expect(umgebung.stoerungshinweis == DorfFehler.netz("").klartext)
+        #expect(umgebung.stoerungshinweis != DorfFehler.nichtAngemeldet.klartext)
+        // Und die Anmeldung steht noch.
+        #expect(anmeldung.sitzung == .angemeldet(entwicklerModus: false))
+    }
+
     @Test func ohneAnmeldungGehtDieAnfrageOhneKopfzeileHinaus() async throws {
         // Die Ideen nimmt das Backend auch ohne Anmeldung an.
         let api = DorfApi(basis: URL(string: "http://127.0.0.1:8099")!,

--- a/ios/DorfTests/AnmeldungTests.swift
+++ b/ios/DorfTests/AnmeldungTests.swift
@@ -1,0 +1,329 @@
+import Foundation
+import Testing
+
+@testable import Dorf
+
+/// Dass eine einmal erteilte Anmeldung hält.
+///
+/// Der Kern dieser Datei ist ein einziger Unterschied: **„Der Server sagt
+/// nein" ist etwas anderes als „ich konnte den Server nicht fragen."** Das
+/// Erste ist eine Entscheidung der Rössing-ID — widerrufenes Token,
+/// gesperrtes Konto, geändertes Passwort —, das Zweite ein Funkloch. Solange
+/// beides zum selben Ergebnis führte, kostete jeder schlechte Augenblick im
+/// Mobilfunknetz die Anmeldung, und die Person stand ohne Grund wieder vor
+/// dem Anmeldeknopf.
+///
+/// Der zweite Kern ist der Kaltstart: Beim Start fragen mehrere Abrufe im
+/// selben Augenblick nach einem Token (Profil, Orte, Gerätekennung). Zitadel
+/// gibt bei jeder Erneuerung ein **neues** Erneuerungstoken aus und weist das
+/// alte danach ab — wer parallel erneuert, gewinnt einmal und verliert
+/// sonst. Genau das war nach einer Aktualisierung zu sehen.
+///
+/// **Kein Test geht ins Netz.** Die Rössing-ID ist eine Attrappe
+/// ([RoessingId]), abgefangen über `protocolClasses`; der Schlüsselbund des
+/// Rechners wird nicht angefasst, die Ablage ist ein Feld im Speicher. Und
+/// kein Test wartet: Es wird nirgends geschlafen.
+@Suite(.serialized)
+@MainActor
+struct AnmeldungTests {
+    // MARK: Werkzeug
+
+    /// Eine Ablage im Speicher — statt des echten Schlüsselbunds.
+    private final class Ablagefach {
+        var satz: Tokensatz?
+        var geloescht = false
+
+        init(_ satz: Tokensatz?) { self.satz = satz }
+
+        var ablage: Tokenablage {
+            Tokenablage(
+                lesen: { self.satz },
+                sichern: { self.satz = $0 },
+                loeschen: {
+                    self.satz = nil
+                    self.geloescht = true
+                }
+            )
+        }
+    }
+
+    private static let aussteller = URL(string: "http://127.0.0.1:8123")!
+
+    /// Ein abgelaufenes Zugangstoken mit Erneuerungstoken — die Lage nach
+    /// jedem Kaltstart am nächsten Morgen.
+    private static func abgelaufen(erneuerung: String? = "r1") -> Tokensatz {
+        Tokensatz(
+            zugangstoken: "alt",
+            erneuerungstoken: erneuerung,
+            idToken: nil,
+            laeuftAbAm: Date().addingTimeInterval(-60)
+        )
+    }
+
+    private static func aufbau(_ satz: Tokensatz?,
+                               _ antworten: [RoessingId.Antwort]) -> (Anmeldung, Ablagefach) {
+        RoessingId.aufsetzen(antworten)
+        let fach = Ablagefach(satz)
+        let k = URLSessionConfiguration.ephemeral
+        k.protocolClasses = [RoessingId.self]
+        let anmeldung = Anmeldung(
+            sitzung: URLSession(configuration: k),
+            aussteller: Self.aussteller,
+            clientId: "test-client",
+            ruecksprung: "de.roessing.app:/oauth2redirect",
+            ablage: fach.ablage
+        )
+        return (anmeldung, fach)
+    }
+
+    private static let erfolg = RoessingId.Antwort.erfolg(zugang: "neu", erneuerung: "r2")
+
+    // MARK: Was die Rössing-ID wirklich entschieden hat
+
+    @Test func einWiderrufenesErneuerungstokenMeldetAb() async {
+        let (anmeldung, fach) = Self.aufbau(Self.abgelaufen(),
+                                            [.abgewiesen(status: 400, kuerzel: "invalid_grant")])
+
+        #expect(await anmeldung.frischesToken() == .abgemeldet)
+        #expect(anmeldung.sitzung == .abgemeldet)
+        // Und der Satz ist weg: Ein widerrufenes Token wieder und wieder zu
+        // versuchen, hilft niemandem.
+        #expect(fach.satz == nil)
+        #expect(fach.geloescht)
+    }
+
+    @Test func ohneErneuerungstokenIstDieSitzungWirklichZuEnde() async {
+        // Nichts mehr da, womit sich erneuern ließe — das ist kein Umstand.
+        let (anmeldung, fach) = Self.aufbau(Self.abgelaufen(erneuerung: nil), [Self.erfolg])
+
+        #expect(await anmeldung.frischesToken() == .abgemeldet)
+        #expect(anmeldung.sitzung == .abgemeldet)
+        #expect(fach.satz == nil)
+        #expect(RoessingId.tokenanfragen == 0, "Ohne Erneuerungstoken gibt es nichts zu fragen")
+    }
+
+    // MARK: Was bloß ein Umstand war
+
+    @Test func einFunklochKostetDieAnmeldungNicht() async {
+        let (anmeldung, fach) = Self.aufbau(Self.abgelaufen(), [.netzausfall])
+
+        #expect(await anmeldung.frischesToken() == .nichtErreichbar)
+        #expect(anmeldung.sitzung == .angemeldet(entwicklerModus: false))
+        // Der Satz bleibt unangetastet — samt Erneuerungstoken.
+        #expect(fach.satz?.erneuerungstoken == "r1")
+        #expect(!fach.geloescht)
+    }
+
+    @Test func einServerfehlerKostetDieAnmeldungNicht() async {
+        // 5xx ist der Zustand des Servers, nicht sein Urteil über die Sitzung.
+        let (anmeldung, fach) = Self.aufbau(Self.abgelaufen(), [.serverfehler(status: 503)])
+
+        #expect(await anmeldung.frischesToken() == .nichtErreichbar)
+        #expect(anmeldung.sitzung == .angemeldet(entwicklerModus: false))
+        #expect(fach.satz?.erneuerungstoken == "r1")
+    }
+
+    @Test func eineAntwortOhneKuerzelKostetDieAnmeldungNicht() async {
+        // 400, aber ohne das Kürzel, das RFC 6749 verlangt: Wir wissen nicht,
+        // was der Server sagen wollte — dann wird nicht abgemeldet.
+        let (anmeldung, fach) = Self.aufbau(Self.abgelaufen(), [.roh(status: 400, rumpf: Data())])
+
+        #expect(await anmeldung.frischesToken() == .nichtErreichbar)
+        #expect(anmeldung.sitzung == .angemeldet(entwicklerModus: false))
+        #expect(fach.satz?.erneuerungstoken == "r1")
+    }
+
+    @Test func einFehlerInUnsererEinrichtungKostetDieAnmeldungNicht() async {
+        // `invalid_client` heißt: An unserer Anmeldung ist etwas falsch. Wer
+        // deswegen abmeldet, wirft eine gültige Sitzung weg — und die neue
+        // Anmeldung scheiterte an derselben Stelle wieder.
+        let (anmeldung, _) = Self.aufbau(Self.abgelaufen(),
+                                         [.abgewiesen(status: 400, kuerzel: "invalid_client")])
+
+        #expect(await anmeldung.frischesToken() == .nichtErreichbar)
+        #expect(anmeldung.sitzung == .angemeldet(entwicklerModus: false))
+    }
+
+    @Test func nachDemFunklochGehtEsWeiterOhneNeuanmeldung() async {
+        let (anmeldung, fach) = Self.aufbau(Self.abgelaufen(), [.netzausfall, Self.erfolg])
+
+        #expect(await anmeldung.frischesToken() == .nichtErreichbar)
+        // Wieder Empfang: derselbe Aufruf, kein Browser, kein Passwort.
+        #expect(await anmeldung.frischesToken() == .token("neu"))
+        #expect(anmeldung.sitzung == .angemeldet(entwicklerModus: false))
+        #expect(fach.satz?.zugangstoken == "neu")
+        #expect(fach.satz?.erneuerungstoken == "r2")
+    }
+
+    // MARK: Der Kaltstart — mehrere Abrufe, eine Erneuerung
+
+    @Test func gleichzeitigeAbrufeErneuernNurEinMal() async {
+        // Die zweite Antwort wäre ein anderes Token; sie darf nie gebraucht
+        // werden. Bei Zitadel wäre sie in Wahrheit ein „invalid_grant", weil
+        // das Erneuerungstoken mit dem ersten Gebrauch verfällt.
+        let (anmeldung, fach) = Self.aufbau(Self.abgelaufen(), [
+            Self.erfolg,
+            .abgewiesen(status: 400, kuerzel: "invalid_grant"),
+        ])
+
+        async let erster = anmeldung.frischesToken()
+        async let zweiter = anmeldung.frischesToken()
+        let (a, b) = await (erster, zweiter)
+
+        #expect(RoessingId.tokenanfragen == 1, "Zwei Abrufe dürfen nur einmal erneuern")
+        #expect(a == .token("neu"))
+        #expect(b == .token("neu"))
+        #expect(anmeldung.sitzung == .angemeldet(entwicklerModus: false))
+        #expect(fach.satz?.erneuerungstoken == "r2")
+    }
+
+    @Test func nachDerErneuerungWirdNichtWiederGefragt() async {
+        let (anmeldung, _) = Self.aufbau(Self.abgelaufen(), [Self.erfolg])
+
+        #expect(await anmeldung.frischesToken() == .token("neu"))
+        #expect(await anmeldung.frischesToken() == .token("neu"))
+        #expect(RoessingId.tokenanfragen == 1, "Das frische Token gilt weiter")
+    }
+
+    @Test func einGueltigesTokenFragtGarNichtNach() async {
+        let gueltig = Tokensatz(zugangstoken: "gilt", erneuerungstoken: "r1", idToken: nil,
+                                laeuftAbAm: Date().addingTimeInterval(3600))
+        let (anmeldung, _) = Self.aufbau(gueltig, [Self.erfolg])
+
+        #expect(await anmeldung.frischesToken() == .token("gilt"))
+        #expect(RoessingId.tokenanfragen == 0)
+    }
+
+    // MARK: Die Regel für sich
+
+    @Test func nurEinWiderrufBeendetEineSitzung() {
+        #expect(Anmeldung.istSitzungsende("invalid_grant"))
+        // Alles andere ist entweder unser Fehler oder der Zustand des Servers.
+        #expect(!Anmeldung.istSitzungsende("invalid_client"))
+        #expect(!Anmeldung.istSitzungsende("invalid_request"))
+        #expect(!Anmeldung.istSitzungsende("server_error"))
+        #expect(!Anmeldung.istSitzungsende("temporarily_unavailable"))
+        #expect(!Anmeldung.istSitzungsende(""))
+    }
+
+    // MARK: Was die Person davon sieht
+
+    @Test func eineNichtErneuerbareAnmeldungMeldetEinNetzproblem() async throws {
+        let api = DorfApi(basis: URL(string: "http://127.0.0.1:8099")!,
+                          tokenGeber: { .nichtErreichbar })
+        do {
+            _ = try await api.anfrage("GET", "api/v1/me")
+            Issue.record("Ohne Token darf keine Anfrage gebaut werden")
+        } catch let fehler as DorfFehler {
+            #expect(fehler.klartext == DorfFehler.netz("").klartext)
+            // Und ausdrücklich nicht der Satz, der zur Neuanmeldung auffordert:
+            // Die Anmeldung gilt ja noch, es fehlt bloß die Verbindung.
+            #expect(fehler.klartext != DorfFehler.nichtAngemeldet.klartext)
+        }
+    }
+
+    @Test func mitTokenGehtDieKopfzeileMit() async throws {
+        let api = DorfApi(basis: URL(string: "http://127.0.0.1:8099")!,
+                          tokenGeber: { .token("abc") })
+        let anfrage = try await api.anfrage("GET", "api/v1/me")
+        #expect(anfrage.value(forHTTPHeaderField: "Authorization") == "Bearer abc")
+    }
+
+    @Test func ohneAnmeldungGehtDieAnfrageOhneKopfzeileHinaus() async throws {
+        // Die Ideen nimmt das Backend auch ohne Anmeldung an.
+        let api = DorfApi(basis: URL(string: "http://127.0.0.1:8099")!,
+                          tokenGeber: { .abgemeldet })
+        let anfrage = try await api.anfrage("GET", "api/v1/ideen")
+        #expect(anfrage.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+}
+
+/// Die Rössing-ID als Attrappe: Discovery und Token-Endpunkt, örtlich
+/// abgefangen. Es geht nichts hinaus, und es wird nirgends gewartet.
+private nonisolated final class RoessingId: URLProtocol {
+    enum Antwort {
+        case erfolg(zugang: String, erneuerung: String?)
+        /// Der Server hat geantwortet und abgelehnt — mit Kürzel nach RFC 6749.
+        case abgewiesen(status: Int, kuerzel: String)
+        case serverfehler(status: Int)
+        /// Beliebige Antwort, um auch das Unfertige zu prüfen.
+        case roh(status: Int, rumpf: Data)
+        /// Gar keine Antwort: kein Netz.
+        case netzausfall
+    }
+
+    private static let schloss = NSLock()
+    nonisolated(unsafe) private static var folge: [Antwort] = []
+    nonisolated(unsafe) private static var gezaehlt = 0
+
+    /// Legt fest, was der Token-Endpunkt der Reihe nach antwortet. Die letzte
+    /// Antwort gilt weiter, wenn öfter gefragt wird.
+    static func aufsetzen(_ antworten: [Antwort]) {
+        schloss.lock()
+        defer { schloss.unlock() }
+        folge = antworten
+        gezaehlt = 0
+    }
+
+    /// Wie oft der **Token**-Endpunkt gefragt wurde (Discovery zählt nicht).
+    static var tokenanfragen: Int {
+        schloss.lock()
+        defer { schloss.unlock() }
+        return gezaehlt
+    }
+
+    private static func naechste() -> Antwort {
+        schloss.lock()
+        defer { schloss.unlock() }
+        guard !folge.isEmpty else { return .netzausfall }
+        let antwort = folge[min(gezaehlt, folge.count - 1)]
+        gezaehlt += 1
+        return antwort
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let pfad = request.url?.path ?? ""
+        if pfad.hasSuffix("openid-configuration") {
+            antworte(200, Data(Self.entdeckung.utf8))
+            return
+        }
+        switch Self.naechste() {
+        case .erfolg(let zugang, let erneuerung):
+            let erneuerungsfeld = erneuerung.map { ",\"refresh_token\":\"\($0)\"" } ?? ""
+            antworte(200, Data("""
+            {"access_token":"\(zugang)","expires_in":43200\(erneuerungsfeld)}
+            """.utf8))
+        case .abgewiesen(let status, let kuerzel):
+            antworte(status, Data("{\"error\":\"\(kuerzel)\"}".utf8))
+        case .serverfehler(let status):
+            antworte(status, Data("{\"error\":\"server_error\"}".utf8))
+        case .roh(let status, let rumpf):
+            antworte(status, rumpf)
+        case .netzausfall:
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+        }
+    }
+
+    override func stopLoading() {}
+
+    private func antworte(_ status: Int, _ rumpf: Data) {
+        let kopf = HTTPURLResponse(
+            url: request.url ?? URL(string: "http://127.0.0.1:8123")!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json; charset=utf-8"]
+        )!
+        client?.urlProtocol(self, didReceive: kopf, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: rumpf)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    private static let entdeckung = """
+    {"authorization_endpoint":"http://127.0.0.1:8123/oauth/v2/authorize",
+     "token_endpoint":"http://127.0.0.1:8123/oauth/v2/token",
+     "end_session_endpoint":"http://127.0.0.1:8123/oidc/v1/end_session"}
+    """
+}

--- a/ios/DorfTests/PushTests.swift
+++ b/ios/DorfTests/PushTests.swift
@@ -70,7 +70,7 @@ struct PushTests {
     /// Anfrage vom **gemeinsamen** Transport (`DorfApi.anfrage`), damit hier
     /// geprüft wird, was tatsächlich hinausginge. Geschickt wird nichts.
     private static func zugang(token: String?) -> DorfApi {
-        DorfApi(basis: testBasis, tokenGeber: { token })
+        DorfApi(basis: testBasis, tokenGeber: { token.map { .token($0) } ?? .abgemeldet })
     }
 
     private static func geraeteanfrage(_ methode: String, token: String?) async throws -> URLRequest {


### PR DESCRIPTION
Der Betreiber musste sich nach einer TestFlight-Aktualisierung erneut mit der
Rössing-ID anmelden. Das lag **nicht** an einer abgelaufenen Sitzung — sein
Erneuerungstoken war noch tagelang gültig.

## Die Ursache: gleichzeitige Erneuerungen

Beim Kaltstart fragen mehrere Stellen im selben Augenblick nach einem Token —
die Startseite lädt „wer bin ich", die Ortsliste lädt die Orte, der Push-
Abgleich meldet die Gerätekennung. `frischesToken()` kannte keine Bündelung,
also schickte **jeder** seine eigene Erneuerung los, alle mit demselben
Erneuerungstoken.

Zitadel rotiert Erneuerungstoken: Der erste Aufruf gewinnt, das alte Token ist
ab da ungültig, alle übrigen bekommen `invalid_grant`. Und das hat abgemeldet.

Genau diese Lage entsteht **nach einer Aktualisierung**: kalter Start, und das
Zugangstoken ist über Nacht abgelaufen.

## Die zweite Ursache: jeder Fehler galt als Nein

Der Kommentar behauptete „Erneuerung endgültig gescheitert (z.B. Token
widerrufen)". Der Code darunter fing **jeden** Fehler und meldete ab — Funkloch,
Serverfehler, gescheiterte Discovery. Für sich genommen hätte das vielleicht
niemanden getroffen; es hat die erste Ursache erst tödlich gemacht.

Jetzt gilt: Abgemeldet wird nur bei `invalid_grant` oder wenn gar kein
Erneuerungstoken mehr da ist. Alles andere lässt die Anmeldung stehen.

## Die dritte, nebenbei gefunden

`Schluesselbund.sichern` löschte den Eintrag und legte ihn neu an. Scheitert
das Anlegen, bleibt **gar nichts** stehen — die laufende Sitzung merkt nichts,
der nächste Start steht vor dem Anmeldeknopf.

## Was die Person jetzt sieht

`ichFehler` stand im Modell, wurde aber **nirgends angezeigt**. Jetzt zeigt die
Startseite den Grund, einen Knopf „Erneut versuchen" und den Satz „Du bleibst
angemeldet". Eine App, die stumm nichts lädt, ist so schlecht wie eine, die
abmeldet.

## Android

Die gleichzeitigen Erneuerungen hatte Android nie — AppAuth bündelt sie selbst;
das steht jetzt als Kommentar dabei, damit es niemand wegbaut. Die
Fehlerklassifikation war dort **genauso falsch** und ist mitgezogen.

## Gegenprobe

Die Korrektur wurde testweise zurückgedreht: Dann meldet
`gleichzeitigeAbrufeErneuernNurEinMal` zwei Erneuerungen, und der zweite
Aufrufer landet auf `.abgemeldet` — der Fehler des Betreibers, reproduziert
ohne Server. Insgesamt 21 Beanstandungen beim Rückdrehen. Die Tests sind also
keine Placebos.

## Geprüft

iOS **176 Tests grün** (15 neue), Android-Unit-Tests grün (9 neue), Wache grün.
Kein Test geht ins Netz, keiner schläft.

**Nicht ausgeführt:** Android-Instrumentierungstests (kein Emulator), kein Lauf
gegen die echte Rössing-ID, kein echtes Gerät. Dass Zitadel bei paralleler
Nutzung `invalid_grant` schickt, ist begründet, nicht gemessen — die Korrektur
trägt aber auch dann, wenn es anders wäre: Sie schickt die zweite Anfrage gar
nicht erst los.

🤖 Generated with [Claude Code](https://claude.com/claude-code)