### PR TITLE
Android: Termine des Dorfes zeigen ihre Einzelheiten in der App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ backend/internal/admin/node_modules/
 # Python
 __pycache__/
 *.pyc
+
+# Arbeitsverzeichnisse paralleler Agenten — gehoeren niemandem sonst.
+.claude/

--- a/android/app/src/androidTest/java/de/roessing/app/VeranstaltungenUiTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/VeranstaltungenUiTest.kt
@@ -1,6 +1,9 @@
 package de.roessing.app
 
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -29,6 +32,7 @@ import de.roessing.app.ui.PlacesViewModel
 import de.roessing.app.ui.ProfileViewModel
 import de.roessing.app.ui.VeranstaltungenViewModel
 import de.roessing.app.ui.theme.DorfAppTheme
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -103,9 +107,23 @@ class VeranstaltungenUiTest {
         url = "https://xn--rssing-wxa.de/events/2026-08-20-grillen",
     )
 
+    /**
+     * Wohin die App hinausgeführt hat. Der echte UriHandler würde den Browser
+     * starten — die App wäre im Hintergrund und der Test fände seine Oberfläche
+     * nicht mehr wieder. Hier wird nur mitgeschrieben.
+     */
+    private val hinausgefuehrt = mutableListOf<String>()
+
+    private val notizbuch = object : UriHandler {
+        override fun openUri(uri: String) {
+            hinausgefuehrt += uri
+        }
+    }
+
     private fun zeigeApp(repo: VeranstaltungenRepository) {
         compose.setContent {
             DorfAppTheme {
+                CompositionLocalProvider(LocalUriHandler provides notizbuch) {
                 HomeScreen(
                     viewModel = PlacesViewModel(FakePlaces(), FakeVergabeRepo()),
                     leaderboardViewModel = LeaderboardViewModel(FakeStats()),
@@ -117,6 +135,7 @@ class VeranstaltungenUiTest {
                     ),
                     onLogout = {},
                 )
+                }
             }
         }
         compose.waitForIdle()
@@ -200,6 +219,7 @@ class VeranstaltungenUiTest {
         // Keine zweite Fassung in der App — der Tipp geht nach draußen.
         compose.onNodeWithTag("termin-detail").assertDoesNotExist()
         compose.onNodeWithTag("veranstaltungen").assertIsDisplayed()
+        assertEquals(listOf("https://nordstemmen.example/kreisfest"), hinausgefuehrt)
     }
 
     @Test

--- a/android/app/src/androidTest/java/de/roessing/app/VeranstaltungenUiTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/VeranstaltungenUiTest.kt
@@ -83,6 +83,18 @@ class VeranstaltungenUiTest {
         organizer = VeranstalterDto(name = "DRK Rössing"),
     )
 
+    /** Fremde Primärquelle: Der Tipp führt nach draußen, nicht in die App. */
+    private val kreisfest = VeranstaltungDto(
+        id = "2026-08-22-kreisfest",
+        name = "Kreisfest in Nordstemmen",
+        description = "Nicht unsere Veranstaltung.",
+        start = "2026-08-22",
+        allDay = true,
+        url = "https://nordstemmen.example/kreisfest",
+        external = true,
+        organizer = VeranstalterDto(name = "Gemeinde Nordstemmen"),
+    )
+
     private val grillen = VeranstaltungDto(
         id = "2026-08-20-grillen",
         name = "Grillen im Pfarrgarten",
@@ -142,6 +154,52 @@ class VeranstaltungenUiTest {
         zuDenTerminen()
 
         compose.onNodeWithText("18:00 Uhr").assertIsDisplayed()
+    }
+
+    @Test
+    fun einTerminDesDorfesZeigtSeineEinzelheitenInDerApp() {
+        zeigeApp(FakeTermine(listOf(blutspende)))
+        zuDenTerminen()
+
+        compose.onNodeWithTag("termin-2026-08-17-blutspende").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithTag("termin-detail").assertIsDisplayed()
+        compose.onNodeWithTag("termin-beschreibung").assertIsDisplayed()
+        compose.onNodeWithText("Dorfgemeinschaftshaus Rössing").assertIsDisplayed()
+        compose.onNodeWithText("DRK Rössing").assertIsDisplayed()
+        // Ganztägig heißt: keine erfundene Uhrzeit, auch hier nicht.
+        compose.onNodeWithText("Ganztägig").assertIsDisplayed()
+    }
+
+    @Test
+    fun ausDemTerminFuehrtZurueckInDieListe() {
+        zeigeApp(FakeTermine(listOf(blutspende, grillen)))
+        zuDenTerminen()
+
+        compose.onNodeWithTag("termin-2026-08-17-blutspende").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithTag("termin-detail").assertIsDisplayed()
+
+        compose.onNodeWithTag("zurueck").performClick()
+        compose.waitForIdle()
+
+        // Zurück in die Liste, nicht auf die Startseite: ein Schritt, nicht zwei.
+        compose.onNodeWithTag("veranstaltungen").assertIsDisplayed()
+        compose.onNodeWithTag("termin-2026-08-20-grillen").assertIsDisplayed()
+    }
+
+    @Test
+    fun einFremderTerminBleibtBeiSeinerQuelle() {
+        zeigeApp(FakeTermine(listOf(kreisfest)))
+        zuDenTerminen()
+
+        compose.onNodeWithTag("termin-2026-08-22-kreisfest").performClick()
+        compose.waitForIdle()
+
+        // Keine zweite Fassung in der App — der Tipp geht nach draußen.
+        compose.onNodeWithTag("termin-detail").assertDoesNotExist()
+        compose.onNodeWithTag("veranstaltungen").assertIsDisplayed()
     }
 
     @Test

--- a/android/app/src/main/java/de/roessing/app/ui/HomeScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/HomeScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -103,13 +104,33 @@ fun HomeScreen(
     var bereich by rememberSaveable { mutableStateOf(Bereich.START) }
     val snackbar = remember { SnackbarHostState() }
     val context = LocalContext.current
+    val browser = LocalUriHandler.current
     var tab by rememberSaveable { mutableStateOf(0) }
     var selectedPlaceId by rememberSaveable { mutableStateOf<Long?>(null) }
+    // Der aufgeschlagene Termin, als Kennung: Ein Termin selbst überlebt das
+    // Drehen des Geräts nicht, seine Kennung schon — und die Liste liegt
+    // ohnehin daneben.
+    var offenerTermin by rememberSaveable { mutableStateOf<String?>(null) }
     var menuOpen by remember { mutableStateOf(false) }
 
-    // System-Zurück führt aus dem Bereich auf die Startseite — und erst von
-    // dort aus der App heraus.
-    BackHandler(enabled = bereich != Bereich.START) { bereich = Bereich.START }
+    // Nur im eigenen Bereich: Wer die Termine verlässt und später
+    // zurückkommt, landet wieder in der Liste und nicht mitten in einem
+    // Termin von vorgestern.
+    val termin = veranstaltungen.termine
+        .find { it.id == offenerTermin }
+        ?.takeIf { bereich == Bereich.VERANSTALTUNGEN }
+
+    // System-Zurück führt aus dem aufgeschlagenen Termin zurück in die Liste,
+    // aus dem Bereich auf die Startseite — und erst von dort aus der App
+    // heraus. Jeder Schritt einzeln, keiner übersprungen.
+    BackHandler(enabled = bereich != Bereich.START || termin != null) {
+        if (termin != null) {
+            offenerTermin = null
+        } else {
+            offenerTermin = null
+            bereich = Bereich.START
+        }
+    }
 
     // Standort: nur im Vordergrund, nur auf Wunsch — und er bleibt auf dem
     // Gerät. Das Backend bekommt ihn nie zu sehen.
@@ -300,7 +321,11 @@ fun HomeScreen(
                             Bereich.PROFIL -> stringResource(R.string.profile_title)
                             Bereich.DORFBEWOHNER -> stringResource(R.string.members_title)
                             Bereich.MITHELFEN -> stringResource(R.string.area_care_title)
-                            Bereich.VERANSTALTUNGEN -> stringResource(R.string.events_title)
+                            Bereich.VERANSTALTUNGEN -> if (termin != null) {
+                                stringResource(R.string.events_detail_title)
+                            } else {
+                                stringResource(R.string.events_title)
+                            }
                             Bereich.IDEEN -> stringResource(R.string.ideas_title)
                             Bereich.START -> stringResource(R.string.home_title)
                         },
@@ -309,7 +334,10 @@ fun HomeScreen(
                 navigationIcon = {
                     if (bereich != Bereich.START) {
                         IconButton(
-                            onClick = { bereich = Bereich.START },
+                            onClick = {
+                                offenerTermin = null
+                                if (termin == null) bereich = Bereich.START
+                            },
                             modifier = Modifier.testTag("zurueck"),
                         ) {
                             Icon(
@@ -468,11 +496,20 @@ fun HomeScreen(
                     modifier = Modifier.padding(padding),
                 )
 
-                Bereich.VERANSTALTUNGEN -> VeranstaltungenScreen(
-                    state = veranstaltungen,
-                    modifier = Modifier.padding(padding),
-                    onAktualisieren = veranstaltungenViewModel::aktualisieren,
-                )
+                Bereich.VERANSTALTUNGEN -> if (termin != null) {
+                    TerminDetail(
+                        termin = termin,
+                        modifier = Modifier.padding(padding),
+                        onWebsite = { browser.openUri(termin.url) },
+                    )
+                } else {
+                    VeranstaltungenScreen(
+                        state = veranstaltungen,
+                        modifier = Modifier.padding(padding),
+                        onAktualisieren = veranstaltungenViewModel::aktualisieren,
+                        onTermin = { offenerTermin = it.id },
+                    )
+                }
 
                 Bereich.IDEEN -> IdeenScreen(
                     state = ideen,

--- a/android/app/src/main/java/de/roessing/app/ui/TerminDetail.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/TerminDetail.kt
@@ -1,0 +1,188 @@
+package de.roessing.app.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import de.roessing.app.R
+import de.roessing.app.data.Termin
+
+/**
+ * Ein Termin des Dorfes, ausführlich — ohne die App zu verlassen.
+ *
+ * Bewusst nur für **eigene** Termine: Verweist ein Eintrag auf eine fremde
+ * Primärquelle, führt der Tipp dorthin. Denselben Inhalt an zwei Stellen zu
+ * erzählen heißt, dass eine der beiden irgendwann falsch ist — dieselbe
+ * Regel, nach der die Termine überhaupt nur auf rössing.de gepflegt werden.
+ *
+ * Dieselbe Gliederung wie auf iOS (`TerminDetailView`): Wann, Wo und von wem,
+ * Worum es geht, zuletzt der Weg zur Quelle. Wer zwei Telefone nebeneinander
+ * hält, soll dasselbe sehen.
+ */
+@Composable
+fun TerminDetail(
+    termin: Termin,
+    modifier: Modifier = Modifier,
+    onWebsite: () -> Unit = {},
+) {
+    Column(
+        modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp, vertical = 12.dp)
+            .testTag("termin-detail"),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                termin.datumText,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Text(termin.name, style = MaterialTheme.typography.headlineSmall)
+        }
+
+        Abschnitt(stringResource(R.string.events_when)) {
+            Angabe(Icons.Filled.CalendarMonth, stringResource(R.string.events_day), termin.datumText)
+            HorizontalDivider()
+            // Ganztägig heißt: Es gibt keine Uhrzeit — und es wird auch keine
+            // erfunden.
+            Angabe(
+                Icons.Filled.Schedule,
+                stringResource(R.string.events_time),
+                termin.zeitText ?: stringResource(R.string.events_all_day),
+            )
+        }
+
+        if (termin.ortName != null || termin.veranstalter != null) {
+            Abschnitt(stringResource(R.string.events_where)) {
+                termin.ortName?.let {
+                    Angabe(Icons.Filled.Place, stringResource(R.string.events_place), it)
+                }
+                termin.ortAdresse?.let {
+                    HorizontalDivider()
+                    Angabe(null, stringResource(R.string.events_address), it)
+                }
+                termin.veranstalter?.let {
+                    if (termin.ortName != null) HorizontalDivider()
+                    Angabe(Icons.Filled.Group, stringResource(R.string.events_organizer), it)
+                }
+            }
+        }
+
+        if (termin.beschreibung.isNotBlank()) {
+            Abschnitt(stringResource(R.string.events_about)) {
+                Text(
+                    termin.beschreibung,
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .testTag("termin-beschreibung"),
+                )
+            }
+        }
+
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            TextButton(
+                onClick = onWebsite,
+                modifier = Modifier.testTag("termin-quelle"),
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Filled.OpenInNew,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.events_source_link))
+            }
+            Text(
+                stringResource(R.string.events_source_note),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/** Überschrift und Karte — dieselbe Gliederung für jeden Block. */
+@Composable
+private fun Abschnitt(titel: String, inhalt: @Composable () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            titel,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Card(
+            shape = MaterialTheme.shapes.large,
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        ) { inhalt() }
+    }
+}
+
+/**
+ * Eine Zeile „Titel — Wert" mit Symbol, damit Wann und Wo gleich aussehen.
+ * Ohne Symbol bleibt die Spalte trotzdem stehen: Die Adresse gehört unter den
+ * Ortsnamen, nicht an den linken Rand.
+ */
+@Composable
+private fun Angabe(symbol: ImageVector?, titel: String, wert: String) {
+    Row(
+        Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        if (symbol != null) {
+            Icon(
+                symbol,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            Spacer(Modifier.size(18.dp))
+        }
+        Spacer(Modifier.width(12.dp))
+        Text(
+            titel,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.width(12.dp))
+        Text(
+            wert,
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.End,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}

--- a/android/app/src/main/java/de/roessing/app/ui/VeranstaltungenScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/VeranstaltungenScreen.kt
@@ -47,6 +47,7 @@ fun VeranstaltungenScreen(
     state: VeranstaltungenUiState,
     modifier: Modifier = Modifier,
     onAktualisieren: () -> Unit = {},
+    onTermin: (Termin) -> Unit = {},
 ) {
     val browser = LocalUriHandler.current
     Column(modifier.fillMaxWidth().testTag("veranstaltungen")) {
@@ -86,7 +87,14 @@ fun VeranstaltungenScreen(
             }
 
             items(state.termine, key = { it.id }) { termin ->
-                TerminKarte(termin) { browser.openUri(termin.url) }
+                // Ein Termin des Dorfes trägt alles, was wir über ihn wissen,
+                // schon in sich — dafür muss niemand die App verlassen. Nur
+                // eine fremde Primärquelle führt hinaus; sie hier
+                // nachzuerzählen hieße, eine zweite Fassung in die Welt zu
+                // setzen, die irgendwann von der ersten abweicht.
+                TerminKarte(termin) {
+                    if (termin.extern) browser.openUri(termin.url) else onTermin(termin)
+                }
             }
 
             if (state.leer) {
@@ -163,6 +171,9 @@ private fun TerminKarte(termin: Termin, onClick: () -> Unit) {
                 termin.zeitText ?: stringResource(R.string.events_all_day),
             )
             termin.ortName?.let { Zeile(Icons.Filled.Place, it) }
+            // Die Adresse gehört unter den Ortsnamen, nicht an den linken
+            // Rand — deshalb bleibt die Symbolspalte leer stehen.
+            termin.ortAdresse?.let { Zeile(null, it) }
             termin.veranstalter?.let { Zeile(Icons.Filled.Group, it) }
 
             if (termin.beschreibung.isNotBlank()) {
@@ -186,14 +197,18 @@ private fun TerminKarte(termin: Termin, onClick: () -> Unit) {
 }
 
 @Composable
-private fun Zeile(symbol: ImageVector, text: String) {
+private fun Zeile(symbol: ImageVector?, text: String) {
     Row(verticalAlignment = Alignment.CenterVertically) {
-        Icon(
-            symbol,
-            contentDescription = null,
-            modifier = Modifier.size(16.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        if (symbol != null) {
+            Icon(
+                symbol,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            Spacer(Modifier.size(16.dp))
+        }
         Spacer(Modifier.width(8.dp))
         Text(
             text,

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -201,4 +201,15 @@
     <string name="events_offline_stale">Gerade keine Verbindung — die Liste ist möglicherweise nicht mehr aktuell.</string>
     <string name="events_retry">Erneut versuchen</string>
     <string name="events_loading">Termine werden geholt …</string>
+    <string name="events_detail_title">Termin</string>
+    <string name="events_when">Wann</string>
+    <string name="events_where">Wo und von wem</string>
+    <string name="events_about">Worum es geht</string>
+    <string name="events_day">Tag</string>
+    <string name="events_time">Uhrzeit</string>
+    <string name="events_place">Ort</string>
+    <string name="events_address">Adresse</string>
+    <string name="events_organizer">Veranstalter</string>
+    <string name="events_source_link">Auf rössing.de ansehen</string>
+    <string name="events_source_note">Gepflegt wird der Termin auf rössing.de. Dort steht immer der neueste Stand.</string>
 </resources>


### PR DESCRIPTION
Behebt #51.

## Was schief stand

`VeranstaltungenScreen.kt` rief bei **jedem** Tipp `browser.openUri(termin.url)` — ohne Ansehen von `termin.extern`. Der gesamte Terminfeed von rössing.de trägt `external: false`, also landete auf Android jeder einzelne Termin im Browser, obwohl Ort, Adresse, Veranstalter und Beschreibung längst in der App lagen. iOS zeigt seit `TerminDetailView` die Einzelheiten in der App. Zwei Dörfer, je nach Telefon — genau das, was `CLAUDE.md` ausschließt.

## Was jetzt gilt

Dieselbe Regel wie drüben:

- **`external = false`** → `TerminDetail` in der App: *Wann* (Tag, Uhrzeit), *Wo und von wem* (Ort, Adresse, Veranstalter), *Worum es geht*, zuletzt „Auf rössing.de ansehen" mit dem Hinweis, wo gepflegt wird.
- **`external = true`** → der Tipp führt zur fremden Primärquelle. Denselben Inhalt an zwei Stellen zu erzählen heißt, dass eine der beiden irgendwann falsch ist.

Die Gliederung ist Abschnitt für Abschnitt die von `TerminDetailView`. Dazu steht die **Adresse** jetzt auch auf der Karte in der Liste — drüben stand sie schon dort.

## Zurück, Schritt für Schritt

Der aufgeschlagene Termin lebt als Kennung (`offenerTermin`) neben dem Bereich, wie `selectedPlaceId` es vormacht — eine Kennung übersteht das Drehen des Geräts, ein `Termin` nicht.

System-Zurück und der Pfeil oben links führen **erst** in die Liste, **dann** zur Startseite; die Überschrift wechselt dabei auf „Termin". Wer den Bereich verlässt und später zurückkommt, landet wieder in der Liste und nicht in einem Termin von vorgestern.

## Geprüft

- `./gradlew testDebugUnitTest assembleDebug` — grün.
- `./gradlew assembleDebugAndroidTest` — übersetzt. Drei neue Fälle in `VeranstaltungenUiTest`: Einzelheiten in der App, Zurück führt in die Liste, ein fremder Termin bleibt bei seiner Quelle. **Ausgeführt** sind sie hier nicht — auf dieser Maschine läuft kein Emulator, das erledigt die CI.