### PR TITLE
Auslieferung 0.1.11 — und der Build meldet sich selbst zur Beta App Review an

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -382,6 +382,31 @@ jobs:
           python3 store/asc.py beta-info \
             || echo "::warning::Beta-Angaben konnten nicht gesetzt werden — von Hand unter TestFlight → Test Information nachtragen."
 
+      # Ein hochgeladener Build ist noch kein ausgelieferter Build. Die Gruppe
+      # „Dorf" ist **extern** — das ist der Grund für den öffentlichen Link,
+      # mit dem ein Link ins Dorf reicht statt einer Einladung je Adresse. Für
+      # externe Tester prüft Apple jeden ersten Build einer Versionsnummer, und
+      # diese Prüfung stößt niemand von selbst an. Ohne diesen Schritt liegt
+      # der Build in TestFlight und wartet, während im Dorf niemand etwas sieht.
+      #
+      # Der Schritt wartet, bis Apple den Build verarbeitet hat (5 bis 30
+      # Minuten), deshalb das großzügige Zeitlimit. Er ist wiederholbar: ein
+      # schon eingereichter Build wird gemeldet, nicht doppelt angemeldet.
+      #
+      # Nur eine Warnung, wenn er scheitert: Der Build ist dann trotzdem oben,
+      # und die Einreichung lässt sich jederzeit mit
+      # `python3 store/asc.py beta-einreichen` nachholen.
+      - name: Zur Beta App Review anmelden
+        if: env.SIGNIEREN == 'ja' && env.APP_DA == 'ja' && (github.event_name != 'workflow_dispatch' || inputs.hochladen)
+        timeout-minutes: 40
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: |
+          set -uo pipefail
+          python3 store/asc.py beta-einreichen \
+            || echo '::warning::Beta App Review nicht angemeldet — später von Hand nachholen mit: python3 store/asc.py beta-einreichen'
+
       # Der Upload-Bericht ist das Einzige, woran sich später nachvollziehen
       # lässt, welche Buildnummer wann oben angekommen ist — und Apples
       # Fehlermeldungen (ITMS-…) stehen ausschließlich darin.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -31,8 +31,8 @@ android {
         // keinen Build mit kleinerer Nummer über einen größeren — sonst
         // müssten alle Tester die App erst deinstallieren. Ab hier wieder in
         // Einerschritten weiterzählen.
-        versionCode = 1000110
-        versionName = "0.1.10"
+        versionCode = 1000111
+        versionName = "0.1.11"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -67,11 +67,11 @@ targets:
         INFOPLIST_FILE: Dorf/Info.plist
         CURRENT_PROJECT_VERSION: "1"
         # Beide Apps tragen dieselbe Nummer: Sie sind ein Produkt in zwei
-        # Fassungen, und "Rössing 0.1.10" soll auf beiden Telefonen
+        # Fassungen, und "Rössing 0.1.11" soll auf beiden Telefonen
         # dasselbe bedeuten (siehe CLAUDE.md, "Android und iOS bleiben auf
         # demselben Stand"). Die Buildnummer bleibt davon unberührt —
         # sie zählt Auslieferungen, nicht Stände.
-        MARKETING_VERSION: "0.1.10"
+        MARKETING_VERSION: "0.1.11"
         TARGETED_DEVICE_FAMILY: "1,2"
         # Ohne Apple-Entwicklerkonto lässt sich für den Simulator bauen; für
         # Gerät und TestFlight trägt DEVELOPMENT_TEAM die Team-ID nach.

--- a/store/asc.py
+++ b/store/asc.py
@@ -509,6 +509,137 @@ def testflight_gruppe() -> None:
     print("Der Link trägt erst, wenn ein Build die Beta App Review bestanden hat.")
 
 
