### PR TITLE
Die Dorf-App ist das Dach fürs Dörfliche, nicht nur für die Allmende

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ backend/internal/admin/node_modules/
 # Python
 __pycache__/
 *.pyc
+
+# Arbeitsverzeichnisse paralleler Agenten — gehoeren niemandem sonst.
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,10 +132,27 @@ Wird ein Befund doch mitgegeben, weil er Zeit spart, dann ausdrücklich als
 
 ## Träger (Vereine und Gruppen)
 
-Die Dorf-App verwaltet die **Allmende**, sie vermittelt nicht zwischen
-Privatleuten. Jeder Ort und jede Aufgabe gehört einem **Träger**; Aufgaben
-werden von Vereinen und Gruppen **kuratiert** eingestellt. **Keine
-Parallelstrukturen zu bestehenden Vereinen aufbauen.**
+Jeder Ort und jede Aufgabe gehört einem **Träger**; Aufgaben werden von
+Vereinen und Gruppen **kuratiert** eingestellt. **Keine Parallelstrukturen zu
+bestehenden Vereinen aufbauen.** Das ist der Kern: Die Dorf-App verwaltet die
+**Allmende**.
+
+**Sie ist aber nicht darauf beschränkt** (Entscheidung vom 31.08.2026). Die
+Dorf-App ist das Dach für das Dörfliche überhaupt — auch für Vermittlung
+zwischen Privatleuten, wie sie der **Verleih** betreibt. Der frühere Satz „sie
+vermittelt nicht zwischen Privatleuten" stand hier, um keine Parallelstruktur
+neben den Vereinen zu bauen; dafür gilt weiter, was oben steht. Einen Dienst
+aufzunehmen, den es im Dorf längst gibt und der keinem Verein etwas wegnimmt,
+war davon nie gemeint. Wer den alten Satz sucht: Er ist bewusst gestrichen,
+nicht vergessen.
+
+Aufnehmen heißt dabei nicht einverleiben: **Getrennte Dienste unter eigenen
+Adressen, kein App-Monolith.** Der Verleih bleibt unter
+`mieten.xn--rssing-wxa.de` mit eigenem Backend und eigener Inferenz; die Apps
+rufen ihn unmittelbar auf, das Go-Backend ist kein Weiterleiter. Zusammen hält
+alles **eine Identität** (Rössing-ID), nicht ein gemeinsames Backend. Der
+Präzedenzfall steht im Haus: Die Veranstaltungen kommen von einem fremden
+Server über einen eigenen kleinen Client, und das Backend weiß nichts davon.
 
 - **Ein Träger = ein Zitadel-Projekt** mit genau zwei Rollen: `admin` und
   `mitglied`. **Keine Rollennamen mit Vereinspräfix.**

--- a/README.md
+++ b/README.md
@@ -57,12 +57,20 @@ keine der beiden Apps noch einmal.
     „Mithelfen" liegt unter `/admin/mithelfen/…` (der frühere Pfad
     `/admin/dorfpflege/…` leitet dauerhaft per 308 dorthin um)
   - SQLite im WAL-Modus auf einem PVC (`/data/dorfapp.sqlite`)
-- **Träger**: Alles, was in der App steht, gehört einem **Verein oder einer
-  Gruppe**. Die Dorf-App vermittelt ausdrücklich **nicht** zwischen
-  Privatleuten, sondern verwaltet die **Allmende** — das, was dem Dorf
-  gemeinsam gehört. Aufgaben entstehen deshalb nicht spontan von Einzelnen,
-  sondern werden von Trägern **kuratiert** eingestellt; neben den bestehenden
-  Vereinen entsteht keine Parallelstruktur.
+- **Träger**: Alles, was an Aufgaben in der App steht, gehört einem **Verein
+  oder einer Gruppe**. Aufgaben entstehen nicht spontan von Einzelnen, sondern
+  werden von Trägern **kuratiert** eingestellt; neben den bestehenden Vereinen
+  entsteht keine Parallelstruktur. Das bleibt der Kern: Die Dorf-App verwaltet
+  die **Allmende** — das, was dem Dorf gemeinsam gehört.
+  **Sie ist aber nicht darauf beschränkt.** Seit dem 31.08.2026 ist sie das
+  Dach für das Dörfliche überhaupt, und dazu gehört auch Vermittlung zwischen
+  Privatleuten: Der **Verleih** („Maschinchenring", `mieten.xn--rssing-wxa.de`)
+  ist ein eigener Dienst mit eigener Adresse, den die Apps unmittelbar
+  aufrufen, und er vermittelt Geräte von Nachbar zu Nachbar. Der frühere Satz
+  „vermittelt ausdrücklich nicht zwischen Privatleuten" ist damit gefallen.
+  Er hatte einen guten Grund — keine Parallelstruktur zu den Vereinen zu
+  bauen — und dieser Grund gilt weiter für **Aufgaben**. Für einen Dienst, den
+  es im Dorf längst gibt und der niemandem etwas wegnimmt, galt er nie.
   **Ein Träger = ein Zitadel-Projekt** mit genau zwei Rollen, `admin` und
   `mitglied` (ohne Vereinspräfix — sie sind im Projekt eindeutig).
   Ein Träger hat einen **Zulassungsstand** (`beantragt`, `zugelassen`,


### PR DESCRIPTION
Der Verleih („Maschinchenring") soll vollständig in beide Apps. Dagegen stand ein Satz in `README.md` und `CLAUDE.md`:

> Die Dorf-App verwaltet die **Allmende**, sie vermittelt nicht zwischen Privatleuten.

Der Verleih ist genau das: Privatleute verleihen ihre Maschinen an Privatleute, gegen Geld, mit Kaution. Solange der Satz so dasteht, steht der neue Bereich neben einer Regel, die ihn ausschließt — und beim nächsten Bereich wird sie wieder dagegen zitiert.

Der Betreiber hat entschieden: **der Satz fällt.** Die Dorf-App ist das Dach für das Dörfliche überhaupt.

## Was ausdrücklich bleibt

Der **Grund**, aus dem der Satz dastand, fällt nicht mit: Neben den bestehenden Vereinen entsteht keine Parallelstruktur, Aufgaben werden weiter von Trägern kuratiert eingestellt, jeder Ort und jede Aufgabe gehört einem Träger. Was sich ändert, ist allein die Behauptung, die Dorf-App dürfe nichts anderes als die Allmende.

## Was dabei nicht verrutschen darf

Aufnehmen heißt nicht einverleiben. Beide Dateien halten jetzt fest, was der Betreiber dazu gesagt hat: **getrennte Dienste unter eigenen Adressen, kein App-Monolith.** Der Verleih bleibt unter `mieten.xn--rssing-wxa.de` mit eigenem Backend und eigener Inferenz; die Apps rufen ihn unmittelbar auf, das Go-Backend ist kein Weiterleiter. Zusammen hält alles **eine Identität** (Rössing-ID), nicht ein gemeinsames Backend. Der Präzedenzfall steht im Haus: Die Veranstaltungen kommen von einem fremden Server über einen eigenen kleinen Client.

Nur Dokumentation — kein Quelltext berührt. Die Umsetzung des Bereichs läuft in eigenen Zweigen.