### PR TITLE
Träger können unter einem Dach arbeiten

### DIFF
--- a/backend/internal/db/traeger.go
+++ b/backend/internal/db/traeger.go
@@ -75,6 +75,9 @@ CREATE INDEX IF NOT EXISTS idx_antrag_status ON befaehigungs_antraege(status);
 		`ALTER TABLE places ADD COLUMN traeger_id INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE care_tasks ADD COLUMN sichtbarkeit TEXT NOT NULL DEFAULT 'oeffentlich'`,
 		`ALTER TABLE care_tasks ADD COLUMN befaehigung_id INTEGER NOT NULL DEFAULT 0`,
+		// Das Dach über einem Arbeitskreis. 0 heißt „keins“ — damit ändert
+		// sich für jeden bestehenden Träger nichts.
+		`ALTER TABLE traeger ADD COLUMN parent_id INTEGER NOT NULL DEFAULT 0`,
 	} {
 		if _, err := d.sql.Exec(stmt); err != nil && !istDoppelteSpalte(err) {
 			return err
@@ -135,13 +138,16 @@ func (d *DB) TraegerSicherstellen(schluessel, name string) (*model.Traeger, erro
 
 // --- Träger -----------------------------------------------------------------
 
-const traegerSpalten = `id,schluessel,projekt_id,name,beschreibung,status,sichtbarkeit,created_at`
+const traegerSpalten = `id,schluessel,projekt_id,name,beschreibung,status,sichtbarkeit,parent_id,created_at`
 
 func (d *DB) InsertTraeger(t *model.Traeger) error {
-	res, err := d.sql.Exec(`INSERT INTO traeger(schluessel,projekt_id,name,beschreibung,status,sichtbarkeit,created_at)
-		VALUES(?,?,?,?,?,?,?)`,
+	if err := d.dachPruefen(t); err != nil {
+		return err
+	}
+	res, err := d.sql.Exec(`INSERT INTO traeger(schluessel,projekt_id,name,beschreibung,status,sichtbarkeit,parent_id,created_at)
+		VALUES(?,?,?,?,?,?,?,?)`,
 		t.Schluessel, t.ProjektID, t.Name, t.Beschreibung, string(t.Status), string(t.Sichtbarkeit),
-		t.CreatedAt.UTC().Format(timeFormat))
+		t.ParentID, t.CreatedAt.UTC().Format(timeFormat))
 	if err != nil {
 		return err
 	}
@@ -150,13 +156,77 @@ func (d *DB) InsertTraeger(t *model.Traeger) error {
 }
 
 func (d *DB) UpdateTraeger(t *model.Traeger) error {
-	res, err := d.sql.Exec(`UPDATE traeger SET projekt_id=?,name=?,beschreibung=?,status=?,sichtbarkeit=?
+	if err := d.dachPruefen(t); err != nil {
+		return err
+	}
+	res, err := d.sql.Exec(`UPDATE traeger SET projekt_id=?,name=?,beschreibung=?,status=?,sichtbarkeit=?,parent_id=?
 		WHERE id=?`,
-		t.ProjektID, t.Name, t.Beschreibung, string(t.Status), string(t.Sichtbarkeit), t.ID)
+		t.ProjektID, t.Name, t.Beschreibung, string(t.Status), string(t.Sichtbarkeit), t.ParentID, t.ID)
 	if err != nil {
 		return err
 	}
 	return requireRow(res)
+}
+
+// dachPruefen hält die Hierarchie flach und kreisfrei.
+//
+// Zwei Regeln, beide aus demselben Grund: Ein Dach über einem Dach gibt es
+// im Dorf nicht (Verein → Arbeitskreis, fertig), und ohne die Grenze bräuchte
+// jede Abfrage eine Zyklusprüfung. Was hier nicht durchkommt, kann später
+// nirgends mehr Schaden anrichten.
+//
+// Die Prüfung steht in der Ablage und nicht in Validate, weil sie den
+// Bestand kennen muss: ob es das Dach gibt und ob es selbst unter einem steht.
+func (d *DB) dachPruefen(t *model.Traeger) error {
+	if t.ParentID == 0 {
+		return nil
+	}
+	if t.ParentID == t.ID {
+		return errors.New("ein Träger kann nicht sein eigenes Dach sein")
+	}
+	dach, err := d.GetTraeger(t.ParentID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return errors.New("das angegebene Dach gibt es nicht")
+	}
+	if err != nil {
+		return err
+	}
+	if dach.ParentID != 0 {
+		return errors.New("ein Dach steht nicht selbst unter einem Dach — " +
+			"vorgesehen ist genau eine Ebene, Verein über Arbeitskreis")
+	}
+	// Wer selbst schon Arbeitskreise trägt, kann nicht unter ein Dach ziehen:
+	// sonst stünde am Ende doch etwas auf der dritten Ebene.
+	if t.ID != 0 {
+		var kinder int
+		if err := d.sql.QueryRow(`SELECT COUNT(*) FROM traeger WHERE parent_id=?`, t.ID).
+			Scan(&kinder); err != nil {
+			return err
+		}
+		if kinder > 0 {
+			return errors.New("dieser Träger trägt selbst schon Arbeitskreise " +
+				"und kann deshalb nicht unter ein Dach ziehen")
+		}
+	}
+	return nil
+}
+
+// ListUnterTraeger nennt die Arbeitskreise unter einem Dach, nach Namen.
+func (d *DB) ListUnterTraeger(parentID int64) ([]model.Traeger, error) {
+	rows, err := d.sql.Query(`SELECT `+traegerSpalten+` FROM traeger WHERE parent_id=? ORDER BY name`, parentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []model.Traeger{}
+	for rows.Next() {
+		t, err := scanTraeger(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *t)
+	}
+	return out, rows.Err()
 }
 
 // DeleteTraeger gibt es bewusst nicht: An einem Träger hängen Orte, Aufgaben
@@ -229,7 +299,7 @@ func scanTraeger(row scannable) (*model.Traeger, error) {
 	var t model.Traeger
 	var status, sicht, created string
 	if err := row.Scan(&t.ID, &t.Schluessel, &t.ProjektID, &t.Name, &t.Beschreibung,
-		&status, &sicht, &created); err != nil {
+		&status, &sicht, &t.ParentID, &created); err != nil {
 		return nil, err
 	}
 	t.Status = model.TraegerStatus(status)

--- a/backend/internal/db/traeger_test.go
+++ b/backend/internal/db/traeger_test.go
@@ -210,3 +210,97 @@ func TestFrischeDatenbankLegtErstBeiBedarfAn(t *testing.T) {
 		t.Fatalf("nicht dem Platzhalter zugeordnet: %+v %v", dek, err)
 	}
 }
+
+// --- Arbeitskreise unter einem Dach -----------------------------------------
+
+// Ein Arbeitskreis ist ein eigener Träger mit eigenem Zitadel-Projekt, der
+// unter einem Verein arbeitet. Der Verein bleibt sein Dach; verwaltet wird er
+// von seinen eigenen Admins.
+func TestUnterTraegerHatEinDach(t *testing.T) {
+	d := testDB(t)
+	verein := testTraeger(t, d, "Dorfpflege", "377270137180389479")
+
+	ak := model.Traeger{
+		Name: "AK 2 Umwelt und Natur", ProjektID: "388659726272954563",
+		ParentID: verein.ID, Status: model.TraegerZugelassen,
+		Sichtbarkeit: model.TraegerOffen, CreatedAt: time.Now().UTC(),
+	}
+	if err := d.InsertTraeger(&ak); err != nil {
+		t.Fatalf("Arbeitskreis anlegen: %v", err)
+	}
+
+	gelesen, err := d.GetTraeger(ak.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gelesen.ParentID != verein.ID {
+		t.Fatalf("Dach verloren: %+v", gelesen)
+	}
+	if !gelesen.IstUnterTraeger() {
+		t.Errorf("sollte ein Unter-Träger sein: %+v", gelesen)
+	}
+
+	unter, err := d.ListUnterTraeger(verein.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unter) != 1 || unter[0].ID != ak.ID {
+		t.Fatalf("Arbeitskreise unter dem Verein: %+v", unter)
+	}
+
+	// Der Verein selbst steht unter keinem Dach — und trägt sich nicht selbst.
+	if oben, err := d.GetTraeger(verein.ID); err != nil || oben.IstUnterTraeger() {
+		t.Fatalf("der Verein hat ein Dach bekommen: %+v (%v)", oben, err)
+	}
+}
+
+// Genau eine Ebene: Verein über Arbeitskreis. Alles darunter wäre ein Baum,
+// den niemand hat, und jede Abfrage bräuchte eine Zyklusprüfung.
+func TestDreiteEbeneWirdAbgelehnt(t *testing.T) {
+	d := testDB(t)
+	verein := testTraeger(t, d, "Dorfpflege", "1")
+
+	ak := model.Traeger{Name: "AK 2", ParentID: verein.ID, Status: model.TraegerZugelassen,
+		Sichtbarkeit: model.TraegerOffen, CreatedAt: time.Now().UTC()}
+	if err := d.InsertTraeger(&ak); err != nil {
+		t.Fatal(err)
+	}
+
+	untergruppe := model.Traeger{Name: "Untergruppe", ParentID: ak.ID,
+		Status: model.TraegerZugelassen, Sichtbarkeit: model.TraegerOffen,
+		CreatedAt: time.Now().UTC()}
+	if err := d.InsertTraeger(&untergruppe); err == nil {
+		t.Fatal("eine dritte Ebene wurde angenommen")
+	}
+
+	// Und andersherum: Wer schon Arbeitskreise trägt, zieht nicht selbst
+	// unter ein Dach — sonst stünde am Ende doch etwas auf der dritten Ebene.
+	anderer := testTraeger(t, d, "DRK", "2")
+	verein.ParentID = anderer.ID
+	if err := d.UpdateTraeger(&verein); err == nil {
+		t.Fatal("ein Dach durfte unter ein anderes ziehen")
+	}
+}
+
+func TestDachMussEsGeben(t *testing.T) {
+	d := testDB(t)
+	waise := model.Traeger{Name: "AK ohne Verein", ParentID: 999,
+		Status: model.TraegerZugelassen, Sichtbarkeit: model.TraegerOffen,
+		CreatedAt: time.Now().UTC()}
+	if err := d.InsertTraeger(&waise); err == nil {
+		t.Fatal("ein Dach, das es nicht gibt, wurde angenommen")
+	}
+}
+
+// Der Bestand hat kein Dach und soll auch keins bekommen: Die Migration
+// setzt die Spalte auf 0, und daran ändert sich beim Lesen nichts.
+func TestBestandBleibtOhneDach(t *testing.T) {
+	d := testDB(t)
+	dek, err := d.TraegerSicherstellen(model.SchluesselDEK, model.NameDEK)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dek.IstUnterTraeger() {
+		t.Fatalf("der Dorfentwicklungskreis hat ein Dach bekommen: %+v", dek)
+	}
+}

--- a/backend/internal/model/traeger.go
+++ b/backend/internal/model/traeger.go
@@ -75,8 +75,25 @@ type Traeger struct {
 	Beschreibung string              `json:"beschreibung"`
 	Status       TraegerStatus       `json:"status"`
 	Sichtbarkeit TraegerSichtbarkeit `json:"sichtbarkeit"`
-	CreatedAt    time.Time           `json:"createdAt"`
+	// ParentID nennt das Dach, unter dem dieser Träger arbeitet — 0 heißt:
+	// keins. So wird aus einem Arbeitskreis kein Nachbar seines Vereins.
+	//
+	// Genau **eine** Ebene, nicht beliebig tief (siehe ParentID-Prüfung in
+	// der Ablage): Verein → Arbeitskreis ist das, was es im Dorf gibt. Tiefer
+	// zu schachteln kostet Zyklusprüfungen und rekursive Abfragen für einen
+	// Fall, den niemand hat.
+	//
+	// Eigenständig bleibt er trotzdem: eigenes Zitadel-Projekt, eigene
+	// Mitglieder, eigene Admins. Wer den AK 2 verwalten darf, verwaltet
+	// deshalb **nicht** den Verein darüber — und umgekehrt genauso wenig.
+	// Das ist der ganze Grund, warum ein Arbeitskreis ein eigener Träger ist
+	// und kein Feld am Verein.
+	ParentID  int64     `json:"parentId,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
 }
+
+// IstUnterTraeger sagt, ob dieser Träger unter einem Dach arbeitet.
+func (t Traeger) IstUnterTraeger() bool { return t.ParentID != 0 }
 
 // Zugelassen sagt, ob der Träger überhaupt in Erscheinung treten darf.
 func (t Traeger) Zugelassen() bool { return t.Status == TraegerZugelassen }
@@ -98,6 +115,13 @@ func (t *Traeger) Validate() error {
 	// Tippfehler und liefe später still ins Leere.
 	if t.ProjektID != "" && strings.Trim(t.ProjektID, "0123456789") != "" {
 		return errors.New("projektId muss die numerische Zitadel-Projekt-ID sein")
+	}
+	if t.ParentID < 0 {
+		return errors.New("parentId muss ein Träger sein")
+	}
+	// Ein Träger unter sich selbst wäre kein Dach, sondern ein Kreis.
+	if t.ParentID != 0 && t.ParentID == t.ID {
+		return errors.New("ein Träger kann nicht sein eigenes Dach sein")
 	}
 	return nil
 }

--- a/backend/internal/model/traeger_test.go
+++ b/backend/internal/model/traeger_test.go
@@ -223,3 +223,26 @@ func TestGeschlosseneGruppeVerraetIhrenNamenNicht(t *testing.T) {
 		t.Errorf("offene Gruppe verdeckt ihren Namen: %q", got)
 	}
 }
+
+// Ein Träger unter sich selbst wäre kein Dach, sondern ein Kreis. Die
+// Prüfung, ob es das Dach überhaupt gibt und ob es selbst unter einem steht,
+// braucht den Bestand und sitzt deshalb in der Ablage — hier steht nur, was
+// sich am Datensatz allein entscheiden lässt.
+func TestTraegerIstNichtSeinEigenesDach(t *testing.T) {
+	tr := Traeger{ID: 7, ParentID: 7, Name: "AK 2",
+		Status: TraegerZugelassen, Sichtbarkeit: TraegerOffen}
+	if err := tr.Validate(); err == nil {
+		t.Fatal("ein Träger durfte sein eigenes Dach sein")
+	}
+}
+
+func TestTraegerOhneDachIstGueltig(t *testing.T) {
+	tr := Traeger{ID: 7, Name: "Dorfpflege",
+		Status: TraegerZugelassen, Sichtbarkeit: TraegerOffen}
+	if err := tr.Validate(); err != nil {
+		t.Fatalf("ein Träger ohne Dach wurde abgewiesen: %v", err)
+	}
+	if tr.IstUnterTraeger() {
+		t.Error("ohne parentId ist er kein Unter-Träger")
+	}
+}


### PR DESCRIPTION
Erster Teil von #55. Modell und Ablage — Web-Verwaltung und MCP kommen im nächsten Schritt.

## Warum

Die Dorfpflege Rössing e.V. soll als Träger geführt werden und **darin** der AK 2 (Umwelt und Natur) — er gießt die Blumenkästen, jätet das Beet vor dem Dorfgemeinschaftshaus und versorgt zwei Streuobstwiesen. Bisher wären die beiden Nachbarn im Verzeichnis gewesen, nicht Verein und Arbeitskreis.

Ein Träger bekommt deshalb ein `parent_id`.

## Was er ausdrücklich *nicht* bekommt

**Gemeinsame Verwaltung.** Der Arbeitskreis behält sein eigenes Zitadel-Projekt, seine eigenen Mitglieder und seine eigenen Admins. Genau darum geht es: Olaf soll den AK 2 verwalten können, **ohne** den ganzen Verein zu verwalten — und die `admin`-Rolle des jeweiligen Projekts ist das einzige Mittel dafür. Rechte vererben sich in keine Richtung.

Das ist die vorsichtige Vorbelegung, nicht die endgültige Antwort: Wer später will, dass der Vereins-Admin auch seine Arbeitskreise verwaltet, kann das hinzufügen, ohne jemandem etwas wegzunehmen. Andersherum wäre es eine Rechte-Entziehung.

## Genau eine Ebene

Verein über Arbeitskreis, mehr nicht. Die Ablage hält das durch — vier Regeln, vier Tests:

- Ein Dach steht nicht selbst unter einem Dach.
- Wer schon Arbeitskreise trägt, zieht nicht selbst unter eines (sonst stünde am Ende doch etwas auf der dritten Ebene).
- Ein Träger ist nicht sein eigenes Dach.
- Ein Dach, das es nicht gibt, wird abgewiesen.

Tiefer zu schachteln kostet Zyklusprüfungen und rekursive Abfragen für einen Fall, den im Dorf niemand hat. Die Strukturprüfung sitzt in der Ablage und nicht in `Validate`, weil sie den Bestand kennen muss; was sich am Datensatz allein entscheiden lässt (Selbstbezug), steht weiter im Modell.

## Bestand

Die Spalte kommt rein additiv mit Vorbelegung `0` dazu — für jeden bestehenden Träger ändert sich nichts. Ein Test hält fest, dass der Dorfentwicklungskreis nach der Migration kein Dach bekommt.

## Geprüft

`gofmt`, `go vet ./...`, `go test ./...` — alles grün. `pruefe_lokale_tests.py`: 74 Dateien, kein Zugriff nach draußen.

## In Zitadel liegt es bereit

| Träger | Projekt-ID |
| --- | --- |
| Dorfpflege | `377270137180389479` |
| Dorfpflege – AK 2 Umwelt und Natur | `388659726272954563` |

Beide mit den Rollen `admin` und `mitglied`; die 14 Bestandsmitglieder der Dorfpflege trugen bis dahin nur die Rolle `mitglieder`, die der Quelltext gar nicht kennt, und tragen jetzt zusätzlich `mitglied`.