### PR TITLE
iOS-Archiv: die Signieridentität leeren, statt sie vorzuschreiben

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -251,13 +251,28 @@ jobs:
       # den Store. Für diesen einen Aufruf wird das übersteuert, statt die
       # Datei anzufassen.
       #
-      # Die Identität ist hier bewusst **Apple Development** und nicht
-      # Distribution. Beim automatischen Signieren sucht Xcode sie selbst aus;
-      # wer ihm daneben eine Distributionsidentität vorschreibt, bekommt
-      # „Dorf has conflicting provisioning settings" und gar kein Archiv. Zur
-      # Distribution signiert der Export weiter unten um — dafür ist
-      # `method: app-store-connect` da. Genau daran ist der erste Lauf
-      # gescheitert (ios-v0.1.11, 31.08.2026).
+      # Die Identität wird hier **geleert**, nicht gesetzt. Das ist der Kern:
+      # Beim automatischen Signieren sucht Xcode sie selbst aus, und für ein
+      # Archiv auf der Release-Konfiguration wählt es die Verteilung. Wer ihm
+      # daneben etwas vorschreibt, verliert genau diese Wahl — beide Wege sind
+      # am 31.08.2026 vorgeführt worden:
+      #
+      #   "Apple Distribution" -> "Dorf has conflicting provisioning settings.
+      #       Dorf is automatically signed for development, but a conflicting
+      #       code signing identity Apple Distribution has been manually
+      #       specified."
+      #   "Apple Development"  -> "Your team has no devices from which to
+      #       generate a provisioning profile."
+      #
+      # Der zweite Fehler ist der lehrreiche: Ein Entwicklungsprofil verlangt
+      # ein registriertes Gerät, und zu diesem Team gehört keines — es gibt
+      # kein echtes iPhone (siehe CLAUDE.md, "Entwicklungsumgebung (iOS)").
+      # Ein Verteilungsprofil braucht keines. Der Weg über die Verteilung ist
+      # hier also nicht der bequemere, sondern der einzige.
+      #
+      # Geleert werden muss die Angabe, weil ios/project.yml
+      # CODE_SIGN_IDENTITY: "-" traegt — Ad-hoc, richtig fuer den Simulator
+      # und untauglich fuer den Store. Ohne das Leeren gilt sie auch hier.
       - name: Archivieren (signiert)
         if: env.SIGNIEREN == 'ja'
         working-directory: ios
@@ -277,7 +292,8 @@ jobs:
             -authenticationKeyIssuerID "$ISSUER_ID" \
             DEVELOPMENT_TEAM="$TEAM" \
             CODE_SIGN_STYLE=Automatic \
-            CODE_SIGN_IDENTITY="Apple Development" \
+            CODE_SIGN_IDENTITY="" \
+            PROVISIONING_PROFILE_SPECIFIER="" \
             CODE_SIGNING_REQUIRED=YES \
             CODE_SIGNING_ALLOWED=YES \
             CURRENT_PROJECT_VERSION="$BAUZAHL" \


### PR DESCRIPTION
Nachtrag zu #64. Der dortige Fix war die halbe Wahrheit — der nächste Lauf ist an der anderen Hälfte gescheitert.

## Zwei Läufe, zwei Fehler, eine Ursache

| Vorgeschriebene Identität | Was Apple sagt |
| --- | --- |
| `Apple Distribution` | „Dorf has conflicting provisioning settings. Dorf is automatically signed for development, but a conflicting code signing identity Apple Distribution has been manually specified." |
| `Apple Development` | „Your team has no devices from which to generate a provisioning profile." |

Der zweite Fehler ist der lehrreiche: Ein **Entwicklungs**profil verlangt ein registriertes Gerät, und zu diesem Team gehört keines — es gibt kein echtes iPhone (`CLAUDE.md`, „Entwicklungsumgebung (iOS)"). Ein **Verteilungs**profil braucht keines. Der Weg über die Verteilung ist hier also nicht der bequemere, sondern der einzige.

## Was jetzt passiert

Beim automatischen Signieren sucht Xcode die Identität selbst aus und wählt für ein Archiv auf der Release-Konfiguration die Verteilung. Wer ihm daneben etwas vorschreibt, verliert genau diese Wahl. Also wird `CODE_SIGN_IDENTITY` **geleert** statt gesetzt — geleert deshalb, weil `ios/project.yml` die Ad-hoc-Signatur `"-"` trägt, die für den Simulator richtig und für den Store untauglich ist. `PROVISIONING_PROFILE_SPECIFIER` ebenso, damit nichts Halbes stehenbleibt.

Beide Fehlermeldungen stehen wörtlich als Kommentar über dem Schritt, mit Datum. Wer die Zeile später „aufräumt", soll vorher lesen, was das kostet.

## Stand der Auslieferung 0.1.11

**Android ist draußen** — der Lauf zu `v0.1.11` ist grün, das Bundle liegt im Play-Track `internal` und bei Firebase. iOS hängt allein an diesem Schritt; nach dem Merge löse ich die Auslieferung erneut aus.