### PR TITLE
iOS: Die Terminliste fällt nicht mehr auseinander

### DIFF
--- a/ios/Dorf/Bereiche/Veranstaltungen/TerminDetailView.swift
+++ b/ios/Dorf/Bereiche/Veranstaltungen/TerminDetailView.swift
@@ -85,7 +85,9 @@ private struct Beschriftet: View {
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 12) {
             Group {
-                if let symbol { Image(systemName: symbol) } else { Color.clear }
+                // Verstecktes Symbol statt Farbfläche: `Color.clear` hat keine
+                // eigene Größe und dehnt die Zeile in die Höhe.
+                if let symbol { Image(systemName: symbol) } else { Image(systemName: "circle").hidden() }
             }
             .font(.footnote)
             .frame(width: 18)

--- a/ios/Dorf/Bereiche/Veranstaltungen/VeranstaltungenView.swift
+++ b/ios/Dorf/Bereiche/Veranstaltungen/VeranstaltungenView.swift
@@ -20,37 +20,34 @@ struct VeranstaltungenView: View {
                 }
             }
 
+            // Liste, Warten und Leere gehören in *einen* Abschnitt: Drei
+            // eigene Abschnitte lassen dort, wo gerade keiner von ihnen etwas
+            // zu sagen hat, nur eine Lücke stehen.
             Section {
-                Text("Die Termine kommen von rössing.de — gepflegt werden sie dort, "
-                    + "damit sie nur an einer Stelle stehen.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .listRowBackground(Color.clear)
-            }
-
-            if modell.laedt && modell.termine.isEmpty {
-                Section {
+                if modell.laedt && modell.termine.isEmpty {
                     HStack(spacing: 10) {
                         ProgressView()
                         Text("Termine werden geholt …").foregroundStyle(.secondary)
                     }
                     .accessibilityIdentifier("veranstaltungen-laedt")
                 }
-            }
 
-            Section {
                 ForEach(modell.termine) { termin in
                     TerminZeile(termin: termin)
                 }
-            }
 
-            if modell.leer {
-                Section {
+                if modell.leer {
                     Text("Gerade steht kein Termin an. Sobald etwas eingetragen ist, "
                         + "steht es hier.")
                         .foregroundStyle(.secondary)
                         .accessibilityIdentifier("veranstaltungen-leer")
                 }
+            } footer: {
+                // Woher die Termine kommen, steht als Fußnote unter der Liste —
+                // dort, wo iOS Erklärungen erwartet. Als eigener Abschnitt
+                // darüber wäre es ein Kasten, der aussieht wie ein Termin.
+                Text("Die Termine kommen von rössing.de — gepflegt werden sie dort, "
+                    + "damit sie nur an einer Stelle stehen.")
             }
         }
         .accessibilityIdentifier("veranstaltungen")
@@ -128,10 +125,15 @@ private struct TerminZeile: View {
 
                 // Ein Termin, der nach draußen führt, sagt das mit dem Symbol,
                 // das iOS dafür benutzt — nicht mit einer anderen Textfarbe.
-                Image(systemName: termin.extern ? "arrow.up.forward.app" : "chevron.right")
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(.tertiary)
-                    .padding(.top, 3)
+                // Nach innen wird hier nichts gemalt: Den Pfeil setzt in einer
+                // Liste der NavigationLink selbst, und zwei Pfeile in einer
+                // Zeile sind einer zu viel.
+                if termin.extern {
+                    Image(systemName: "arrow.up.forward.app")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                        .padding(.top, 3)
+                }
             }
             .padding(.vertical, 4)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -224,7 +226,12 @@ private struct Angabe: View {
                 if let symbol {
                     Image(systemName: symbol)
                 } else {
-                    Color.clear
+                    // Die Spalte bleibt stehen, damit die Adresse unter dem
+                    // Ortsnamen bündig steht — aber als *verstecktes Symbol*,
+                    // nicht als Farbfläche. `Color.clear` hat keine eigene
+                    // Größe und dehnt sich in die Höhe, bis die Zeile
+                    // auseinanderfällt und in die nächste läuft.
+                    Image(systemName: "circle").hidden()
                 }
             }
             .font(.footnote)


### PR DESCRIPTION
Behebt #50.

## Was schief stand

Sobald ein Termin eine **Adresse** trug, zog sich seine Zeile über hunderte Punkte in die Höhe, und der Beschreibungstext schob sich unter die Überschrift des nächsten Termins.

Der Grund saß im Platzhalter der Symbolspalte: Die Adresszeile bekommt kein eigenes Symbol, dort stand `Color.clear`. Eine Farbfläche hat keine eigene Größe — sie nimmt, was sie kriegen kann, und dehnt die Zeile in die Höhe, bis nichts mehr passt. Ein **verstecktes** Symbol (`Image(systemName: "circle").hidden()`) hält die Spalte an ihrer Stelle, ohne Höhe zu fordern. Dieselbe Stelle gab es zweimal: in der Liste und in `TerminDetailView`.

## Zwei Dinge, die im selben Bild schief standen

- **Zwei Pfeile je Zeile.** In einer `List` setzt der `NavigationLink` seinen Pfeil selbst; der selbstgemalte kam obendrauf. Er bleibt jetzt den externen Terminen vorbehalten — dort sagt `arrow.up.forward.app` etwas aus, das sonst niemand sagt.
- **Der Einleitungstext** stand als eigener Abschnitt über der Liste und sah aus wie ein leerer Termin. Er steht jetzt als Fußnote unter der Liste, wo iOS Erklärungen erwartet — so hält es `TerminDetailView` bereits. Warten, Liste und Leere teilen sich einen Abschnitt, statt drei Kästen mit Lücken dazwischen aufzuspannen.

## Nachgesehen

Simulator iPhone 17 / iOS 26.5, gegen den echten Terminfeed von rössing.de.

Vorher: „Offenes Dorfarchiv" — Ortsname, dann ein leeres Feld von rund 180 Punkten, dann erst die Kirchstraße; „Das Dorfarchiv Rössing ist für alle Interessierten geöffnet." lag über der Überschrift „42. Rössinger Dorffest".

Nachher: Jede Zeile ist so hoch wie ihr Inhalt, die Adresse steht bündig unter dem Ortsnamen, ein Pfeil je Zeile, nichts überlappt. Die Detailansicht ebenso geprüft.

`xcodebuild test`: 176 Tests in 12 Suiten grün. `pruefe_lokale_tests.py`: 74 Dateien, kein Zugriff nach draußen.

## Android

Nicht betroffen — die Terminkarte dort hat keine leere Symbolspalte. Der andere Unterschied zwischen den Fassungen steht als #51 daneben und kommt in einem eigenen Zweig.