### PR TITLE
iOS-Auslieferung: Beim Archivieren wählt Xcode die Identität selbst

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -250,6 +250,14 @@ jobs:
       # CODE_SIGNING_REQUIRED NO) — richtig für den Simulator, untauglich für
       # den Store. Für diesen einen Aufruf wird das übersteuert, statt die
       # Datei anzufassen.
+      #
+      # Die Identität ist hier bewusst **Apple Development** und nicht
+      # Distribution. Beim automatischen Signieren sucht Xcode sie selbst aus;
+      # wer ihm daneben eine Distributionsidentität vorschreibt, bekommt
+      # „Dorf has conflicting provisioning settings" und gar kein Archiv. Zur
+      # Distribution signiert der Export weiter unten um — dafür ist
+      # `method: app-store-connect` da. Genau daran ist der erste Lauf
+      # gescheitert (ios-v0.1.11, 31.08.2026).
       - name: Archivieren (signiert)
         if: env.SIGNIEREN == 'ja'
         working-directory: ios
@@ -269,7 +277,7 @@ jobs:
             -authenticationKeyIssuerID "$ISSUER_ID" \
             DEVELOPMENT_TEAM="$TEAM" \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
+            CODE_SIGN_IDENTITY="Apple Development" \
             CODE_SIGNING_REQUIRED=YES \
             CODE_SIGNING_ALLOWED=YES \
             CURRENT_PROJECT_VERSION="$BAUZAHL" \


### PR DESCRIPTION
Der **erste TestFlight-Lauf überhaupt** (`ios-v0.1.11`) ist am Signieren gescheitert, bevor auch nur ein Archiv entstand:

> `Dorf has conflicting provisioning settings. Dorf is automatically signed for development, but a conflicting code signing identity Apple Distribution has been manually specified.`

Der Workflow gab `CODE_SIGN_STYLE=Automatic` **und** `CODE_SIGN_IDENTITY="Apple Distribution"` zugleich mit. Beim automatischen Signieren sucht Xcode die Identität aber selbst aus; eine daneben vorgeschriebene Distributionsidentität ist ein Widerspruch, und Xcode nennt die Auflösung in derselben Meldung.

Das Archiv wird jetzt mit **`Apple Development`** signiert. Zur Distribution signiert der **Export** darunter um — genau dafür steht `method: app-store-connect` in den ExportOptions, zusammen mit `signingStyle: automatic` und `-allowProvisioningUpdates`. Am Ergebnis ändert das nichts; es ändert nur, wer die Identität aussucht.

Der Grund steht als Kommentar über dem Schritt, samt Datum des gescheiterten Laufs — damit niemand die Zeile in einem halben Jahr „aufräumt" und denselben Lauf noch einmal an die Wand fährt.

Nach dem Merge löse ich die iOS-Auslieferung erneut aus (`workflow_dispatch`, Buildnummer steigt von selbst). Der Android-Teil von 0.1.11 ist davon nicht betroffen und läuft getrennt.