+def _neuester_build(app_id: str) -> dict:
+    """Der zuletzt hochgeladene Build der App.
+
+    Nach Uploaddatum absteigend, ein Treffer. Eine Buildnummer als Filter wäre
+    genauer, aber der Workflow kennt sie nicht mehr, wenn dieser Schritt
+    läuft — `altool` gibt sie nicht zurück.
+    """
+    antwort = anfrage(
+        "GET",
+        f"/v1/builds?filter[app]={app_id}&sort=-uploadedDate&limit=1",
+    )
+    daten = antwort.get("data", [])
+    if not daten:
+        raise SystemExit(
+            "Zu dieser App ist noch kein Build in App Store Connect.\n"
+            "Erst hochladen (.github/workflows/ios-release.yml), dann "
+            "einreichen. Es wurde nichts geändert."
+        )
+    return daten[0]
+
+
+def _auf_verarbeitung_warten(build: dict, frist: int = 1800) -> dict:
+    """Warten, bis Apple den Build verarbeitet hat.
+
+    Ein frisch hochgeladener Build steht auf PROCESSING und lässt sich weder
+    einer Gruppe zuordnen noch einreichen. Das dauert erfahrungsgemäß 5 bis 30
+    Minuten — deshalb die halbe Stunde Frist und nicht fünf Minuten.
+
+    INVALID ist ein Abbruch und keine Geduldsfrage: Der Build ist unbrauchbar,
+    und Apple sagt den Grund in App Store Connect.
+    """
+    kennung = build["id"]
+    while True:
+        stand = build.get("attributes", {}).get("processingState")
+        if stand == "VALID":
+            return build
+        if stand in ("INVALID", "FAILED"):
+            raise SystemExit(
+                f"Build {build['attributes'].get('version')} ist {stand} — "
+                "Apple hat ihn abgewiesen. Der Grund steht in App Store "
+                "Connect unter TestFlight. Es wurde nichts eingereicht."
+            )
+        if PROBE:
+            print(f"[Trockenlauf] Warten auf Verarbeitung entfällt (Stand {stand}).")
+            return build
+        if frist <= 0:
+            raise SystemExit(
+                f"Build steht nach der Wartezeit immer noch auf {stand}. "
+                "Das ist kein Fehler, nur langsam: später erneut "
+                "`python3 store/asc.py beta-einreichen` aufrufen."
+            )
+        print(f"  Build ist {stand} — in 60 s noch einmal nachsehen "
+              f"(noch {frist // 60} Minuten Geduld).")
+        time.sleep(60)
+        frist -= 60
+        build = anfrage("GET", f"/v1/builds/{kennung}")["data"]
+
+
+def beta_einreichen() -> None:
+    """Den neuesten Build der externen Gruppe geben und zur Beta App Review anmelden.
+
+    Interne Tester bekommen einen Build sofort. Die Gruppe „Dorf“ ist aber
+    **extern** — das ist der Grund für den öffentlichen Link, mit dem ein Link
+    ins Dorf reicht statt einer Einladung je Adresse. Extern heißt: Apple prüft
+    den ersten Build und jede neue Versionsnummer, bevor jemand ihn laden kann.
+
+    Diese Prüfung stößt niemand von selbst an. Ohne diesen Schritt liegt der
+    Build in TestFlight und wartet — und niemand im Dorf sieht ihn.
+
+    Der Aufruf ist wiederholbar: Ein bereits eingereichter Build wird nicht
+    doppelt angemeldet, sondern gemeldet.
+    """
+    app = app_datensatz()
+    build = _auf_verarbeitung_warten(_neuester_build(app["id"]))
+    eigenschaften = build.get("attributes", {})
+    print(f"Build {eigenschaften.get('version')} "
+          f"(hochgeladen {eigenschaften.get('uploadedDate')}), Stand "
+          f"{eigenschaften.get('processingState')}.")
+
+    # Die Gruppe muss es geben — sie anzulegen ist ein eigener Befehl, damit
+    # dieser hier nicht nebenbei etwas erschafft.
+    gruppen = anfrage("GET", f"/v1/apps/{app['id']}/betaGroups?limit=200")
+    gruppe = next(
+        (e for e in gruppen.get("data", [])
+         if e.get("attributes", {}).get("name") == TESTFLIGHT_GRUPPE),
+        None,
+    )
+    if gruppe is None:
+        raise SystemExit(
+            f"Die Tester-Gruppe „{TESTFLIGHT_GRUPPE}“ gibt es nicht.\n"
+            "Erst anlegen: python3 store/asc.py testflight-gruppe\n"
+            "Es wurde nichts eingereicht."
+        )
+
+    # 409 heißt hier „liegt schon in der Gruppe“ — kein Grund für Rot.
+    antwort = anfrage(
+        "POST", f"/v1/betaGroups/{gruppe['id']}/relationships/builds",
+        {"data": [{"type": "builds", "id": build["id"]}]},
+        dulden=(409,),
+    )
+    if antwort.get("__status") == 409:
+        print(f"Build liegt bereits in der Gruppe „{TESTFLIGHT_GRUPPE}“.")
+    else:
+        print(f"Build der Gruppe „{TESTFLIGHT_GRUPPE}“ zugeordnet.")
+
+    vorhanden = anfrage(
+        "GET",
+        f"/v1/betaAppReviewSubmissions?filter[build]={build['id']}&limit=1",
+    )
+    if vorhanden.get("data"):
+        stand = vorhanden["data"][0].get("attributes", {}).get("betaReviewState")
+        print(f"Dieser Build ist bereits zur Beta App Review angemeldet "
+              f"(Stand: {stand}). Es wurde nichts doppelt eingereicht.")
+        return
+
+    anfrage("POST", "/v1/betaAppReviewSubmissions", {
+        "data": {
+            "type": "betaAppReviewSubmissions",
+            "relationships": {
+                "build": {"data": {"type": "builds", "id": build["id"]}},
+            },
+        },
+    })
+    print("Zur Beta App Review angemeldet. Apple antwortet in aller Regel "
+          "innerhalb eines Tages; bis dahin steht der Build in TestFlight auf "
+          "„Waiting for Review“.")
+    print("Wichtig: Ohne hinterlegtes Prüfkonto samt Passwort wird die Prüfung "
+          "abgelehnt — die App kommt ohne Anmeldung nicht über den ersten "
+          "Bildschirm hinaus (store/ios-veroeffentlichung.md).")
+
+
 def beta_info() -> None:
     """Beta-Angaben je Sprache setzen (betaAppLocalizations).
 
@@ -1361,6 +1492,7 @@ BEFEHLE = {
     "app-zeigen": app_zeigen,
     "testflight-gruppe": testflight_gruppe,
     "beta-info": beta_info,
+    "beta-einreichen": beta_einreichen,
     "kategorien": kategorien,
     "alterseinstufung": alterseinstufung,
     "pruefangaben": pruefangaben,

--- a/store/metadata/android/de-DE/changelogs/1000111.txt
+++ b/store/metadata/android/de-DE/changelogs/1000111.txt
@@ -1,0 +1,3 @@
+Termine: Ein Termin des Dorfes zeigt seine Einzelheiten jetzt in der App — Wann, Wo und von wem, worum es geht. Bisher führte jeder Tipp in den Browser, obwohl alles davon schon in der App lag. Nur Termine, die einem fremden Veranstalter gehören, führen weiterhin auf dessen Seite; dieselbe Sache zweimal zu erzählen hieße, dass eine der beiden irgendwann falsch ist.
+
+Dazu steht die Adresse jetzt auch auf der Terminkarte in der Liste.

--- a/store/metadata/android/en-US/changelogs/1000111.txt
+++ b/store/metadata/android/en-US/changelogs/1000111.txt
@@ -1,0 +1,3 @@
+Events: an event from the village now shows its details inside the app — when, where, who is hosting, what it is about. Until now every tap opened the browser, even though all of it was already in the app. Only events belonging to an outside host still lead to their own page; telling the same thing twice would mean one of the two is eventually wrong.
+
+The address now also appears on the event card in the list.


### PR DESCRIPTION
Schneidet die Fassung **0.1.11** für beide Kanäle und schließt die Lücke am Ende der iOS-Auslieferung.

## Version

`versionCode 1000111` / `versionName 0.1.11` auf Android, `MARKETING_VERSION 0.1.11` auf iOS — beide Fassungen tragen dieselbe Nummer, weil sie ein Produkt sind. Änderungshinweise für Play liegen in beiden Sprachen bei; `store/check_metadata.py` und `store/check_ios_metadata.py` laufen durch.

Inhaltlich sind das die beiden Termin-Änderungen: #50 (die iOS-Liste fiel bei jedem Termin mit Adresse auseinander) und #51 (auf Android führte jeder Termin in den Browser, statt seine Einzelheiten zu zeigen).

## Die Lücke am Ende

Der Workflow lud bisher nach TestFlight hoch und war fertig. Das reicht nicht: Die Tester-Gruppe „Dorf" ist **extern** — genau deshalb gibt es sie, denn der öffentliche Link erspart eine Einladung je Adresse. Für externe Tester prüft Apple jeden ersten Build einer Versionsnummer, und **diese Prüfung stößt niemand von selbst an**. Der Build lag also oben und wartete, während im Dorf niemand etwas sah.

Neu ist deshalb `store/asc.py beta-einreichen`:

1. den zuletzt hochgeladenen Build holen,
2. warten, bis Apple ihn verarbeitet hat — das dauert 5 bis 30 Minuten, deshalb eine halbe Stunde Geduld statt fünf Minuten; `INVALID` bricht ab statt weiterzuwarten,
3. ihn der Gruppe „Dorf" zuordnen (409 heißt „liegt schon drin", kein Grund für Rot),
4. zur Beta App Review anmelden — es sei denn, dieser Build ist schon angemeldet, dann sagt er das und tut nichts.

Der Workflow ruft ihn nach dem Upload auf. Scheitert er, bleibt es bei einer **Warnung**: Der Build ist dann trotzdem oben, und die Einreichung lässt sich jederzeit von Hand nachholen.

## Was der Betreiber wissen muss

Das ist der **erste** iOS-Lauf überhaupt — `.github/workflows/ios-release.yml` ist noch nie gelaufen. Der Lauf legt dabei Zertifikat und Provisioning-Profil selbst an (`-allowProvisioningUpdates`).

Und: Ohne hinterlegtes Prüfkonto samt Passwort wird die Beta App Review abgelehnt — die App kommt ohne Anmeldung nicht über den ersten Bildschirm. Laut `store/ios-veroeffentlichung.md` ist das Passwort über `asc.py pruefangaben` bereits gesetzt; falls Apple trotzdem ablehnt, ist das die erste Stelle zum Nachsehen.