### PR TITLE
Android: Der Maschinchenring wohnt jetzt in der Dorf-App

### DIFF
--- a/.github/scripts/pruefe_lokale_tests.py
+++ b/.github/scripts/pruefe_lokale_tests.py
@@ -73,6 +73,7 @@ ENDUNGEN = {".kt", ".java", ".swift", ".go", ".mjs", ".js", ".ts", ".sh", ".yml"
 VERBOTENE_DIENSTE = [
     (r"id\.xn--rssing-wxa\.de", "Produktions-Zitadel (Rössing-ID)"),
     (r"app\.xn--rssing-wxa\.de", "Produktions-Backend der Dorf-App"),
+    (r"mieten\.xn--rssing-wxa\.de", "Produktions-Mietplattform (Maschinchenring)"),
     (r"tiles\.openfreemap\.org", "fremder Kachelserver"),
     (r"fcm\.googleapis\.com", "Firebase Cloud Messaging"),
     # Beide Apple-Adressen einzeln: „api.sandbox.push.apple.com" enthält
@@ -93,7 +94,7 @@ ENDPUNKT_MUSTER = re.compile(
 FREIGABE = re.compile(r"ci-extern-ok:")
 
 # 3) Jeder Testlauf muss diese Adressen lokal setzen.
-PFLICHT_UEBERSTEUERUNGEN = ["-PapiBaseUrl", "-PwebsiteBaseUrl", "-PmapStyleUrl"]
+PFLICHT_UEBERSTEUERUNGEN = ["-PapiBaseUrl", "-PwebsiteBaseUrl", "-PmapStyleUrl", "-PmietenBaseUrl"]
 
 # Dasselbe für iOS: Die Build-Einstellungen aus `ios/project.yml` zeigen auf die
 # Produktion, jeder `xcodebuild`-Aufruf der CI muss sie übersteuern.
@@ -305,6 +306,8 @@ def selbsttest() -> int:
     faelle = [
         ("android/app/src/androidTest/Boese.kt", 'val issuer = "https://id.xn--rssing-wxa.de"', True),
         ("backend/e2e/boese.mjs", "const s = 'https://tiles.openfreemap.org/styles/liberty'", True),
+        ("android/app/src/test/Boese.kt", 'val basis = "https://mieten.xn--rssing-wxa.de"', True),
+        ("android/e2e/fixtures/mieten/gut.json", '{"webUrl": "https://mieten.example.invalid/x/"}', False),
         ("backend/e2e/boese.go", 'ziel := "https://api.push.apple.com/3/device/" + token', True),
         ("backend/e2e/boese.go", 'ziel := "https://api.sandbox.push.apple.com/3/device/" + token', True),
         ("backend/e2e/gut.go", 'ziel := srv.URL + "/3/device/" + token', False),

--- a/README.md
+++ b/README.md
@@ -270,6 +270,34 @@ keine der beiden Apps noch einmal.
   Erinnerung wäre ein eigenes Thema mit eigener Einwilligung.
   Termine mit Koordinaten sind für die Dorfkarte vorbereitet; Koordinaten
   pflegt die Website an den Orten (`geo` in `src/data/locations/*.yaml`).
+- **Verleih** („Maschinchenring"): Nachbarn verleihen ihre Geräte an
+  Nachbarn. Der Dienst läuft unter `https://mieten.xn--rssing-wxa.de` mit
+  eigenem Backend; die App redet **unmittelbar** mit ihm, das Dorf-Backend ist
+  kein Weiterleiter und weiß nichts davon — derselbe Zuschnitt wie bei den
+  Veranstaltungen, nur dass hier ein Token mitgeht. Der Vertrag steht in
+  `docs/mieten-api.md` und ist die einzige Quelle für die Datenform.
+  **Ansehen und suchen geht ohne Anmeldung** (Geräteliste, Detail, Suche,
+  belegte Zeiträume und Verfügbarkeit sind drüben öffentlich, so wie auf ihrer
+  Webseite) — der Bereich ist deshalb auch vom Anmeldeschirm aus erreichbar.
+  Mit der Rössing-ID kommen die eigenen Buchungen dazu: anfragen, ansehen,
+  stornieren. **Die App enthält keine Regeln des Verleihs**: Ob ein Zeitraum
+  frei ist, sagt `GET /api/v1/availability`; ob storniert werden darf, sagt
+  `canCancel`. Die Tarife stehen einzeln da und werden **nicht** zu einer
+  Summe verrechnet — welcher bei welcher Dauer gilt, legt die Mietplattform
+  nirgends fest. Zeiträume sind halboffen: `endDate` ist der Rückgabetag.
+  Ist die Mietplattform nicht erreichbar, steht ein Hinweis über der
+  (womöglich älteren) Liste statt einer leeren Seite.
+  Damit ein Token drüben gilt, muss ihr Zitadel-Projekt in der `aud` stehen —
+  angefordert über den Scope `urn:zitadel:iam:org:project:id:<id>:aud`
+  (Android: `LOGIN_SCOPES`, Kennung aus `BuildConfig.MIETEN_PROJECT_ID`).
+  **Ein Gerät, das schon angemeldet war, behält seinen Token-Satz über die
+  Aktualisierung hinweg** und bekommt von der Mietplattform `401`
+  (`token_audience`). Die App sieht deshalb vor jeder angemeldeten Anfrage in
+  ihr eigenes Token (`auth/RentalAudience.kt`) und bittet um eine **erneute
+  Anmeldung**, statt eine leere Liste zu zeigen; die bestehende Anmeldung
+  bleibt dabei stehen, falls der Browser abgebrochen wird.
+  **Geräte anlegen und pflegen** gibt es in der App bewusst nicht — das läuft
+  über den Chat und die Webfassung der Mietplattform.
 - **Spielschutz**: Nach einer Erledigung bleibt dieselbe Aufgabe gesperrt —
   50 % des Soll-Intervalls (beim Gießen mit dem Hitzefaktor skaliert, bei
   Jäten & Co. nicht), mindestens 12 Stunden, höchstens das volle Intervall.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -43,6 +43,21 @@ android {
             "WEBSITE_BASE_URL",
             "\"${prop("websiteBaseUrl", "https://xn--rssing-wxa.de")}\"",
         )
+        // Die Mietplattform („Maschinchenring") ist ein eigener Dienst; die App
+        // redet unmittelbar mit ihr, das Dorf-Backend weiß nichts davon.
+        buildConfigField(
+            "String",
+            "MIETEN_BASE_URL",
+            "\"${prop("mietenBaseUrl", "https://mieten.xn--rssing-wxa.de")}\"",
+        )
+        // Zitadel-Projekt der Mietplattform. Es muss in der `aud` des Tokens
+        // stehen, sonst weist sie jede angemeldete Anfrage ab — angefordert
+        // wird das über einen Scope, siehe auth/RentalAudience.kt.
+        buildConfigField(
+            "String",
+            "MIETEN_PROJECT_ID",
+            "\"${prop("mietenProjectId", "377276525071827047")}\"",
+        )
         buildConfigField("String", "OIDC_ISSUER", "\"${prop("oidcIssuer", "https://id.xn--rssing-wxa.de")}\"")
         buildConfigField("String", "OIDC_CLIENT_ID", "\"${prop("oidcClientId", "385941807986376899")}\"")
         buildConfigField("String", "OIDC_REDIRECT_URI", "\"de.roessing.app:/oauth2redirect\"")

--- a/android/app/src/androidTest/java/de/roessing/app/RentalUiTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/RentalUiTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -294,7 +295,13 @@ class RentalUiTest {
         compose.onNodeWithTag("rental-book").performScrollTo().assertIsNotEnabled()
     }
 
-    /** Die Beschreibung kommt als Markdown und wird als Klartext gezeigt. */
+    /**
+     * Die Beschreibung kommt als Markdown und wird als Klartext gezeigt.
+     *
+     * Geprüft wird am Blatt, nicht am Wortlaut: Die Kachel in der Liste zeigt
+     * dieselbe Beschreibung (nur gekürzt), und ein Text kommt damit zweimal
+     * in der Oberfläche vor.
+     */
     @Test
     fun eineBeschreibungStehtOhneSternchenDa() {
         zeigeApp(FakeRental(devices = listOf(maeher)))
@@ -303,12 +310,18 @@ class RentalUiTest {
         compose.onNodeWithTag("device-${maeher.id}").performClick()
         compose.waitForIdle()
 
-        compose.onNodeWithText("• Arbeitsbreite 85 cm", substring = true).assertIsDisplayed()
+        compose.onNodeWithTag("device-description")
+            .assertTextContains("• Arbeitsbreite 85 cm", substring = true)
     }
 
     /**
      * Der Weg nach draußen führt in den Browser — im Test in ein Notizbuch,
      * sonst wäre die App im Hintergrund und der Test ohne Oberfläche.
+     *
+     * Der Verweis steht im Blatt zum Gerät, und ein Blatt ist ein eigenes
+     * Fenster: Dort drinnen belegt Compose `LocalUriHandler` selbst wieder mit
+     * dem Browser des Systems. Dieser Fall prüft mit, dass der Bereich den Weg
+     * nach draußen davor nachschlägt — sonst geht hier wirklich Chromium auf.
      */
     @Test
     fun derWegZurWebfassungFuehrtNachDraussen() {

--- a/android/app/src/androidTest/java/de/roessing/app/RentalUiTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/RentalUiTest.kt
@@ -1,0 +1,357 @@
+package de.roessing.app
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import de.roessing.app.auth.RentalSignIn
+import de.roessing.app.data.BookingRequest
+import de.roessing.app.data.BookingStatus
+import de.roessing.app.data.CompletionDto
+import de.roessing.app.data.LeaderboardDto
+import de.roessing.app.data.LenderStatus
+import de.roessing.app.data.MeDto
+import de.roessing.app.data.MemberDto
+import de.roessing.app.data.OccupancyStatus
+import de.roessing.app.data.PlacesRepository
+import de.roessing.app.data.PlacesResponse
+import de.roessing.app.data.ProfileDto
+import de.roessing.app.data.ProfileInput
+import de.roessing.app.data.ProfileRepository
+import de.roessing.app.data.RentalAvailability
+import de.roessing.app.data.RentalBooking
+import de.roessing.app.data.RentalDevice
+import de.roessing.app.data.RentalDeviceDetail
+import de.roessing.app.data.RentalOccupancy
+import de.roessing.app.data.RentalPeriod
+import de.roessing.app.data.RentalPickup
+import de.roessing.app.data.RentalProfile
+import de.roessing.app.data.RentalRepository
+import de.roessing.app.data.StatsRepository
+import de.roessing.app.ui.HomeScreen
+import de.roessing.app.ui.IdeenViewModel
+import de.roessing.app.ui.LeaderboardViewModel
+import de.roessing.app.ui.PlacesViewModel
+import de.roessing.app.ui.ProfileViewModel
+import de.roessing.app.ui.RentalViewModel
+import de.roessing.app.ui.theme.DorfAppTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+import java.time.LocalDate
+
+/**
+ * Der „Maschinchenring" in der App: Von der Startseite führt eine Kachel zu
+ * den Geräten, die eigenen Buchungen stehen darüber, und wenn die
+ * Mietplattform gerade nicht erreichbar ist, steht ein Hinweis über der
+ * zuletzt geholten Liste statt einer leeren Seite.
+ *
+ * Der Bereich redet mit einem eigenen Dienst; hier steht an dessen Stelle ein
+ * Doppel im selben Prozess. Kein Netz, kein entfernter Server.
+ */
+@RunWith(AndroidJUnit4::class)
+class RentalUiTest {
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private class FakePlaces : PlacesRepository {
+        override suspend fun me() = MeDto(sub = "erna", name = "Erna Beispiel")
+        override suspend fun places() = PlacesResponse(places = emptyList())
+        override suspend fun complete(taskId: Long, liters: Double?, note: String) = CompletionDto()
+        override suspend fun completions(taskId: Long): List<CompletionDto> = emptyList()
+    }
+
+    private class FakeStats : StatsRepository {
+        override suspend fun leaderboard(period: String) = LeaderboardDto(period = period)
+    }
+
+    private class FakeProfile : ProfileRepository {
+        override suspend fun profile() = ProfileDto(userSub = "erna", displayName = "Erna Beispiel")
+        override suspend fun saveProfile(input: ProfileInput) = profile()
+        override suspend fun members(): Pair<List<MemberDto>, Boolean> = emptyList<MemberDto>() to false
+    }
+
+    /** Die Mietplattform als Doppel — sie antwortet, sie entscheidet. */
+    private class FakeRental(
+        private val devices: List<RentalDevice> = emptyList(),
+        private val bookings: List<RentalBooking> = emptyList(),
+        private val available: Boolean = true,
+        private val fehler: Boolean = false,
+    ) : RentalRepository {
+        var letzteAnfrage: BookingRequest? = null
+
+        override suspend fun devices(): List<RentalDevice> {
+            if (fehler) throw IOException("kein Netz")
+            return devices
+        }
+
+        override suspend fun device(id: String) = RentalDeviceDetail(
+            device = devices.first { it.id == id },
+            images = emptyList(),
+        )
+
+        override suspend fun search(query: String): List<RentalDevice> {
+            if (fehler) throw IOException("kein Netz")
+            return devices.filter { it.name.contains(query, ignoreCase = true) }
+        }
+
+        override suspend fun occupancy(deviceId: String) = listOf(
+            RentalOccupancy(
+                deviceId = deviceId,
+                setId = null,
+                period = RentalPeriod(
+                    LocalDate.parse("2026-09-12"),
+                    LocalDate.parse("2026-09-14"),
+                ),
+                status = OccupancyStatus.APPROVED,
+            ),
+        )
+
+        override suspend fun availability(deviceId: String, period: RentalPeriod) =
+            RentalAvailability(period, available, if (available) null else "occupied")
+
+        override suspend fun profile() = RentalProfile(
+            name = "Erna Beispiel",
+            email = "erna@example.invalid",
+            phone = "+49 5069 123456",
+            addressStreet = "Kirchstraße 3",
+            addressZip = "31171",
+            addressCity = "Nordstemmen",
+            lender = false,
+            lenderStatus = LenderStatus.NONE,
+            profileComplete = true,
+            missingFields = emptyList(),
+        )
+
+        override suspend fun myBookings() = bookings
+
+        override suspend fun book(request: BookingRequest): RentalBooking {
+            letzteAnfrage = request
+            return bookings.first()
+        }
+
+        override suspend fun cancel(bookingId: String) = Unit
+    }
+
+    private val maeher = RentalDevice(
+        id = "as-585-km-kreiselmaeher",
+        name = "AS 585 KM Kreiselmäher",
+        description = "Für hohes Gras und Böschungen.\n\n- Arbeitsbreite 85 cm",
+        pricePerDay = 25.0,
+        pricePerWeekend = 40.0,
+        pricePerWeek = null,
+        deposit = 100.0,
+        tags = listOf("garten"),
+        thumbnailUrl = null,
+        productUrl = null,
+        webUrl = "https://mieten.example.invalid/geraete/as-585-km-kreiselmaeher/",
+    )
+
+    private val walze = RentalDevice(
+        id = "rasenwalze",
+        name = "Rasenwalze",
+        description = null,
+        pricePerDay = 8.0,
+        pricePerWeekend = null,
+        pricePerWeek = null,
+        deposit = null,
+        tags = listOf("garten"),
+        thumbnailUrl = null,
+        productUrl = null,
+        webUrl = null,
+    )
+
+    private val buchung = RentalBooking(
+        id = "b-4711",
+        deviceId = maeher.id,
+        setId = null,
+        deviceName = maeher.name,
+        period = RentalPeriod(LocalDate.parse("2026-09-05"), LocalDate.parse("2026-09-07")),
+        status = BookingStatus.APPROVED,
+        rawStatus = "approved",
+        notes = null,
+        canCancel = true,
+        pickup = RentalPickup("Hauptstraße 1, 31171 Nordstemmen", "+49 5069 123456"),
+    )
+
+    /**
+     * Wohin die App hinausgeführt hat. Der echte UriHandler würde den Browser
+     * starten — die App wäre im Hintergrund und der Test fände seine
+     * Oberfläche nicht mehr wieder. Hier wird nur mitgeschrieben.
+     */
+    private val hinausgefuehrt = mutableListOf<String>()
+
+    private val notizbuch = object : UriHandler {
+        override fun openUri(uri: String) {
+            hinausgefuehrt += uri
+        }
+    }
+
+    private fun zeigeApp(repo: RentalRepository, anmeldung: RentalSignIn = RentalSignIn.VALID) {
+        compose.setContent {
+            DorfAppTheme {
+                CompositionLocalProvider(LocalUriHandler provides notizbuch) {
+                    HomeScreen(
+                        viewModel = PlacesViewModel(FakePlaces(), FakeVergabeRepo()),
+                        leaderboardViewModel = LeaderboardViewModel(FakeStats()),
+                        profileViewModel = ProfileViewModel(FakeProfile()),
+                        ideenViewModel = IdeenViewModel(FakeIdeen()),
+                        rentalViewModel = RentalViewModel(repo, signIn = { anmeldung }),
+                        onLogout = {},
+                        onReauthenticate = {},
+                    )
+                }
+            }
+        }
+        compose.waitForIdle()
+    }
+
+    private fun zumVerleih() {
+        compose.onNodeWithTag("bereich-verleih").performScrollTo().performClick()
+        compose.waitForIdle()
+        compose.onNodeWithTag("rental").assertIsDisplayed()
+    }
+
+    @Test
+    fun kachelAufDerStartseiteFuehrtZumMaschinchenring() {
+        zeigeApp(FakeRental(devices = listOf(maeher, walze)))
+
+        compose.onNodeWithTag("bereich-verleih").performScrollTo().assertIsDisplayed()
+        zumVerleih()
+
+        compose.onNodeWithTag("device-${maeher.id}").assertIsDisplayed()
+        compose.onNodeWithTag("device-${walze.id}").assertIsDisplayed()
+    }
+
+    /** Der Preis steht als Tarif da — die App rechnet keine Summe daraus. */
+    @Test
+    fun einGeraetZeigtSeinenTagespreis() {
+        zeigeApp(FakeRental(devices = listOf(maeher)))
+        zumVerleih()
+
+        compose.onNodeWithText("25 € pro Tag").assertIsDisplayed()
+    }
+
+    @Test
+    fun ohneNetzStehtEinHinweisStattEinerLeerenSeite() {
+        zeigeApp(FakeRental(fehler = true))
+        zumVerleih()
+
+        compose.onNodeWithTag("rental-offline").assertIsDisplayed()
+    }
+
+    @Test
+    fun eigeneBuchungenStehenUeberDenGeraeten() {
+        zeigeApp(FakeRental(devices = listOf(maeher), bookings = listOf(buchung)))
+        zumVerleih()
+
+        compose.onNodeWithTag("booking-b-4711").performScrollTo().assertIsDisplayed()
+        // Die Abholadresse steht erst nach der Zusage da — hier steht sie.
+        compose.onNodeWithText("Hauptstraße 1, 31171 Nordstemmen").assertIsDisplayed()
+        compose.onNodeWithTag("booking-cancel-b-4711").assertIsDisplayed()
+    }
+
+    /**
+     * Der Sonderfall, der wie ein Defekt aussieht: Das Gerät ist angemeldet,
+     * aber mit einem Token von vor der Umstellung. Statt einer leeren Liste
+     * steht dort ein Satz, den jemand befolgen kann.
+     */
+    @Test
+    fun einVeraltetesTokenBittetUmEineNeueAnmeldung() {
+        zeigeApp(FakeRental(devices = listOf(maeher)), anmeldung = RentalSignIn.STALE)
+        zumVerleih()
+
+        compose.onNodeWithTag("rental-stale").assertIsDisplayed()
+        compose.onNodeWithTag("rental-stale-signin").assertIsDisplayed()
+        // Die Geräte sind öffentlich und stehen trotzdem da.
+        compose.onNodeWithTag("device-${maeher.id}").assertIsDisplayed()
+    }
+
+    /**
+     * Ohne Zeitraum ist nichts anzufragen — und das ist keine Regel der App,
+     * sondern schlicht eine unvollständige Anfrage.
+     */
+    @Test
+    fun ohneZeitraumBleibtDerAnfrageknopfAus() {
+        zeigeApp(FakeRental(devices = listOf(maeher)))
+        zumVerleih()
+
+        compose.onNodeWithTag("device-${maeher.id}").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithTag("device-detail").assertIsDisplayed()
+        compose.onNodeWithTag("rental-book").performScrollTo().assertIsNotEnabled()
+    }
+
+    /** Die Beschreibung kommt als Markdown und wird als Klartext gezeigt. */
+    @Test
+    fun eineBeschreibungStehtOhneSternchenDa() {
+        zeigeApp(FakeRental(devices = listOf(maeher)))
+        zumVerleih()
+
+        compose.onNodeWithTag("device-${maeher.id}").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("• Arbeitsbreite 85 cm", substring = true).assertIsDisplayed()
+    }
+
+    /**
+     * Der Weg nach draußen führt in den Browser — im Test in ein Notizbuch,
+     * sonst wäre die App im Hintergrund und der Test ohne Oberfläche.
+     */
+    @Test
+    fun derWegZurWebfassungFuehrtNachDraussen() {
+        zeigeApp(FakeRental(devices = listOf(maeher)))
+        zumVerleih()
+
+        compose.onNodeWithTag("device-${maeher.id}").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithTag("rental-web").performScrollTo().performClick()
+        compose.waitForIdle()
+
+        assertEquals(listOf(maeher.webUrl), hinausgefuehrt)
+    }
+
+    @Test
+    fun belegteZeitraeumeStehenAmGeraet() {
+        zeigeApp(FakeRental(devices = listOf(maeher)))
+        zumVerleih()
+
+        compose.onNodeWithTag("device-${maeher.id}").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithText("12.–13. September 2026 (vergeben)").assertIsDisplayed()
+    }
+
+    /** Ohne Anmeldung gibt es keine Buchungen und keinen Anfrageknopf. */
+    @Test
+    fun ohneAnmeldungBleibtDasBuchenZu() {
+        zeigeApp(FakeRental(devices = listOf(maeher)), anmeldung = RentalSignIn.MISSING)
+        zumVerleih()
+
+        compose.onNodeWithTag("device-${maeher.id}").assertIsDisplayed()
+        compose.onNodeWithTag("booking-b-4711").assertDoesNotExist()
+    }
+
+    @Test
+    fun einAnfrageknopfWirdErstFreiWennDerServerFreiSagt() {
+        zeigeApp(FakeRental(devices = listOf(maeher), bookings = listOf(buchung)))
+        zumVerleih()
+        compose.onNodeWithTag("device-${maeher.id}").performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithTag("rental-pick-period").performScrollTo().assertIsEnabled()
+        compose.onNodeWithTag("rental-book").performScrollTo().assertIsNotEnabled()
+    }
+}

--- a/android/app/src/androidTest/java/de/roessing/app/RentalUiTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/RentalUiTest.kt
@@ -8,11 +8,13 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToNode
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import de.roessing.app.auth.RentalSignIn
 import de.roessing.app.data.BookingRequest
@@ -224,6 +226,25 @@ class RentalUiTest {
         compose.onNodeWithTag("rental").assertIsDisplayed()
     }
 
+    /** Blättert zu einer Gerätekachel und stellt fest, dass sie da ist. */
+    private fun geraetIstDa(id: String) {
+        compose.onNodeWithTag("rental-list").performScrollToNode(hasTestTag("device-$id"))
+        compose.onNodeWithTag("device-$id").assertIsDisplayed()
+    }
+
+    /**
+     * Öffnet ein Gerät.
+     *
+     * Erst blättern, dann tippen: Über den Geräten stehen die eigenen
+     * Buchungen, und eine LazyColumn baut nur, was zu sehen ist — eine Kachel
+     * weiter unten gibt es also noch gar nicht, wenn man nach ihr greift.
+     */
+    private fun oeffneGeraet(id: String) {
+        compose.onNodeWithTag("rental-list").performScrollToNode(hasTestTag("device-$id"))
+        compose.onNodeWithTag("device-$id").performClick()
+        compose.waitForIdle()
+    }
+
     @Test
     fun kachelAufDerStartseiteFuehrtZumMaschinchenring() {
         zeigeApp(FakeRental(devices = listOf(maeher, walze)))
@@ -231,8 +252,8 @@ class RentalUiTest {
         compose.onNodeWithTag("bereich-verleih").performScrollTo().assertIsDisplayed()
         zumVerleih()
 
-        compose.onNodeWithTag("device-${maeher.id}").assertIsDisplayed()
-        compose.onNodeWithTag("device-${walze.id}").assertIsDisplayed()
+        geraetIstDa(maeher.id)
+        geraetIstDa(walze.id)
     }
 
     /** Der Preis steht als Tarif da — die App rechnet keine Summe daraus. */
@@ -276,7 +297,7 @@ class RentalUiTest {
         compose.onNodeWithTag("rental-stale").assertIsDisplayed()
         compose.onNodeWithTag("rental-stale-signin").assertIsDisplayed()
         // Die Geräte sind öffentlich und stehen trotzdem da.
-        compose.onNodeWithTag("device-${maeher.id}").assertIsDisplayed()
+        geraetIstDa(maeher.id)
     }
 
     /**
@@ -288,8 +309,7 @@ class RentalUiTest {
         zeigeApp(FakeRental(devices = listOf(maeher)))
         zumVerleih()
 
-        compose.onNodeWithTag("device-${maeher.id}").performClick()
-        compose.waitForIdle()
+        oeffneGeraet(maeher.id)
 
         compose.onNodeWithTag("device-detail").assertIsDisplayed()
         compose.onNodeWithTag("rental-book").performScrollTo().assertIsNotEnabled()
@@ -307,8 +327,7 @@ class RentalUiTest {
         zeigeApp(FakeRental(devices = listOf(maeher)))
         zumVerleih()
 
-        compose.onNodeWithTag("device-${maeher.id}").performClick()
-        compose.waitForIdle()
+        oeffneGeraet(maeher.id)
 
         compose.onNodeWithTag("device-description")
             .assertTextContains("• Arbeitsbreite 85 cm", substring = true)
@@ -328,8 +347,7 @@ class RentalUiTest {
         zeigeApp(FakeRental(devices = listOf(maeher)))
         zumVerleih()
 
-        compose.onNodeWithTag("device-${maeher.id}").performClick()
-        compose.waitForIdle()
+        oeffneGeraet(maeher.id)
         compose.onNodeWithTag("rental-web").performScrollTo().performClick()
         compose.waitForIdle()
 
@@ -341,10 +359,11 @@ class RentalUiTest {
         zeigeApp(FakeRental(devices = listOf(maeher)))
         zumVerleih()
 
-        compose.onNodeWithTag("device-${maeher.id}").performClick()
-        compose.waitForIdle()
+        oeffneGeraet(maeher.id)
 
-        compose.onNodeWithText("12.–13. September 2026 (vergeben)").assertIsDisplayed()
+        compose.onNodeWithText("12.–13. September 2026 (vergeben)")
+            .performScrollTo()
+            .assertIsDisplayed()
     }
 
     /** Ohne Anmeldung gibt es keine Buchungen und keinen Anfrageknopf. */
@@ -353,7 +372,7 @@ class RentalUiTest {
         zeigeApp(FakeRental(devices = listOf(maeher)), anmeldung = RentalSignIn.MISSING)
         zumVerleih()
 
-        compose.onNodeWithTag("device-${maeher.id}").assertIsDisplayed()
+        geraetIstDa(maeher.id)
         compose.onNodeWithTag("booking-b-4711").assertDoesNotExist()
     }
 
@@ -361,8 +380,7 @@ class RentalUiTest {
     fun einAnfrageknopfWirdErstFreiWennDerServerFreiSagt() {
         zeigeApp(FakeRental(devices = listOf(maeher), bookings = listOf(buchung)))
         zumVerleih()
-        compose.onNodeWithTag("device-${maeher.id}").performClick()
-        compose.waitForIdle()
+        oeffneGeraet(maeher.id)
 
         compose.onNodeWithTag("rental-pick-period").performScrollTo().assertIsEnabled()
         compose.onNodeWithTag("rental-book").performScrollTo().assertIsNotEnabled()

--- a/android/app/src/androidTest/java/de/roessing/app/StartNavigationTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/StartNavigationTest.kt
@@ -88,17 +88,19 @@ class StartNavigationTest {
     fun startseite_zeigtDieBereicheStattDerKarte() {
         zeigeApp(listOf(ort(1, "green")))
 
+        // Von oben nach unten gelesen. Die Startseite wächst mit jedem
+        // Bereich, und was gestern noch über der Falz stand, liegt heute
+        // darunter — deshalb steht zuerst, was oben ist, und alles Weitere
+        // wird herangeblättert. Ohne das meldet ein neuer Bereich seinen
+        // Einzug als Fehler in einem Fall, der mit ihm nichts zu tun hat.
+        compose.onNodeWithText("Moin, Erna!").assertIsDisplayed()
         compose.onNodeWithTag("bereich-mithelfen").assertIsDisplayed()
-        compose.onNodeWithTag("bereich-profil").assertIsDisplayed()
-        compose.onNodeWithTag("bereich-dorfbewohner").assertIsDisplayed()
         // Der Reiter-Balken gehört in den Bereich, nicht auf die oberste Ebene.
         compose.onNodeWithTag("tab-map").assertDoesNotExist()
-        // Freundlicher Einstieg mit dem Namen aus dem Profil.
-        compose.onNodeWithText("Moin, Erna!").assertIsDisplayed()
+        compose.onNodeWithTag("bereich-profil").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithTag("bereich-dorfbewohner").performScrollTo().assertIsDisplayed()
         // Kein Versprechen, aber die Einladung, Wünsche zu äußern: Die
-        // Ausblick-Kachel führt inzwischen ins Ideen-Formular. Sie steht ganz
-        // unten und liegt auf kleinen Bildschirmen unter dem sichtbaren
-        // Bereich — deshalb erst scrollen.
+        // Ausblick-Kachel führt inzwischen ins Ideen-Formular.
         compose.onNodeWithTag("bereich-ideen").performScrollTo().assertIsDisplayed()
     }
 
@@ -150,7 +152,7 @@ class StartNavigationTest {
     fun profil_istEinBereichUndZurueckFuehrtHeim() {
         zeigeApp(listOf(ort(1, "green")))
 
-        compose.onNodeWithTag("bereich-profil").performClick()
+        compose.onNodeWithTag("bereich-profil").performScrollTo().performClick()
         compose.waitForIdle()
         compose.onNodeWithTag("sichtbarkeitshinweis").assertIsDisplayed()
 
@@ -163,12 +165,14 @@ class StartNavigationTest {
     fun dorfbewohner_istEinBereichUndZurueckFuehrtHeim() {
         zeigeApp(listOf(ort(1, "green")))
 
-        compose.onNodeWithTag("bereich-dorfbewohner").performClick()
+        compose.onNodeWithTag("bereich-dorfbewohner").performScrollTo().performClick()
         compose.waitForIdle()
         compose.onNodeWithTag("dorfbewohner").assertIsDisplayed()
 
         zurueckDruecken()
 
-        compose.onNodeWithTag("bereich-dorfbewohner").assertIsDisplayed()
+        // Die Startseite steht danach wieder oben — ihre Blätterstellung
+        // überlebt den Ausflug in den Bereich nicht.
+        compose.onNodeWithTag("bereich-dorfbewohner").performScrollTo().assertIsDisplayed()
     }
 }

--- a/android/app/src/main/java/de/roessing/app/DorfApp.kt
+++ b/android/app/src/main/java/de/roessing/app/DorfApp.kt
@@ -3,6 +3,7 @@ package de.roessing.app
 import android.app.Application
 import android.content.Context
 import de.roessing.app.auth.AuthManager
+import de.roessing.app.auth.RentalAudience
 import de.roessing.app.data.ApiChatRepository
 import de.roessing.app.data.ApiDeviceRepository
 import de.roessing.app.data.ApiIdeenRepository
@@ -14,6 +15,9 @@ import de.roessing.app.data.ChatRepository
 import de.roessing.app.data.DeviceRepository
 import de.roessing.app.data.IdeenRepository
 import de.roessing.app.data.DorfApi
+import de.roessing.app.data.MietenApi
+import de.roessing.app.data.MietenRentalRepository
+import de.roessing.app.data.RentalRepository
 import de.roessing.app.data.PlacesRepository
 import de.roessing.app.data.ProfileRepository
 import de.roessing.app.data.StatsRepository
@@ -55,6 +59,20 @@ class AppContainer(context: Context) {
     // Website — dort werden sie gepflegt. Eigener Client, ohne Token.
     val veranstaltungenRepository: VeranstaltungenRepository =
         WebsiteVeranstaltungenRepository(WebsiteApi.create(BuildConfig.WEBSITE_BASE_URL))
+
+    // Der Maschinchenring läuft auf einem eigenen Server. Das Dorf-Backend ist
+    // kein Weiterleiter und weiß von ihm nichts — deshalb ein eigener Client,
+    // wie bei den Veranstaltungen, nur dass hier ein Token mitgeht.
+    val rentalRepository: RentalRepository = MietenRentalRepository(
+        MietenApi.create(BuildConfig.MIETEN_BASE_URL) { authManager.freshToken() },
+        signIn = {
+            RentalAudience.state(authManager.freshToken(), BuildConfig.MIETEN_PROJECT_ID)
+        },
+    )
+
+    /** Wie die Anmeldung dieses Geräts zur Mietplattform steht. */
+    suspend fun rentalSignIn() =
+        RentalAudience.state(authManager.freshToken(), BuildConfig.MIETEN_PROJECT_ID)
 }
 
 val Context.appContainer: AppContainer

--- a/android/app/src/main/java/de/roessing/app/MainActivity.kt
+++ b/android/app/src/main/java/de/roessing/app/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,6 +30,8 @@ import de.roessing.app.ui.LeaderboardViewModel
 import de.roessing.app.ui.LoginScreen
 import de.roessing.app.ui.PlacesViewModel
 import de.roessing.app.ui.ProfileViewModel
+import de.roessing.app.ui.PublicRentalScreen
+import de.roessing.app.ui.RentalViewModel
 import de.roessing.app.ui.VeranstaltungenViewModel
 import de.roessing.app.push.PushZiel
 import de.roessing.app.ui.theme.DorfAppTheme
@@ -77,6 +80,9 @@ private fun Root(pushZiel: PushZiel? = null, onPushZielVerbraucht: () -> Unit = 
     val scope = rememberCoroutineScope()
     // null = kein Fehler. Ein Abbruch (Zurück-Taste) ist bewusst kein Fehler.
     var loginError by remember { mutableStateOf<String?>(null) }
+    // Der Maschinchenring ist der einzige Bereich, den man ohne Anmeldung
+    // ansehen kann — seine Geräteliste ist auch im Web öffentlich.
+    var verleihOhneAnmeldung by remember { mutableStateOf(false) }
 
     val authLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
@@ -89,24 +95,53 @@ private fun Root(pushZiel: PushZiel? = null, onPushZielVerbraucht: () -> Unit = 
         }
     }
 
+    // Die Anmeldung anstoßen. Sie steht hier oben, weil sie an zwei Stellen
+    // gebraucht wird: auf dem Anmeldeschirm und im Maschinchenring, wo ein
+    // Token von vor der Umstellung eine *erneute* Anmeldung verlangt, ohne
+    // die bestehende vorher wegzuwerfen.
+    val anmelden = {
+        loginError = null
+        scope.launch {
+            runCatching { authLauncher.launch(container.authManager.buildLoginIntent()) }
+                .onFailure { loginError = it::class.java.simpleName }
+        }
+        Unit
+    }
+
     when (session) {
         is SessionState.Loading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             CircularProgressIndicator()
         }
 
-        is SessionState.LoggedOut -> LoginScreen(
-            errorCode = loginError,
-            onLogin = {
-                loginError = null
-                scope.launch {
-                    runCatching { authLauncher.launch(container.authManager.buildLoginIntent()) }
-                        .onFailure { loginError = it::class.java.simpleName }
-                }
-            },
-            onDevLogin = { asAdmin ->
-                scope.launch { container.authManager.devLogin(asAdmin) }
-            },
-        )
+        is SessionState.LoggedOut -> {
+            if (verleihOhneAnmeldung) {
+                val verleihVm: RentalViewModel = viewModel(factory = viewModelFactory(container))
+                val verleih by verleihVm.state.collectAsState()
+                LaunchedEffect(Unit) { verleihVm.load() }
+                PublicRentalScreen(
+                    state = verleih,
+                    onBack = { verleihOhneAnmeldung = false },
+                    onSignIn = {
+                        verleihOhneAnmeldung = false
+                        anmelden()
+                    },
+                    onQuery = verleihVm::setQuery,
+                    onRefresh = verleihVm::refresh,
+                    onOpen = verleihVm::open,
+                    onClose = verleihVm::close,
+                    onPeriod = verleihVm::setPeriod,
+                )
+            } else {
+                LoginScreen(
+                    errorCode = loginError,
+                    onLogin = anmelden,
+                    onDevLogin = { asAdmin ->
+                        scope.launch { container.authManager.devLogin(asAdmin) }
+                    },
+                    onBrowseRental = { verleihOhneAnmeldung = true },
+                )
+            }
+        }
 
         is SessionState.LoggedIn -> {
             val factory = viewModelFactory(container)
@@ -116,6 +151,7 @@ private fun Root(pushZiel: PushZiel? = null, onPushZielVerbraucht: () -> Unit = 
             val ideenVm: IdeenViewModel = viewModel(factory = factory)
             val chatVm: ChatViewModel = viewModel(factory = factory)
             val termineVm: VeranstaltungenViewModel = viewModel(factory = factory)
+            val verleihVm: RentalViewModel = viewModel(factory = factory)
             HomeScreen(
                 viewModel = vm,
                 leaderboardViewModel = rangVm,
@@ -123,6 +159,7 @@ private fun Root(pushZiel: PushZiel? = null, onPushZielVerbraucht: () -> Unit = 
                 ideenViewModel = ideenVm,
                 chatViewModel = chatVm,
                 veranstaltungenViewModel = termineVm,
+                rentalViewModel = verleihVm,
                 pushZiel = pushZiel,
                 onPushZielVerbraucht = onPushZielVerbraucht,
                 onLogout = {
@@ -133,6 +170,10 @@ private fun Root(pushZiel: PushZiel? = null, onPushZielVerbraucht: () -> Unit = 
                         container.authManager.logout()
                     }
                 },
+                // Neu anmelden, ohne die bestehende Anmeldung vorher
+                // wegzuwerfen: Bricht jemand im Browser ab, bleibt alles, wie
+                // es war.
+                onReauthenticate = anmelden,
             )
         }
     }
@@ -159,6 +200,12 @@ private fun viewModelFactory(container: AppContainer) =
 
             modelClass.isAssignableFrom(VeranstaltungenViewModel::class.java) ->
                 VeranstaltungenViewModel(container.veranstaltungenRepository) as T
+
+            modelClass.isAssignableFrom(RentalViewModel::class.java) ->
+                RentalViewModel(
+                    container.rentalRepository,
+                    signIn = { container.rentalSignIn() },
+                ) as T
 
             else -> error("Unbekanntes ViewModel: ${modelClass.name}")
         }

--- a/android/app/src/main/java/de/roessing/app/auth/AuthManager.kt
+++ b/android/app/src/main/java/de/roessing/app/auth/AuthManager.kt
@@ -42,12 +42,30 @@ private val Context.authDataStore by preferencesDataStore(name = "auth")
 const val ROLLEN_SCOPE = "urn:zitadel:iam:org:projects:roles"
 
 /**
+ * Der Scope, mit dem das Token auch für die Mietplattform gilt.
+ *
+ * Ein Zitadel-Token gilt nur für die Projekte, die in seiner `aud` stehen.
+ * Die Mietplattform („Maschinchenring") ist ein eigenes Projekt derselben
+ * Rössing-ID; ohne diesen Scope weist sie jede angemeldete Anfrage der App
+ * ab. Die Projektkennung steht in den Build-Einstellungen, nicht hier.
+ */
+val MIETEN_AUDIENCE_SCOPE: String = RentalAudience.scopeFor(BuildConfig.MIETEN_PROJECT_ID)
+
+/**
  * Die Scopes, mit denen sich die App anmeldet.
  *
  * offline_access hält die Sitzung über den Neustart hinweg, die Rollen
- * entscheiden, wer verwalten darf.
+ * entscheiden, wer verwalten darf, und die Empfänger-Angabe macht das Token
+ * zusätzlich für die Mietplattform gültig.
  */
-val LOGIN_SCOPES = listOf("openid", "profile", "email", "offline_access", ROLLEN_SCOPE)
+val LOGIN_SCOPES = listOf(
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    ROLLEN_SCOPE,
+    MIETEN_AUDIENCE_SCOPE,
+)
 
 /**
  * Was die App gerade als Access-Token anbieten kann.

--- a/android/app/src/main/java/de/roessing/app/auth/RentalAudience.kt
+++ b/android/app/src/main/java/de/roessing/app/auth/RentalAudience.kt
@@ -1,0 +1,110 @@
+package de.roessing.app.auth
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import java.util.Base64
+
+/**
+ * Does the access token of this device count for the rental platform?
+ *
+ * Zitadel only puts a second project into the `aud` claim when the app asks
+ * for it, with a scope of the shape
+ * `urn:zitadel:iam:org:project:id:<id>:aud`. Adding that scope is one line —
+ * but it only takes effect at the *next* sign-in. A phone that is already
+ * signed in keeps its set of tokens across the app update, so it keeps
+ * handing out tokens without the new audience, and the rental platform
+ * answers 401 to every one of them.
+ *
+ * The app therefore looks into its own token before it asks: is the project
+ * in there? That is not a business rule — it is the app reading its own
+ * credential — and it means the sentence "please sign in again" appears
+ * before the first pointless round trip rather than after it.
+ *
+ * Deliberately pure functions without Android dependencies, so the whole
+ * decision is covered by plain JVM unit tests.
+ */
+object RentalAudience {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * The scope that makes Zitadel add [projectId] to the `aud` claim.
+     *
+     * The project id belongs in the build settings, never in source — see
+     * `BuildConfig.MIETEN_PROJECT_ID`.
+     */
+    fun scopeFor(projectId: String): String = "urn:zitadel:iam:org:project:id:$projectId:aud"
+
+    /**
+     * The audiences of a JWT access token, or null when the token cannot be
+     * read as a JWT.
+     *
+     * No signature is verified here, and none needs to be: the token was
+     * handed to us by our own [AuthManager], and the only question is which
+     * recipients it names. Whoever forges an `aud` for themselves gains
+     * nothing — the rental platform verifies the signature.
+     *
+     * `aud` is a string or an array of strings (RFC 7519, 4.1.3); both occur
+     * in the wild, so both are read.
+     */
+    fun audiences(token: String): List<String>? {
+        val parts = token.split('.')
+        if (parts.size < 2) return null
+        val payload = runCatching {
+            String(Base64.getUrlDecoder().decode(parts[1]), Charsets.UTF_8)
+        }.getOrNull() ?: return null
+        val claims = runCatching { json.parseToJsonElement(payload) as? JsonObject }
+            .getOrNull() ?: return null
+        return when (val aud = claims["aud"]) {
+            is JsonPrimitive -> listOf(aud.content)
+            is JsonArray -> aud.mapNotNull { (it as? JsonPrimitive)?.content }
+            else -> emptyList()
+        }
+    }
+
+    /**
+     * Whether the token names [projectId] as an audience.
+     *
+     * Returns null when the token is not readable as a JWT. That is not the
+     * same as "no": an opaque token may well be valid over there, and the app
+     * must not tell someone to sign in again on a hunch. In that case the
+     * request goes out, and a 401 from the server has the final word.
+     */
+    fun namesProject(token: String, projectId: String): Boolean? {
+        if (projectId.isBlank()) return true
+        return audiences(token)?.contains(projectId)
+    }
+
+    /**
+     * The state of the sign-in as far as the rental platform is concerned.
+     *
+     * @param token what [AuthManager.freshToken] currently offers
+     * @param projectId Zitadel project of the rental platform, from BuildConfig
+     */
+    fun state(token: TokenResult, projectId: String): RentalSignIn = when (token) {
+        is TokenResult.Token ->
+            if (namesProject(token.value, projectId) == false) RentalSignIn.STALE
+            else RentalSignIn.VALID
+
+        TokenResult.LoggedOut -> RentalSignIn.MISSING
+        // Not being able to ask is not a no: the sign-in stands, the network
+        // does not. The area shows "offline", not "sign in again".
+        TokenResult.Unreachable -> RentalSignIn.UNREACHABLE
+    }
+}
+
+/** How the sign-in of this device relates to the rental platform. */
+enum class RentalSignIn {
+    /** A token is there and names the rental platform (or we cannot tell). */
+    VALID,
+
+    /** A token is there, but it was issued before the changeover. */
+    STALE,
+
+    /** Nobody is signed in. */
+    MISSING,
+
+    /** Somebody is signed in, but the token could not be renewed right now. */
+    UNREACHABLE,
+}

--- a/android/app/src/main/java/de/roessing/app/data/Rental.kt
+++ b/android/app/src/main/java/de/roessing/app/data/Rental.kt
@@ -1,0 +1,391 @@
+package de.roessing.app.data
+
+import java.time.LocalDate
+import java.util.Locale
+
+/**
+ * The "Maschinchenring": villagers lend equipment to villagers.
+ *
+ * This file is the vocabulary of the area. The shape of the data on the wire
+ * lives in `RentalApi.kt`; whoever follows a change of the contract in
+ * `docs/mieten-api.md` changes it there.
+ *
+ * **The app holds no rules of the rental business.** Whether a period is
+ * free, whether a booking may still be cancelled, who may become a lender —
+ * the rental platform decides and says so ([RentalAvailability.available],
+ * [RentalBooking.canCancel], [RentalProfile.lenderStatus]). A button may be
+ * greyed out because the server said so; the condition behind it does not
+ * belong here. Otherwise web and app drift apart, and they do it first where
+ * it hurts.
+ */
+
+/**
+ * A period of whole days, **half open**: [start] belongs to it, [end] does
+ * not — [end] is the day the device comes back.
+ *
+ * That is the contract's own definition (`docs/mieten-api.md`, section 1),
+ * and it is the one place where a misunderstanding costs a whole day: a
+ * booking from the 5th to the 7th occupies the 5th and the 6th, and somebody
+ * else may start on the 7th. Everything the person sees is therefore built
+ * from [lastDay], never from [end].
+ */
+data class RentalPeriod(val start: LocalDate, val end: LocalDate) {
+    /** The last day the device is out — [end] minus one. */
+    val lastDay: LocalDate get() = end.minusDays(1)
+
+    /** How many days the device is out. */
+    val days: Int get() = (end.toEpochDay() - start.toEpochDay()).toInt()
+
+    /** A period whose end does not lie after its start is not one. */
+    val isValid: Boolean get() = end.isAfter(start)
+
+    /** "5. September 2026" or "5.–6. September 2026" or across months. */
+    val text: String
+        get() {
+            val last = lastDay
+            return when {
+                start == last -> "${day(start)} ${month(start)} ${start.year}"
+                start.year == last.year && start.month == last.month ->
+                    "${day(start)}–${day(last)} ${month(start)} ${start.year}"
+
+                start.year == last.year ->
+                    "${day(start)} ${month(start)} – ${day(last)} ${month(last)} ${last.year}"
+
+                else ->
+                    "${day(start)} ${month(start)} ${start.year} – " +
+                        "${day(last)} ${month(last)} ${last.year}"
+            }
+        }
+
+    private fun day(date: LocalDate) = "${date.dayOfMonth}."
+
+    private fun month(date: LocalDate) = MONTHS[date.monthValue - 1]
+
+    companion object {
+        /**
+         * The period for a span of days somebody picked, both ends included.
+         *
+         * The calendar hands out the days a person wants the device; the
+         * contract wants the day it comes back. That conversion happens here
+         * and nowhere else.
+         */
+        fun ofPickedDays(first: LocalDate, last: LocalDate): RentalPeriod =
+            RentalPeriod(first, last.plusDays(1))
+
+        /** German month names, so device and test read the same. */
+        private val MONTHS = arrayOf(
+            "Januar", "Februar", "März", "April", "Mai", "Juni",
+            "Juli", "August", "September", "Oktober", "November", "Dezember",
+        )
+    }
+}
+
+/** A device in the list, in the search results and in the detail sheet. */
+data class RentalDevice(
+    val id: String,
+    val name: String,
+    /** Markdown from the server — see [markdownAsPlainText]. May be null. */
+    val description: String?,
+    /** Euro per day. Null means: this tariff does not exist. Never zero. */
+    val pricePerDay: Double?,
+    val pricePerWeekend: Double?,
+    val pricePerWeek: Double?,
+    val deposit: Double?,
+    val tags: List<String>,
+    /** Ready-made, signed address of a picture. Null means: no picture. */
+    val thumbnailUrl: String?,
+    /** The manufacturer's page, if the platform knows one. */
+    val productUrl: String?,
+    /** The same device on the web version of the rental platform. */
+    val webUrl: String?,
+)
+
+/** One picture of a device. */
+data class RentalImage(val id: String, val url: String, val isThumbnail: Boolean)
+
+/** A device with all its pictures, as the detail route delivers it. */
+data class RentalDeviceDetail(val device: RentalDevice, val images: List<RentalImage>)
+
+/**
+ * A period in which a device is not to be had.
+ *
+ * All three [status] values mean the same for the calendar: taken. The
+ * distinction is for drawing only — it is **not** a hint that "pending" might
+ * still be available.
+ */
+data class RentalOccupancy(
+    val deviceId: String?,
+    val setId: String?,
+    val period: RentalPeriod,
+    val status: OccupancyStatus,
+)
+
+enum class OccupancyStatus {
+    /** Somebody has asked, the owner has not decided. Taken all the same. */
+    PENDING,
+
+    /** Confirmed. */
+    APPROVED,
+
+    /** The owner needs it themselves. */
+    BLOCKED,
+
+    /** A value this version of the app does not know. Taken all the same. */
+    UNKNOWN,
+}
+
+/**
+ * The server's answer to "is it free in my week?".
+ *
+ * [reason] is a machine-readable token (`occupied`), not a sentence — the
+ * platform deliberately does not say who or what is in the way.
+ */
+data class RentalAvailability(
+    val period: RentalPeriod,
+    val available: Boolean,
+    val reason: String?,
+)
+
+/** The state of a booking, as the contract fixes it. */
+enum class BookingStatus {
+    /** Asked, the owner has not decided. */
+    PENDING,
+    APPROVED,
+    REJECTED,
+    CANCELLED,
+
+    /** A value this version of the app does not know. */
+    UNKNOWN,
+}
+
+/**
+ * Where the device is picked up. Only present once the owner has approved,
+ * and only if they left an address.
+ *
+ * This is the one place in the whole interface carrying another person's
+ * address and telephone number. It is not cached and shown nowhere else.
+ */
+data class RentalPickup(val address: String?, val phone: String?)
+
+/** One of my bookings. */
+data class RentalBooking(
+    val id: String,
+    val deviceId: String?,
+    val setId: String?,
+    /** The device's name — or the set's name for a set booking. */
+    val deviceName: String,
+    val period: RentalPeriod,
+    val status: BookingStatus,
+    /** What the server literally wrote, for a state we do not know. */
+    val rawStatus: String,
+    val notes: String?,
+    /** Whether cancelling has a prospect of succeeding. The server decides. */
+    val canCancel: Boolean,
+    val pickup: RentalPickup?,
+)
+
+/** Whether somebody may offer devices. Decided over there, by hand. */
+enum class LenderStatus { NONE, PENDING, APPROVED, UNKNOWN }
+
+/** The own account in the rental platform. */
+data class RentalProfile(
+    val name: String?,
+    val email: String?,
+    val phone: String?,
+    val addressStreet: String?,
+    val addressZip: String?,
+    val addressCity: String?,
+    val lender: Boolean,
+    val lenderStatus: LenderStatus,
+    val profileComplete: Boolean,
+    /** What the server misses. The app never works this out itself. */
+    val missingFields: List<String>,
+)
+
+/**
+ * A booking request.
+ *
+ * The three personal fields are the exception, not the rule: normally the
+ * server takes name and telephone from the profile. They are filled in only
+ * after the server has said that it misses them — see
+ * [RentalErrorCode.PROFILE_INCOMPLETE].
+ */
+data class BookingRequest(
+    val deviceId: String,
+    val period: RentalPeriod,
+    val notes: String? = null,
+    val firstName: String? = null,
+    val lastName: String? = null,
+    val phone: String? = null,
+)
+
+/**
+ * The stable error codes of the rental platform.
+ *
+ * The app branches on the code, never on the message — that is the contract's
+ * rule and the reason the wording over there can change without breaking
+ * anything here.
+ */
+enum class RentalErrorCode {
+    BAD_REQUEST,
+    INVALID_PERIOD,
+    PROFILE_INCOMPLETE,
+
+    /** No token, or an expired one → ordinary sign-in. */
+    UNAUTHORIZED,
+
+    /**
+     * The token does not name the rental platform as an audience → the person
+     * has to sign in again. See [de.roessing.app.auth.RentalAudience].
+     */
+    TOKEN_AUDIENCE,
+    FORBIDDEN,
+    NOT_A_LENDER,
+    NOT_FOUND,
+
+    /** The period was taken in the meantime — the ordinary race. */
+    OCCUPIED,
+    CONFLICT,
+    RATE_LIMITED,
+    INTERNAL,
+
+    /** A code this version of the app does not know. */
+    UNKNOWN,
+}
+
+/**
+ * The rental platform refused, and named a reason.
+ *
+ * [message] is German and written over there; it may be shown as it stands.
+ * [missingFields] is filled for [RentalErrorCode.PROFILE_INCOMPLETE] only.
+ */
+class RentalApiException(
+    val code: RentalErrorCode,
+    override val message: String?,
+    val missingFields: List<String> = emptyList(),
+) : RuntimeException(message)
+
+/**
+ * What the app can do with the rental platform.
+ *
+ * Reading needs no sign-in — the device list is public on their website as
+ * well, which is what lets the area work before anybody signs in. Only the
+ * personal calls carry a token.
+ *
+ * The lender's side of the contract (routes 13 to 19) is deliberately absent:
+ * creating and maintaining devices happens in the chat and the web version of
+ * the rental platform, and it is meant to stay there.
+ */
+interface RentalRepository {
+    /** All active devices, sorted by name. No sign-in. */
+    suspend fun devices(): List<RentalDevice>
+
+    /** One device with its pictures. No sign-in. */
+    suspend fun device(id: String): RentalDeviceDetail
+
+    /** Hybrid search on the server. Its ranking, not ours. No sign-in. */
+    suspend fun search(query: String): List<RentalDevice>
+
+    /** The taken periods of one device, for the calendar. No sign-in. */
+    suspend fun occupancy(deviceId: String): List<RentalOccupancy>
+
+    /** Is the period free? The server decides. No sign-in. */
+    suspend fun availability(deviceId: String, period: RentalPeriod): RentalAvailability
+
+    /** The own account. Signed in. */
+    suspend fun profile(): RentalProfile
+
+    /** My bookings, oldest start first. Signed in. */
+    suspend fun myBookings(): List<RentalBooking>
+
+    /** Ask for a device. The owner decides afterwards. Signed in. */
+    suspend fun book(request: BookingRequest): RentalBooking
+
+    /** Withdraw one of my bookings. Signed in. */
+    suspend fun cancel(bookingId: String)
+}
+
+/**
+ * An empty rental platform. The default for user interfaces that are built
+ * without one (tests about something else entirely) — it fetches nothing and
+ * claims nothing.
+ */
+object NoRental : RentalRepository {
+    override suspend fun devices(): List<RentalDevice> = emptyList()
+
+    override suspend fun device(id: String): RentalDeviceDetail =
+        throw RentalApiException(RentalErrorCode.NOT_FOUND, null)
+
+    override suspend fun search(query: String): List<RentalDevice> = emptyList()
+
+    override suspend fun occupancy(deviceId: String): List<RentalOccupancy> = emptyList()
+
+    override suspend fun availability(deviceId: String, period: RentalPeriod) =
+        RentalAvailability(period, available = false, reason = null)
+
+    override suspend fun profile(): RentalProfile =
+        throw RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
+
+    override suspend fun myBookings(): List<RentalBooking> = emptyList()
+
+    override suspend fun book(request: BookingRequest): RentalBooking =
+        throw RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
+
+    override suspend fun cancel(bookingId: String) =
+        throw RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
+}
+
+/**
+ * Markdown as readable plain text.
+ *
+ * Device descriptions arrive as Markdown. Showing them raw, with asterisks
+ * and hash marks, is not an option; a full renderer is a library this app
+ * does not have. So the app does the third thing the contract allows and
+ * shows the text **deliberately as plain text**: emphasis marks fall away,
+ * headings become plain lines, list markers become bullets, and a link keeps
+ * its label.
+ *
+ * A pure function, so the whole conversion is covered by plain unit tests.
+ */
+fun markdownAsPlainText(markdown: String): String = markdown
+    .lineSequence()
+    .map { line ->
+        var text = line.trim()
+        // Headings: the hash marks are Markdown's, the words are the author's.
+        text = text.removePrefix("#").removePrefix("#").removePrefix("#")
+            .removePrefix("#").removePrefix("#").removePrefix("#").trim()
+        // List markers become a bullet that survives being read aloud.
+        text = LIST_MARKER.replace(text) { "• " }
+        // Links keep their label; the address would only be noise on screen.
+        text = LINK.replace(text) { it.groupValues[1] }
+        // Emphasis, bold and inline code lose their marks, keep their words.
+        text = text.replace("**", "").replace("__", "")
+        text = EMPHASIS.replace(text) { it.groupValues[1] }
+        text = text.replace("`", "")
+        text
+    }
+    .joinToString("\n")
+    .replace(Regex("\n{3,}"), "\n\n")
+    .trim()
+
+/**
+ * A price in euro, as it is written in German.
+ *
+ * The platform sends plain numbers (`25`, `12.5`) and no currency — it is
+ * always euro. Whole amounts lose their decimals, the rest keep two: "25 €",
+ * "12,50 €". This formats **one** tariff and never adds tariffs up: which one
+ * applies for which duration is nowhere laid down, and an invented rule here
+ * would be the very drift between web and app the contract warns about.
+ */
+fun euroText(value: Double): String {
+    val rounded = Math.round(value * 100.0) / 100.0
+    return if (rounded == Math.floor(rounded)) {
+        "${rounded.toLong()} €"
+    } else {
+        String.format(Locale.GERMANY, "%.2f €", rounded)
+    }
+}
+
+private val LIST_MARKER = Regex("^[-*+]\\s+")
+private val LINK = Regex("\\[([^]]*)]\\([^)]*\\)")
+private val EMPHASIS = Regex("(?<![\\p{L}\\d])[*_]([^*_]+)[*_](?![\\p{L}\\d])")

--- a/android/app/src/main/java/de/roessing/app/data/RentalApi.kt
+++ b/android/app/src/main/java/de/roessing/app/data/RentalApi.kt
@@ -1,0 +1,532 @@
+package de.roessing.app.data
+
+import de.roessing.app.auth.RentalSignIn
+import de.roessing.app.auth.TokenResult
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import retrofit2.HttpException
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+import java.io.IOException
+import java.time.LocalDate
+import java.util.concurrent.TimeUnit
+
+/**
+ * The wire shape of `mieten.xn--rssing-wxa.de`, exactly as `docs/mieten-api.md`
+ * fixes it — and the only file that changes when that contract changes.
+ *
+ * Everything else in this area speaks the vocabulary of `Rental.kt`.
+ *
+ * Three properties of this client are deliberate:
+ *
+ *  - **It talks to the rental platform directly.** The Go backend of the
+ *    village app is not a relay and knows nothing about renting. This is the
+ *    same arrangement the events use with the website — a second server, its
+ *    own small client. The one difference is that a token goes along here.
+ *  - **Reading carries no token.** Device list, detail, search, occupancy and
+ *    availability are public over there, the same way they are public on
+ *    their website. That is what lets the area work before anybody signs in,
+ *    and it keeps the reading half out of every question about audiences and
+ *    expiry. Only the personal calls are marked with [AUTH_MARKER].
+ *  - **The app branches on `error.code`, never on `error.message`.** The
+ *    message is German and may be shown; the code is what decisions hang on.
+ */
+
+/**
+ * Marks the calls that need an access token. The interceptor swaps it for the
+ * real `Authorization` header; without it no token leaves the device.
+ */
+const val AUTH_MARKER = "X-Dorf-Auth"
+
+/** How many results the search asks for. The contract allows 1 to 20. */
+const val SEARCH_LIMIT = 20
+
+// --- The wire shape ---------------------------------------------------------
+
+/** A device, as routes 1, 2 and 3 deliver it. */
+@Serializable
+data class ItemDto(
+    val id: String = "",
+    val name: String = "",
+    /** Markdown. Often null. */
+    val description: String? = null,
+    val pricePerDay: Double? = null,
+    val pricePerWeekend: Double? = null,
+    val pricePerWeek: Double? = null,
+    val deposit: Double? = null,
+    val tags: List<String> = emptyList(),
+    val thumbnailUrl: String? = null,
+    val productUrl: String? = null,
+    val webUrl: String? = null,
+    /** Only in the search results: 0 to 1, for sorting, not for showing. */
+    val score: Double? = null,
+    /** Only in the detail route. */
+    val images: List<ImageDto> = emptyList(),
+)
+
+@Serializable
+data class ImageDto(
+    val id: String = "",
+    val url: String = "",
+    val isThumbnail: Boolean = false,
+)
+
+/** Route 1: the list comes in an envelope, never as a bare array. */
+@Serializable
+data class ItemsDto(val items: List<ItemDto> = emptyList())
+
+/** Route 2. */
+@Serializable
+data class ItemDetailDto(val item: ItemDto = ItemDto())
+
+/** Route 3. */
+@Serializable
+data class SearchDto(val results: List<ItemDto> = emptyList())
+
+/** Route 5. `reason` is a token (`occupied`), not a sentence. */
+@Serializable
+data class AvailabilityDto(val available: Boolean = false, val reason: String? = null)
+
+/** Route 6. */
+@Serializable
+data class OccupancyDto(val periods: List<OccupancyPeriodDto> = emptyList())
+
+@Serializable
+data class OccupancyPeriodDto(
+    val deviceId: String? = null,
+    val setId: String? = null,
+    val startDate: String = "",
+    val endDate: String = "",
+    /** `pending`, `approved` or `blocked` — all three mean taken. */
+    val status: String = "",
+)
+
+/** Route 7 and 8. */
+@Serializable
+data class ProfileEnvelopeDto(val profile: ProfileDataDto = ProfileDataDto())
+
+@Serializable
+data class ProfileDataDto(
+    val name: String? = null,
+    val email: String? = null,
+    val phone: String? = null,
+    val addressStreet: String? = null,
+    val addressZip: String? = null,
+    val addressCity: String? = null,
+    val lender: Boolean = false,
+    val lenderStatus: String = "none",
+    val profileComplete: Boolean = false,
+    val missingFields: List<String> = emptyList(),
+)
+
+/** Route 10 and 11. */
+@Serializable
+data class MietenBookingDto(
+    val id: String = "",
+    val deviceId: String? = null,
+    val setId: String? = null,
+    val deviceName: String = "",
+    val startDate: String = "",
+    /** The return day — it does **not** belong to the period. */
+    val endDate: String = "",
+    val status: String = "",
+    val notes: String? = null,
+    val canCancel: Boolean = false,
+    val pickup: PickupDto? = null,
+)
+
+@Serializable
+data class PickupDto(val address: String? = null, val phone: String? = null)
+
+@Serializable
+data class MyBookingsDto(val bookings: List<MietenBookingDto> = emptyList())
+
+@Serializable
+data class BookingEnvelopeDto(val booking: MietenBookingDto = MietenBookingDto())
+
+/** The body of route 11. Null fields are left out, not sent as null. */
+@Serializable
+data class BookingInputDto(
+    val deviceId: String,
+    val startDate: String,
+    val endDate: String,
+    val firstName: String? = null,
+    val lastName: String? = null,
+    val phone: String? = null,
+    val notes: String? = null,
+)
+
+/** Every error of the platform has this shape. */
+@Serializable
+data class ApiErrorEnvelopeDto(val error: ApiErrorDataDto = ApiErrorDataDto())
+
+@Serializable
+data class ApiErrorDataDto(
+    val code: String = "",
+    val message: String = "",
+    val missingFields: List<String> = emptyList(),
+)
+
+// --- The client -------------------------------------------------------------
+
+interface MietenApi {
+    @GET("api/v1/items")
+    suspend fun items(): ItemsDto
+
+    @GET("api/v1/items/{id}")
+    suspend fun item(@Path("id") id: String): ItemDetailDto
+
+    @GET("api/v1/search")
+    suspend fun search(
+        @Query("q") query: String,
+        @Query("limit") limit: Int = SEARCH_LIMIT,
+    ): SearchDto
+
+    @GET("api/v1/availability")
+    suspend fun availability(
+        @Query("deviceId") deviceId: String,
+        @Query("startDate") startDate: String,
+        @Query("endDate") endDate: String,
+    ): AvailabilityDto
+
+    @GET("api/v1/occupancy")
+    suspend fun occupancy(@Query("deviceId") deviceId: String): OccupancyDto
+
+    @Headers("$AUTH_MARKER: required")
+    @GET("api/v1/me")
+    suspend fun me(): ProfileEnvelopeDto
+
+    @Headers("$AUTH_MARKER: required")
+    @GET("api/v1/bookings/mine")
+    suspend fun myBookings(): MyBookingsDto
+
+    @Headers("$AUTH_MARKER: required")
+    @POST("api/v1/bookings")
+    suspend fun book(@Body input: BookingInputDto): BookingEnvelopeDto
+
+    @Headers("$AUTH_MARKER: required")
+    @POST("api/v1/bookings/{id}/cancel")
+    suspend fun cancel(@Path("id") bookingId: String)
+
+    companion object {
+        private val json = Json {
+            ignoreUnknownKeys = true
+            coerceInputValues = true
+            // Leaving a field out is how the contract says "take it from my
+            // profile"; sending an explicit null would be something else.
+            explicitNulls = false
+        }
+
+        /**
+         * Attaches the authorisation to a marked request — or lets an
+         * unmarked one pass untouched.
+         *
+         * The third case is the important one, and it is the same reasoning
+         * as in `DorfApi`: if somebody is signed in but the token could not
+         * be renewed just now, the request does **not** go out without the
+         * header. It would come back 401, and the app would read that as
+         * "signed out" — wrong, and it costs a sign-in that still holds. An
+         * IOException is the truth: it is the network.
+         *
+         * A pure function, so it can be checked without a network.
+         */
+        fun authorized(request: Request, token: TokenResult): Request {
+            if (request.header(AUTH_MARKER) == null) return request
+            val stripped = request.newBuilder().removeHeader(AUTH_MARKER)
+            return when (token) {
+                is TokenResult.Token ->
+                    stripped.header("Authorization", "Bearer ${token.value}").build()
+
+                TokenResult.LoggedOut -> stripped.build()
+                TokenResult.Unreachable ->
+                    throw IOException("Die Anmeldung ließ sich gerade nicht erneuern")
+            }
+        }
+
+        fun create(baseUrl: String, tokenProvider: suspend () -> TokenResult): MietenApi {
+            val client = OkHttpClient.Builder()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(20, TimeUnit.SECONDS)
+                .addInterceptor { chain ->
+                    // Only marked calls cost a token lookup; the public ones
+                    // never touch the sign-in at all.
+                    val request = chain.request()
+                    if (request.header(AUTH_MARKER) == null) {
+                        chain.proceed(request)
+                    } else {
+                        val token = runBlocking { tokenProvider() }
+                        chain.proceed(authorized(request, token))
+                    }
+                }
+                .build()
+            return Retrofit.Builder()
+                .baseUrl(if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/")
+                .client(client)
+                .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+                .build()
+                .create(MietenApi::class.java)
+        }
+    }
+}
+
+/**
+ * The repository over the rental platform.
+ *
+ * @param api the HTTP client above
+ * @param signIn how this device's sign-in relates to the rental platform.
+ *   Asked before every personal call, so that a token issued before the
+ *   changeover produces a sentence people can act on instead of a 401 that
+ *   looks like a defect.
+ */
+class MietenRentalRepository(
+    private val api: MietenApi,
+    private val signIn: suspend () -> RentalSignIn,
+) : RentalRepository {
+
+    override suspend fun devices(): List<RentalDevice> =
+        translate { api.items().items.map { it.asDevice() } }
+
+    override suspend fun device(id: String): RentalDeviceDetail = translate {
+        val item = api.item(id).item
+        RentalDeviceDetail(
+            device = item.asDevice(),
+            images = item.images
+                .filter { it.url.isNotBlank() }
+                .map { RentalImage(it.id, it.url, it.isThumbnail) },
+        )
+    }
+
+    override suspend fun search(query: String): List<RentalDevice> = translate {
+        // The ranking of the hybrid search is the server's business — the app
+        // shows the order it gets and does not sort it again.
+        api.search(query).results.map { it.asDevice() }
+    }
+
+    override suspend fun occupancy(deviceId: String): List<RentalOccupancy> = translate {
+        api.occupancy(deviceId).periods.mapNotNull { it.asOccupancy() }
+    }
+
+    override suspend fun availability(
+        deviceId: String,
+        period: RentalPeriod,
+    ): RentalAvailability = translate {
+        val answer = api.availability(
+            deviceId = deviceId,
+            startDate = period.start.toString(),
+            endDate = period.end.toString(),
+        )
+        RentalAvailability(period, answer.available, answer.reason)
+    }
+
+    override suspend fun profile(): RentalProfile = personal {
+        api.me().profile.asProfile()
+    }
+
+    override suspend fun myBookings(): List<RentalBooking> = personal {
+        api.myBookings().bookings.mapNotNull { it.asBooking() }
+    }
+
+    override suspend fun book(request: BookingRequest): RentalBooking = personal {
+        val answer = api.book(
+            BookingInputDto(
+                deviceId = request.deviceId,
+                startDate = request.period.start.toString(),
+                endDate = request.period.end.toString(),
+                firstName = request.firstName?.trim()?.takeIf { it.isNotEmpty() },
+                lastName = request.lastName?.trim()?.takeIf { it.isNotEmpty() },
+                phone = request.phone?.trim()?.takeIf { it.isNotEmpty() },
+                notes = request.notes?.trim()?.takeIf { it.isNotEmpty() },
+            ),
+        )
+        answer.booking.asBooking()
+            ?: throw RentalApiException(RentalErrorCode.INTERNAL, null)
+    }
+
+    override suspend fun cancel(bookingId: String) = personal {
+        api.cancel(bookingId)
+    }
+
+    /**
+     * A personal call: first the sign-in, then the request.
+     *
+     * Asking beforehand saves a pointless round trip on exactly the devices
+     * that have the problem — a phone that kept its tokens across the update
+     * carries one without the rental platform in its `aud`, and every request
+     * with it comes back 401. Where the token cannot be read the request goes
+     * out anyway and the server's answer decides ([translate]).
+     */
+    private suspend fun <T> personal(block: suspend () -> T): T {
+        when (signIn()) {
+            RentalSignIn.VALID -> Unit
+            RentalSignIn.STALE -> throw RentalApiException(RentalErrorCode.TOKEN_AUDIENCE, null)
+            RentalSignIn.MISSING -> throw RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
+            RentalSignIn.UNREACHABLE ->
+                throw IOException("Die Anmeldung ließ sich gerade nicht erneuern")
+        }
+        return translate(block)
+    }
+
+    /**
+     * Turns the platform's refusals into [RentalApiException].
+     *
+     * Anything that is not an answer of the platform — a broken connection,
+     * a timeout — stays what it is and reaches the ViewModel as "not
+     * reachable right now".
+     */
+    private suspend fun <T> translate(block: suspend () -> T): T = try {
+        block()
+    } catch (e: HttpException) {
+        throw e.asRentalException()
+    }
+}
+
+/** Reads errors leniently: a broken body must not hide the status behind it. */
+private val errorJson = Json {
+    ignoreUnknownKeys = true
+    coerceInputValues = true
+}
+
+/** Reads `{"error": {...}}` out of a failed answer. */
+internal fun HttpException.asRentalException(): RentalApiException {
+    val body = runCatching { response()?.errorBody()?.string() }.getOrNull()
+    val error = body?.let {
+        runCatching { errorJson.decodeFromString<ApiErrorEnvelopeDto>(it).error }.getOrNull()
+    }
+    return RentalApiException(
+        code = rentalErrorCode(error?.code, code()),
+        message = error?.message?.takeIf { it.isNotBlank() },
+        missingFields = error?.missingFields.orEmpty(),
+    )
+}
+
+/**
+ * The code of the answer, or a sensible one derived from the HTTP status.
+ *
+ * The fallback matters: a proxy or a gateway can answer 502 without the
+ * platform's envelope ever being written, and the area must still say
+ * something better than nothing.
+ */
+internal fun rentalErrorCode(code: String?, httpStatus: Int): RentalErrorCode = when (code) {
+    "bad_request" -> RentalErrorCode.BAD_REQUEST
+    "invalid_period" -> RentalErrorCode.INVALID_PERIOD
+    "profile_incomplete" -> RentalErrorCode.PROFILE_INCOMPLETE
+    "unauthorized" -> RentalErrorCode.UNAUTHORIZED
+    "token_audience" -> RentalErrorCode.TOKEN_AUDIENCE
+    "forbidden" -> RentalErrorCode.FORBIDDEN
+    "not_a_lender" -> RentalErrorCode.NOT_A_LENDER
+    "not_found" -> RentalErrorCode.NOT_FOUND
+    "occupied" -> RentalErrorCode.OCCUPIED
+    "conflict" -> RentalErrorCode.CONFLICT
+    "rate_limited" -> RentalErrorCode.RATE_LIMITED
+    "internal" -> RentalErrorCode.INTERNAL
+    else -> when (httpStatus) {
+        // A 401 without a readable body is the ordinary "sign in" — never
+        // the audience case, because that one always names itself.
+        401 -> RentalErrorCode.UNAUTHORIZED
+        403 -> RentalErrorCode.FORBIDDEN
+        404 -> RentalErrorCode.NOT_FOUND
+        409 -> RentalErrorCode.CONFLICT
+        429 -> RentalErrorCode.RATE_LIMITED
+        in 500..599 -> RentalErrorCode.INTERNAL
+        else -> RentalErrorCode.UNKNOWN
+    }
+}
+
+// --- Mapping: wire shape → vocabulary of the area ---------------------------
+
+/** A date that cannot be read costs the one entry, never the whole list. */
+private fun date(text: String): LocalDate? = runCatching { LocalDate.parse(text) }.getOrNull()
+
+/** Blank strings are the wire's way of saying "nothing"; null is the app's. */
+private fun String?.orNullIfBlank(): String? = this?.trim()?.takeIf { it.isNotEmpty() }
+
+internal fun ItemDto.asDevice() = RentalDevice(
+    id = id,
+    name = name,
+    description = description.orNullIfBlank(),
+    // Prices are numbers in euro. A missing tariff is null and stays null —
+    // it is not zero, and the app does not add the tariffs up: which one
+    // applies for which duration is nowhere laid down.
+    pricePerDay = pricePerDay,
+    pricePerWeekend = pricePerWeekend,
+    pricePerWeek = pricePerWeek,
+    deposit = deposit,
+    tags = tags.filter { it.isNotBlank() },
+    thumbnailUrl = thumbnailUrl.orNullIfBlank(),
+    productUrl = productUrl.orNullIfBlank(),
+    webUrl = webUrl.orNullIfBlank(),
+)
+
+internal fun OccupancyPeriodDto.asOccupancy(): RentalOccupancy? {
+    val from = date(startDate) ?: return null
+    val to = date(endDate) ?: return null
+    if (!to.isAfter(from)) return null
+    return RentalOccupancy(
+        deviceId = deviceId.orNullIfBlank(),
+        setId = setId.orNullIfBlank(),
+        period = RentalPeriod(from, to),
+        status = when (status) {
+            "pending" -> OccupancyStatus.PENDING
+            "approved" -> OccupancyStatus.APPROVED
+            "blocked" -> OccupancyStatus.BLOCKED
+            else -> OccupancyStatus.UNKNOWN
+        },
+    )
+}
+
+internal fun MietenBookingDto.asBooking(): RentalBooking? {
+    val from = date(startDate) ?: return null
+    val to = date(endDate) ?: return null
+    return RentalBooking(
+        id = id,
+        deviceId = deviceId.orNullIfBlank(),
+        setId = setId.orNullIfBlank(),
+        deviceName = deviceName,
+        // Even a period the server wrote back to front must not turn into a
+        // negative number of days on screen.
+        period = RentalPeriod(from, if (to.isAfter(from)) to else from.plusDays(1)),
+        status = when (status) {
+            "pending" -> BookingStatus.PENDING
+            "approved" -> BookingStatus.APPROVED
+            "rejected" -> BookingStatus.REJECTED
+            "cancelled" -> BookingStatus.CANCELLED
+            else -> BookingStatus.UNKNOWN
+        },
+        rawStatus = status,
+        notes = notes.orNullIfBlank(),
+        canCancel = canCancel,
+        // The pickup address only exists once the owner has approved. It is
+        // taken as it comes and kept nowhere else.
+        pickup = pickup
+            ?.takeIf { it.address.orNullIfBlank() != null || it.phone.orNullIfBlank() != null }
+            ?.let { RentalPickup(it.address.orNullIfBlank(), it.phone.orNullIfBlank()) },
+    )
+}
+
+internal fun ProfileDataDto.asProfile() = RentalProfile(
+    name = name.orNullIfBlank(),
+    email = email.orNullIfBlank(),
+    phone = phone.orNullIfBlank(),
+    addressStreet = addressStreet.orNullIfBlank(),
+    addressZip = addressZip.orNullIfBlank(),
+    addressCity = addressCity.orNullIfBlank(),
+    lender = lender,
+    lenderStatus = when (lenderStatus) {
+        "none" -> LenderStatus.NONE
+        "pending" -> LenderStatus.PENDING
+        "approved" -> LenderStatus.APPROVED
+        else -> LenderStatus.UNKNOWN
+    },
+    profileComplete = profileComplete,
+    missingFields = missingFields.filter { it.isNotBlank() },
+)

--- a/android/app/src/main/java/de/roessing/app/ui/HomeScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/HomeScreen.kt
@@ -71,6 +71,7 @@ import de.roessing.app.R
 import de.roessing.app.data.DeviceLocation
 import de.roessing.app.data.KeinChat
 import de.roessing.app.data.KeineVeranstaltungen
+import de.roessing.app.data.NoRental
 import de.roessing.app.push.Geraeteanmeldung
 import de.roessing.app.push.PushZiel
 import de.roessing.app.ui.theme.DorfMotion
@@ -97,9 +98,24 @@ fun HomeScreen(
     veranstaltungenViewModel: VeranstaltungenViewModel = remember {
         VeranstaltungenViewModel(KeineVeranstaltungen)
     },
+    // Same reasoning: an empty rental platform, so that screen tests which
+    // have nothing to do with renting keep working.
+    rentalViewModel: RentalViewModel = remember { RentalViewModel(NoRental) },
     pushZiel: PushZiel? = null,
     onPushZielVerbraucht: () -> Unit = {},
     onLogout: () -> Unit,
+    /**
+     * Stößt eine erneute Anmeldung an, ohne die bestehende vorher wegzuwerfen.
+     *
+     * Gebraucht wird das für den Maschinchenring: Ein Gerät, das schon
+     * angemeldet war, behält seinen Token-Satz über die Aktualisierung hinweg
+     * — der nennt die Mietplattform nicht als Empfänger, und daran ist von
+     * hier aus nichts zu reparieren. Abmelden wäre der grobe Weg: Bricht
+     * jemand den Browser ab, stünde er ohne Anmeldung da, obwohl seine noch
+     * gilt. Also anmelden statt abmelden; misslingt es, bleibt alles, wie es
+     * war. Null heißt: Von hier führt kein Weg dorthin (Vorschau, Test).
+     */
+    onReauthenticate: (() -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsState()
     val leaderboard by leaderboardViewModel.state.collectAsState()
@@ -107,6 +123,7 @@ fun HomeScreen(
     val ideen by ideenViewModel.state.collectAsState()
     val chat by chatViewModel.state.collectAsState()
     val veranstaltungen by veranstaltungenViewModel.state.collectAsState()
+    val verleih by rentalViewModel.state.collectAsState()
     var bereich by rememberSaveable { mutableStateOf(Bereich.START) }
     val snackbar = remember { SnackbarHostState() }
     val context = LocalContext.current
@@ -286,6 +303,21 @@ fun HomeScreen(
     LaunchedEffect(bereich) {
         if (bereich == Bereich.VERANSTALTUNGEN) veranstaltungenViewModel.laden()
     }
+    // Der Maschinchenring wird beim Öffnen geholt; die Anmeldung wird dabei
+    // jedes Mal neu angesehen — sie kann sich zwischendurch geändert haben.
+    LaunchedEffect(bereich) {
+        if (bereich == Bereich.VERLEIH) rentalViewModel.load()
+    }
+    val gebuchtMsg = stringResource(R.string.rental_booked)
+    val storniertMsg = stringResource(R.string.rental_cancelled)
+    LaunchedEffect(Unit) {
+        rentalViewModel.events.collect { event ->
+            when (event) {
+                RentalEvent.Booked -> snackbar.showSnackbar(gebuchtMsg)
+                RentalEvent.Cancelled -> snackbar.showSnackbar(storniertMsg)
+            }
+        }
+    }
     // Die Dorfbewohner-Liste wird beim Öffnen frisch geholt.
     LaunchedEffect(bereich) {
         if (bereich == Bereich.DORFBEWOHNER) profileViewModel.loadMembers()
@@ -337,6 +369,7 @@ fun HomeScreen(
                             } else {
                                 stringResource(R.string.events_title)
                             }
+                            Bereich.VERLEIH -> stringResource(R.string.rental_title)
                             Bereich.IDEEN -> stringResource(R.string.ideas_title)
                             Bereich.CHAT -> stringResource(R.string.chat_title)
                             Bereich.START -> stringResource(R.string.home_title)
@@ -537,6 +570,25 @@ fun HomeScreen(
                         onTermin = { offenerTermin = it.id },
                     )
                 }
+
+                Bereich.VERLEIH -> RentalScreen(
+                    state = verleih,
+                    modifier = Modifier.padding(padding),
+                    onQuery = rentalViewModel::setQuery,
+                    onRefresh = rentalViewModel::refresh,
+                    onOpen = rentalViewModel::open,
+                    onClose = rentalViewModel::close,
+                    onPeriod = rentalViewModel::setPeriod,
+                    onBook = { notes, vorname, nachname, telefon ->
+                        rentalViewModel.book(notes, vorname, nachname, telefon)
+                    },
+                    onCancelBooking = rentalViewModel::cancel,
+                    // Wer hier steht, ist angemeldet — nur eben womöglich mit
+                    // einem Token von vor der Umstellung. Dann hilft allein
+                    // eine neue Anmeldung.
+                    onSignIn = null,
+                    onSignInAgain = onReauthenticate,
+                )
 
                 Bereich.IDEEN -> IdeenScreen(
                     state = ideen,

--- a/android/app/src/main/java/de/roessing/app/ui/LoginScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/LoginScreen.kt
@@ -35,6 +35,12 @@ fun LoginScreen(
     errorCode: String? = null,
     onLogin: () -> Unit,
     onDevLogin: (asAdmin: Boolean) -> Unit,
+    /**
+     * Leads into the rental area without signing in. Reading is public over
+     * there, so nobody has to hand over a name to see what the village lends
+     * out — the Rössing-ID is asked for at the booking, where it is needed.
+     */
+    onBrowseRental: (() -> Unit)? = null,
 ) {
     Surface(Modifier.fillMaxSize()) {
         Column(
@@ -88,6 +94,15 @@ fun LoginScreen(
                     textAlign = TextAlign.Center,
                     modifier = Modifier.testTag("login-error"),
                 )
+            }
+            if (onBrowseRental != null) {
+                Spacer(Modifier.height(8.dp))
+                TextButton(
+                    onClick = onBrowseRental,
+                    modifier = Modifier.testTag("login-rental"),
+                ) {
+                    Text(stringResource(R.string.rental_browse_public))
+                }
             }
             if (AuthManager.isDevAuthAllowed()) {
                 Spacer(Modifier.height(24.dp))

--- a/android/app/src/main/java/de/roessing/app/ui/RentalScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/RentalScreen.kt
@@ -1,0 +1,813 @@
+package de.roessing.app.ui
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.EventBusy
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DateRangePicker
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDateRangePickerState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import de.roessing.app.R
+import de.roessing.app.data.BookingStatus
+import de.roessing.app.data.OccupancyStatus
+import de.roessing.app.data.RentalBooking
+import de.roessing.app.data.RentalDevice
+import de.roessing.app.data.RentalErrorCode
+import de.roessing.app.data.RentalOccupancy
+import de.roessing.app.data.RentalPeriod
+import de.roessing.app.data.euroText
+import de.roessing.app.data.markdownAsPlainText
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * The area "Maschinchenring": what the village lends, and to whom.
+ *
+ * The order of the page follows what people come for. Searching sits at the
+ * top, because whoever opens this area is usually after one particular thing.
+ * Then whatever needs saying — no connection, sign in again, sign in at all.
+ * Then my own bookings, because that is the second reason to look. Only then
+ * the devices.
+ *
+ * Not a single decision about renting is made here. "Free", "taken", "may be
+ * cancelled" — every one of those comes from the rental platform; this file
+ * puts it on screen.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RentalScreen(
+    state: RentalUiState,
+    modifier: Modifier = Modifier,
+    onQuery: (String) -> Unit = {},
+    onRefresh: () -> Unit = {},
+    onOpen: (RentalDevice) -> Unit = {},
+    onClose: () -> Unit = {},
+    onPeriod: (RentalPeriod) -> Unit = {},
+    onBook: (notes: String, firstName: String, lastName: String, phone: String) -> Unit =
+        { _, _, _, _ -> },
+    onCancelBooking: (String) -> Unit = {},
+    /** Null when there is no way to sign in from here. */
+    onSignIn: (() -> Unit)? = null,
+    /** Null when a fresh sign-in cannot be started from here. */
+    onSignInAgain: (() -> Unit)? = null,
+) {
+    Column(modifier.fillMaxWidth().testTag("rental")) {
+        SearchField(state.query, onQuery)
+
+        if (state.loading && state.devices.isEmpty()) {
+            LinearProgressIndicator(Modifier.fillMaxWidth())
+        }
+
+        // First the hint, then the (possibly older) list — an empty page
+        // without an explanation would be the worst outcome.
+        if (state.offline) {
+            Notice(
+                text = if (state.devices.isEmpty()) {
+                    stringResource(R.string.rental_offline)
+                } else {
+                    stringResource(R.string.rental_offline_stale)
+                },
+                actionText = stringResource(R.string.rental_retry),
+                testTag = "rental-offline",
+                actionTestTag = "rental-retry",
+                onAction = onRefresh,
+            )
+        }
+
+        if (state.staleSignIn && onSignInAgain != null) {
+            Notice(
+                title = stringResource(R.string.rental_stale_title),
+                text = stringResource(R.string.rental_stale_body),
+                actionText = stringResource(R.string.rental_stale_button),
+                testTag = "rental-stale",
+                actionTestTag = "rental-stale-signin",
+                onAction = onSignInAgain,
+            )
+        }
+
+        LazyColumn(
+            Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 28.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item {
+                Text(
+                    stringResource(R.string.rental_intro),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            if (!state.signedIn && !state.staleSignIn && onSignIn != null) {
+                item { SignInCard(onSignIn) }
+            }
+
+            if (state.signedIn) {
+                item {
+                    Text(
+                        stringResource(R.string.rental_bookings_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
+                if (state.bookingsOffline) {
+                    item {
+                        Text(
+                            stringResource(R.string.rental_bookings_offline),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.testTag("rental-bookings-offline"),
+                        )
+                    }
+                } else if (state.bookings.isEmpty()) {
+                    item {
+                        Text(
+                            stringResource(R.string.rental_bookings_empty),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.testTag("rental-bookings-empty"),
+                        )
+                    }
+                }
+                items(state.bookings, key = { "booking-${it.id}" }) { booking ->
+                    BookingCard(
+                        booking = booking,
+                        busy = booking.id in state.cancelling,
+                        onCancel = { onCancelBooking(booking.id) },
+                    )
+                }
+            }
+
+            items(state.devices, key = { it.id }) { device ->
+                DeviceCard(device) { onOpen(device) }
+            }
+
+            if (state.empty) {
+                item {
+                    Text(
+                        if (state.query.isBlank()) {
+                            stringResource(R.string.rental_empty)
+                        } else {
+                            stringResource(R.string.rental_empty_search)
+                        },
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(top = 24.dp).testTag("rental-empty"),
+                    )
+                }
+            }
+
+            // Wer ein Gerät einstellen will, macht das drüben — die App
+            // kennt dafür bewusst keinen Weg.
+            item {
+                Text(
+                    stringResource(R.string.rental_manage_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 16.dp),
+                )
+            }
+        }
+    }
+
+    val selected = state.selected
+    if (selected != null) {
+        ModalBottomSheet(
+            onDismissRequest = onClose,
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        ) {
+            DeviceDetail(
+                device = selected,
+                state = state,
+                onPeriod = onPeriod,
+                onBook = onBook,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchField(query: String, onQuery: (String) -> Unit) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQuery,
+        singleLine = true,
+        label = { Text(stringResource(R.string.rental_search_label)) },
+        placeholder = { Text(stringResource(R.string.rental_search_placeholder)) },
+        leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
+        trailingIcon = {
+            if (query.isNotEmpty()) {
+                IconButton(
+                    onClick = { onQuery("") },
+                    modifier = Modifier.testTag("rental-search-clear"),
+                ) {
+                    Icon(
+                        Icons.Filled.Clear,
+                        contentDescription = stringResource(R.string.rental_search_clear),
+                    )
+                }
+            }
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 8.dp)
+            .testTag("rental-search"),
+    )
+}
+
+/** The banner above the list: no connection, or sign in again. */
+@Composable
+private fun Notice(
+    text: String,
+    actionText: String,
+    testTag: String,
+    actionTestTag: String,
+    onAction: () -> Unit,
+    title: String? = null,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        shape = MaterialTheme.shapes.large,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 8.dp)
+            .testTag(testTag),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            title?.let { Text(it, style = MaterialTheme.typography.titleSmall) }
+            Text(text, style = MaterialTheme.typography.bodyMedium)
+            TextButton(onClick = onAction, modifier = Modifier.testTag(actionTestTag)) {
+                Text(actionText)
+            }
+        }
+    }
+}
+
+/** Browsing works without an account; booking does not. Said once, calmly. */
+@Composable
+private fun SignInCard(onSignIn: () -> Unit) {
+    Card(
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+        modifier = Modifier.fillMaxWidth().testTag("rental-signin"),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                stringResource(R.string.rental_signin_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Text(
+                stringResource(R.string.rental_signin_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Button(
+                onClick = onSignIn,
+                shape = MaterialTheme.shapes.large,
+                modifier = Modifier.testTag("rental-signin-button"),
+            ) { Text(stringResource(R.string.rental_signin_button)) }
+        }
+    }
+}
+
+@Composable
+private fun DeviceCard(device: RentalDevice, onClick: () -> Unit) {
+    Card(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        modifier = Modifier.fillMaxWidth().testTag("device-${device.id}"),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(device.name, style = MaterialTheme.typography.titleMedium)
+            device.pricePerDay?.let {
+                Text(
+                    stringResource(R.string.rental_price_day, euroText(it)),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            device.description?.let {
+                Text(
+                    markdownAsPlainText(it),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+/** The German wording of a booking state. The four values are the contract's. */
+@Composable
+private fun statusText(booking: RentalBooking): String = when (booking.status) {
+    BookingStatus.PENDING -> stringResource(R.string.rental_status_pending)
+    BookingStatus.APPROVED -> stringResource(R.string.rental_status_approved)
+    BookingStatus.REJECTED -> stringResource(R.string.rental_status_rejected)
+    BookingStatus.CANCELLED -> stringResource(R.string.rental_status_cancelled)
+    // A state a later version of the platform invented: show it as it came
+    // rather than claim something.
+    BookingStatus.UNKNOWN -> booking.rawStatus
+}
+
+@Composable
+private fun BookingCard(booking: RentalBooking, busy: Boolean, onCancel: () -> Unit) {
+    Card(
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        ),
+        modifier = Modifier.fillMaxWidth().testTag("booking-${booking.id}"),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(booking.deviceName, style = MaterialTheme.typography.titleMedium)
+            Text(booking.period.text, style = MaterialTheme.typography.bodyMedium)
+            Text(
+                stringResource(R.string.rental_return_day, dayText(booking.period.end)),
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Text(statusText(booking), style = MaterialTheme.typography.labelLarge)
+            booking.notes?.let {
+                Text(
+                    stringResource(R.string.rental_note, it),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            // Adresse und Telefonnummer eines anderen Menschen — sie stehen
+            // hier erst, nachdem er die Buchung bestätigt hat, und nirgends
+            // sonst in der App.
+            booking.pickup?.let { pickup ->
+                Text(
+                    stringResource(R.string.rental_pickup_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+                pickup.address?.let { Line(Icons.Filled.Place, it) }
+                pickup.phone?.let { Text(stringResource(R.string.rental_pickup_phone, it)) }
+            }
+            // Der Knopf richtet sich nach canCancel — die App prüft den
+            // Zustand nicht selbst nach.
+            if (booking.canCancel) {
+                OutlinedButton(
+                    onClick = onCancel,
+                    enabled = !busy,
+                    shape = MaterialTheme.shapes.large,
+                    modifier = Modifier.testTag("booking-cancel-${booking.id}"),
+                ) { Text(stringResource(R.string.rental_cancel_booking)) }
+            }
+        }
+    }
+}
+
+/**
+ * The detail sheet: everything about one device, and the way to a booking.
+ *
+ * The button is enabled when the server has said the period is free — not
+ * when this screen has worked it out from the taken periods next to it.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DeviceDetail(
+    device: RentalDevice,
+    state: RentalUiState,
+    onPeriod: (RentalPeriod) -> Unit,
+    onBook: (notes: String, firstName: String, lastName: String, phone: String) -> Unit,
+) {
+    var picking by remember { mutableStateOf(false) }
+    var notes by rememberSaveable(device.id) { mutableStateOf("") }
+    var firstName by rememberSaveable(device.id) { mutableStateOf("") }
+    var lastName by rememberSaveable(device.id) { mutableStateOf("") }
+    var phone by rememberSaveable(device.id) { mutableStateOf("") }
+    val browser = LocalUriHandler.current
+
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp)
+            .padding(bottom = 32.dp)
+            .testTag("device-detail"),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(device.name, style = MaterialTheme.typography.headlineSmall)
+
+        // Die Tarife, wie sie drüben stehen — einzeln, unverrechnet.
+        val tariffs = listOfNotNull(
+            device.pricePerDay?.let { stringResource(R.string.rental_price_day, euroText(it)) },
+            device.pricePerWeekend?.let {
+                stringResource(R.string.rental_price_weekend, euroText(it))
+            },
+            device.pricePerWeek?.let { stringResource(R.string.rental_price_week, euroText(it)) },
+        )
+        if (tariffs.isEmpty()) {
+            Text(stringResource(R.string.rental_no_price), style = MaterialTheme.typography.bodyMedium)
+        } else {
+            tariffs.forEach {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+        device.deposit?.let { Text(stringResource(R.string.rental_deposit, euroText(it))) }
+        Text(
+            stringResource(R.string.rental_price_note),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        device.description?.let {
+            Text(
+                markdownAsPlainText(it),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("device-description"),
+            )
+        }
+
+        if (state.images.size > 1) {
+            Text(
+                stringResource(R.string.rental_images, state.images.size),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        // Belegte Zeiträume, gezeichnet wie der Server sie liefert. Sie sind
+        // Anschauung, nicht die Antwort — die gibt die Verfügbarkeit.
+        Text(
+            stringResource(R.string.rental_occupied_title),
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+        if (state.occupancy.isEmpty()) {
+            Text(
+                stringResource(R.string.rental_occupied_none),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("rental-occupancy-empty"),
+            )
+        } else {
+            state.occupancy.forEach { Line(Icons.Filled.EventBusy, occupancyText(it)) }
+        }
+
+        Spacer(Modifier.height(4.dp))
+        OutlinedButton(
+            onClick = { picking = true },
+            shape = MaterialTheme.shapes.large,
+            modifier = Modifier.fillMaxWidth().testTag("rental-pick-period"),
+        ) {
+            Text(
+                if (state.period == null) {
+                    stringResource(R.string.rental_choose_period)
+                } else {
+                    stringResource(R.string.rental_change_period)
+                },
+            )
+        }
+
+        state.period?.let { period ->
+            Text(period.text, style = MaterialTheme.typography.titleSmall)
+            Text(
+                pluralStringResource(R.plurals.rental_days, period.days, period.days),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                stringResource(R.string.rental_return_day, dayText(period.end)),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        when {
+            state.checking -> Row(verticalAlignment = Alignment.CenterVertically) {
+                CircularProgressIndicator(Modifier.size(16.dp))
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.rental_checking))
+            }
+
+            state.availability?.available == true -> Text(
+                stringResource(R.string.rental_free),
+                color = MaterialTheme.colorScheme.primary,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("rental-free"),
+            )
+
+            state.availability != null -> Text(
+                stringResource(R.string.rental_taken),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("rental-taken"),
+            )
+        }
+
+        OutlinedTextField(
+            value = notes,
+            onValueChange = { notes = it },
+            label = { Text(stringResource(R.string.rental_notes_label)) },
+            minLines = 2,
+            modifier = Modifier.fillMaxWidth().testTag("rental-notes"),
+        )
+
+        // Was fehlt, sagt der Server. Die App fragt genau das ab — und nur
+        // dann, wenn er es gesagt hat.
+        if (state.missingFields.isNotEmpty()) {
+            Text(
+                stringResource(R.string.rental_missing_title),
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.testTag("rental-missing"),
+            )
+            if ("firstName" in state.missingFields || "name" in state.missingFields) {
+                OutlinedTextField(
+                    value = firstName,
+                    onValueChange = { firstName = it },
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.rental_missing_first_name)) },
+                    modifier = Modifier.fillMaxWidth().testTag("rental-first-name"),
+                )
+            }
+            if ("lastName" in state.missingFields || "name" in state.missingFields) {
+                OutlinedTextField(
+                    value = lastName,
+                    onValueChange = { lastName = it },
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.rental_missing_last_name)) },
+                    modifier = Modifier.fillMaxWidth().testTag("rental-last-name"),
+                )
+            }
+            if ("phone" in state.missingFields) {
+                OutlinedTextField(
+                    value = phone,
+                    onValueChange = { phone = it },
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.rental_missing_phone)) },
+                    modifier = Modifier.fillMaxWidth().testTag("rental-phone"),
+                )
+            }
+            // Adressfelder kann eine Buchung nicht mitschicken — dafür führt
+            // der Weg auf die Webseite des Maschinchenrings.
+            if (state.missingFields.any { it.startsWith("address") }) {
+                Text(
+                    stringResource(R.string.rental_missing_web),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+                device.webUrl?.let { url ->
+                    TextButton(
+                        onClick = { browser.openUri(url) },
+                        modifier = Modifier.testTag("rental-missing-web"),
+                    ) { Text(stringResource(R.string.rental_web_link)) }
+                }
+            }
+        }
+
+        state.notice?.let { notice ->
+            Text(
+                notice.text ?: stringResource(fallbackFor(notice.code)),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("rental-refusal"),
+            )
+        }
+
+        Button(
+            onClick = { onBook(notes, firstName, lastName, phone) },
+            enabled = state.canBook,
+            shape = MaterialTheme.shapes.large,
+            contentPadding = PaddingValues(vertical = 14.dp),
+            modifier = Modifier.fillMaxWidth().testTag("rental-book"),
+        ) {
+            Text(
+                if (state.booking) {
+                    stringResource(R.string.rental_booking)
+                } else {
+                    stringResource(R.string.rental_book)
+                },
+            )
+        }
+
+        device.webUrl?.let { url ->
+            TextButton(
+                onClick = { browser.openUri(url) },
+                modifier = Modifier.testTag("rental-web"),
+            ) { Text(stringResource(R.string.rental_web_link)) }
+        }
+        device.productUrl?.let { url ->
+            TextButton(
+                onClick = { browser.openUri(url) },
+                modifier = Modifier.testTag("rental-product"),
+            ) { Text(stringResource(R.string.rental_product_link)) }
+        }
+    }
+
+    if (picking) {
+        val picker = rememberDateRangePickerState()
+        DatePickerDialog(
+            onDismissRequest = { picking = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val period = periodOfPicked(
+                            picker.selectedStartDateMillis,
+                            picker.selectedEndDateMillis,
+                        )
+                        picking = false
+                        period?.let(onPeriod)
+                    },
+                    modifier = Modifier.testTag("rental-period-ok"),
+                ) { Text(stringResource(R.string.rental_period_ok)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { picking = false }) {
+                    Text(stringResource(R.string.rental_period_abort))
+                }
+            },
+        ) {
+            DateRangePicker(picker, modifier = Modifier.testTag("rental-period-picker"))
+        }
+    }
+}
+
+/** German wording for a taken period, with the reason it is taken. */
+@Composable
+private fun occupancyText(occupancy: RentalOccupancy): String {
+    val what = when (occupancy.status) {
+        OccupancyStatus.PENDING -> stringResource(R.string.rental_occupied_pending)
+        OccupancyStatus.APPROVED -> stringResource(R.string.rental_occupied_approved)
+        OccupancyStatus.BLOCKED -> stringResource(R.string.rental_occupied_blocked)
+        // Whatever it is, it means taken — and that is all the calendar needs.
+        OccupancyStatus.UNKNOWN -> stringResource(R.string.rental_occupied_approved)
+    }
+    return "${occupancy.period.text} ($what)"
+}
+
+/** Our own wording, used only where the server sent none. */
+private fun fallbackFor(code: RentalErrorCode): Int = when (code) {
+    RentalErrorCode.OCCUPIED -> R.string.rental_error_occupied
+    RentalErrorCode.INVALID_PERIOD -> R.string.rental_error_invalid_period
+    RentalErrorCode.BAD_REQUEST -> R.string.rental_error_bad_request
+    RentalErrorCode.PROFILE_INCOMPLETE -> R.string.rental_error_profile_incomplete
+    RentalErrorCode.FORBIDDEN, RentalErrorCode.NOT_A_LENDER -> R.string.rental_error_forbidden
+    RentalErrorCode.NOT_FOUND -> R.string.rental_error_not_found
+    RentalErrorCode.CONFLICT -> R.string.rental_error_conflict
+    RentalErrorCode.RATE_LIMITED -> R.string.rental_error_rate_limited
+    RentalErrorCode.INTERNAL -> R.string.rental_error_internal
+    else -> R.string.rental_error_unknown
+}
+
+/** "7. September 2026" — used for the return day. */
+private fun dayText(date: LocalDate): String =
+    "${date.dayOfMonth}. ${MONTH_NAMES[date.monthValue - 1]} ${date.year}"
+
+private val MONTH_NAMES = arrayOf(
+    "Januar", "Februar", "März", "April", "Mai", "Juni",
+    "Juli", "August", "September", "Oktober", "November", "Dezember",
+)
+
+/**
+ * Turns the picker's two instants into a period.
+ *
+ * Two things happen here, and both are easy to get wrong. Material hands out
+ * UTC midnights, so the days are read back in UTC — otherwise a tap in
+ * Central European Summer Time lands on the day before. And the calendar
+ * hands out the **days somebody wants the device**, while the contract wants
+ * the **day it comes back**: the last picked day plus one. Picking a single
+ * day means one day of renting.
+ */
+internal fun periodOfPicked(startMillis: Long?, endMillis: Long?): RentalPeriod? {
+    val first = startMillis?.let { day(it) } ?: return null
+    val last = endMillis?.let { day(it) } ?: first
+    if (last.isBefore(first)) return null
+    return RentalPeriod.ofPickedDays(first, last)
+}
+
+private fun day(millis: Long): LocalDate =
+    Instant.ofEpochMilli(millis).atZone(ZoneOffset.UTC).toLocalDate()
+
+@Composable
+private fun Line(symbol: ImageVector, text: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            symbol,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/**
+ * The rental area on its own, before anybody has signed in.
+ *
+ * Reading is public over there, so the area does not have to wait behind the
+ * sign-in screen. Whoever opens the app can look through the devices and
+ * search them; the sentence about the Rössing-ID appears where it becomes
+ * relevant — at the booking — and not as a gate in front of everything.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PublicRentalScreen(
+    state: RentalUiState,
+    onBack: () -> Unit,
+    onSignIn: () -> Unit,
+    onQuery: (String) -> Unit = {},
+    onRefresh: () -> Unit = {},
+    onOpen: (RentalDevice) -> Unit = {},
+    onClose: () -> Unit = {},
+    onPeriod: (RentalPeriod) -> Unit = {},
+) {
+    BackHandler(onBack = onBack)
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(stringResource(R.string.rental_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("rental-back")) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.rental_back_to_login),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        RentalScreen(
+            state = state,
+            modifier = Modifier.padding(padding),
+            onQuery = onQuery,
+            onRefresh = onRefresh,
+            onOpen = onOpen,
+            onClose = onClose,
+            onPeriod = onPeriod,
+            onSignIn = onSignIn,
+            // Nobody is signed in here, so there is no stale token to fix.
+            onSignInAgain = null,
+        )
+    }
+}

--- a/android/app/src/main/java/de/roessing/app/ui/RentalScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/RentalScreen.kt
@@ -102,6 +102,17 @@ fun RentalScreen(
     /** Null when a fresh sign-in cannot be started from here. */
     onSignInAgain: (() -> Unit)? = null,
 ) {
+    // Der Weg nach draußen wird **hier** nachgeschlagen, im Fenster der App —
+    // und nicht unten im Blatt. Ein ModalBottomSheet ist ein eigenes Fenster
+    // mit eigenem Owner, und der belegt `LocalUriHandler` selbst neu
+    // (`ProvideCommonCompositionLocals`). Wer den Verweis erst dort drinnen
+    // liest, bekommt darum immer den Browser des Systems — auch dann, wenn
+    // die App außen etwas anderes untergeschoben bekommen hat. Im Test hieß
+    // das: Chromium ging auf, die App verschwand im Hintergrund, und die drei
+    // folgenden Prüfungen fanden ihre Oberfläche nicht wieder.
+    val uriHandler = LocalUriHandler.current
+    val browser: (String) -> Unit = { uriHandler.openUri(it) }
+
     Column(modifier.fillMaxWidth().testTag("rental")) {
         SearchField(state.query, onQuery)
 
@@ -231,6 +242,7 @@ fun RentalScreen(
                 state = state,
                 onPeriod = onPeriod,
                 onBook = onBook,
+                onOpenLink = browser,
             )
         }
     }
@@ -430,13 +442,14 @@ private fun DeviceDetail(
     state: RentalUiState,
     onPeriod: (RentalPeriod) -> Unit,
     onBook: (notes: String, firstName: String, lastName: String, phone: String) -> Unit,
+    /** Führt eine Adresse nach draußen — gereicht, nicht hier nachgeschlagen. */
+    onOpenLink: (String) -> Unit,
 ) {
     var picking by remember { mutableStateOf(false) }
     var notes by rememberSaveable(device.id) { mutableStateOf("") }
     var firstName by rememberSaveable(device.id) { mutableStateOf("") }
     var lastName by rememberSaveable(device.id) { mutableStateOf("") }
     var phone by rememberSaveable(device.id) { mutableStateOf("") }
-    val browser = LocalUriHandler.current
 
     Column(
         Modifier
@@ -613,7 +626,7 @@ private fun DeviceDetail(
                 )
                 device.webUrl?.let { url ->
                     TextButton(
-                        onClick = { browser.openUri(url) },
+                        onClick = { onOpenLink(url) },
                         modifier = Modifier.testTag("rental-missing-web"),
                     ) { Text(stringResource(R.string.rental_web_link)) }
                 }
@@ -647,13 +660,13 @@ private fun DeviceDetail(
 
         device.webUrl?.let { url ->
             TextButton(
-                onClick = { browser.openUri(url) },
+                onClick = { onOpenLink(url) },
                 modifier = Modifier.testTag("rental-web"),
             ) { Text(stringResource(R.string.rental_web_link)) }
         }
         device.productUrl?.let { url ->
             TextButton(
-                onClick = { browser.openUri(url) },
+                onClick = { onOpenLink(url) },
                 modifier = Modifier.testTag("rental-product"),
             ) { Text(stringResource(R.string.rental_product_link)) }
         }

--- a/android/app/src/main/java/de/roessing/app/ui/RentalScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/RentalScreen.kt
@@ -148,7 +148,10 @@ fun RentalScreen(
         }
 
         LazyColumn(
-            Modifier.fillMaxWidth(),
+            // Die Kennung trägt die Liste selbst: Eine LazyColumn baut nur,
+            // was zu sehen ist, und ein Test muss sie zum Blättern greifen
+            // können, statt eine Kachel zu suchen, die es noch nicht gibt.
+            Modifier.fillMaxWidth().testTag("rental-list"),
             contentPadding = PaddingValues(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 28.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/android/app/src/main/java/de/roessing/app/ui/RentalViewModel.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/RentalViewModel.kt
@@ -1,0 +1,451 @@
+package de.roessing.app.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import de.roessing.app.auth.RentalSignIn
+import de.roessing.app.data.BookingRequest
+import de.roessing.app.data.RentalApiException
+import de.roessing.app.data.RentalAvailability
+import de.roessing.app.data.RentalBooking
+import de.roessing.app.data.RentalDevice
+import de.roessing.app.data.RentalErrorCode
+import de.roessing.app.data.RentalImage
+import de.roessing.app.data.RentalOccupancy
+import de.roessing.app.data.RentalPeriod
+import de.roessing.app.data.RentalProfile
+import de.roessing.app.data.RentalRepository
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * A refusal of the rental platform, on its way to the screen.
+ *
+ * [text] is the German sentence the server wrote and may be shown as it
+ * stands. [code] is what the app decides on; the screen falls back to its own
+ * wording only when the server sent none.
+ */
+data class RentalNotice(val code: RentalErrorCode, val text: String?)
+
+/**
+ * State of the area "Maschinchenring".
+ *
+ * [offline] does not mean "nothing there", it means "not reachable right
+ * now": if an older list is on screen it stays, and the hint appears above
+ * it. An empty page without an explanation would be the worst outcome.
+ *
+ * [staleSignIn] is the one case that looks like a defect and is not one: the
+ * phone is signed in, but with a token issued before the rental platform
+ * joined the Rössing-ID. It cannot be repaired from here — only a fresh
+ * sign-in produces a token with the new audience — so the app says so and
+ * offers the button.
+ */
+data class RentalUiState(
+    val query: String = "",
+    val devices: List<RentalDevice> = emptyList(),
+    val loading: Boolean = false,
+    val offline: Boolean = false,
+    /** Somebody is signed in and the token counts for the rental platform. */
+    val signedIn: Boolean = false,
+    /** Signed in, but with a token from before the changeover. */
+    val staleSignIn: Boolean = false,
+    val profile: RentalProfile? = null,
+    val bookings: List<RentalBooking> = emptyList(),
+    val bookingsOffline: Boolean = false,
+    /** The device whose detail sheet is open, or null. */
+    val selected: RentalDevice? = null,
+    val images: List<RentalImage> = emptyList(),
+    /** Taken periods of the open device, as the server drew them. */
+    val occupancy: List<RentalOccupancy> = emptyList(),
+    val period: RentalPeriod? = null,
+    val availability: RentalAvailability? = null,
+    val checking: Boolean = false,
+    val booking: Boolean = false,
+    val cancelling: Set<String> = emptySet(),
+    /** The last refusal, worded by the server. */
+    val notice: RentalNotice? = null,
+    /**
+     * What the server misses before it will take a booking. Empty is the
+     * normal case — it takes name and telephone from the profile itself.
+     */
+    val missingFields: List<String> = emptyList(),
+) {
+    /** Nothing there, nothing on its way, nothing broken — then it is empty. */
+    val empty: Boolean get() = devices.isEmpty() && !loading && !offline
+
+    /**
+     * Whether the booking button may be pressed.
+     *
+     * Every part of this comes from the server: it said the period is free.
+     * The app adds only that a request is not already on its way.
+     */
+    val canBook: Boolean
+        get() = signedIn &&
+            period?.isValid == true &&
+            availability?.available == true &&
+            !booking
+}
+
+/** One-off events of the area. */
+sealed interface RentalEvent {
+    /** The request went out; the owner decides. */
+    data object Booked : RentalEvent
+
+    data object Cancelled : RentalEvent
+}
+
+/**
+ * Talks to `mieten.xn--rssing-wxa.de` through [RentalRepository].
+ *
+ * Nothing here decides anything about renting. Whether a period is free,
+ * whether a booking may be cancelled — all of that arrives from the server,
+ * and a button is greyed out because the server said so, never because this
+ * class worked it out.
+ *
+ * @param repo the rental platform
+ * @param signIn how this device's sign-in relates to it
+ * @param searchDelay how long typing settles before the server is asked
+ */
+class RentalViewModel(
+    private val repo: RentalRepository,
+    private val signIn: suspend () -> RentalSignIn = { RentalSignIn.MISSING },
+    private val searchDelay: Long = SEARCH_DELAY,
+) : ViewModel() {
+    private val _state = MutableStateFlow(RentalUiState())
+    val state: StateFlow<RentalUiState> = _state
+
+    private val _events = MutableSharedFlow<RentalEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<RentalEvent> = _events
+
+    private var loaded = false
+    private var searchJob: Job? = null
+    private var checkJob: Job? = null
+
+    /**
+     * On opening the area. What is already there is not fetched again; the
+     * sign-in, on the other hand, is looked at every time — somebody may have
+     * signed in on the login screen in between.
+     */
+    fun load() {
+        viewModelScope.launch { refreshSignIn() }
+        if (loaded) return
+        fetch(_state.value.query)
+    }
+
+    /** Deliberate refresh by the user. */
+    fun refresh() {
+        viewModelScope.launch { refreshSignIn() }
+        fetch(_state.value.query)
+    }
+
+    /**
+     * Typing in the search field.
+     *
+     * Searching happens on the server: its hybrid ranking knows the devices
+     * and their descriptions, and a local `contains` would quietly disagree
+     * with the website. Only the waiting is ours, so that a five-letter word
+     * is not five requests.
+     */
+    fun setQuery(text: String) {
+        _state.update { it.copy(query = text) }
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            delay(searchDelay)
+            fetch(text)
+        }
+    }
+
+    private fun fetch(query: String) {
+        viewModelScope.launch {
+            _state.update { it.copy(loading = true) }
+            runCatching {
+                if (query.isBlank()) repo.devices() else repo.search(query.trim())
+            }
+                .onSuccess { list ->
+                    loaded = true
+                    _state.update { it.copy(loading = false, offline = false, devices = list) }
+                }
+                .onFailure {
+                    // The old list stays; the hint goes above it. Whether the
+                    // platform answered 500 or the connection broke makes no
+                    // difference here — either way it is not reachable.
+                    _state.update { it.copy(loading = false, offline = true) }
+                }
+        }
+    }
+
+    /** Looks at the sign-in and, if it counts, fetches profile and bookings. */
+    private suspend fun refreshSignIn() {
+        val signedIn = runCatching { signIn() }.getOrDefault(RentalSignIn.UNREACHABLE)
+        _state.update {
+            it.copy(
+                signedIn = signedIn == RentalSignIn.VALID,
+                staleSignIn = signedIn == RentalSignIn.STALE,
+                // Nobody signed in means no bookings to show — and none to
+                // keep on screen either.
+                bookings = if (signedIn == RentalSignIn.VALID) it.bookings else emptyList(),
+                profile = if (signedIn == RentalSignIn.VALID) it.profile else null,
+            )
+        }
+        if (signedIn == RentalSignIn.VALID) {
+            loadProfile()
+            loadBookings()
+        }
+    }
+
+    /**
+     * The own account over there.
+     *
+     * Worth its own call even though the booking works without it: the first
+     * request creates the account in the rental platform, and its answer is
+     * the cheapest place to notice a token that does not count over there.
+     */
+    fun loadProfile() {
+        viewModelScope.launch {
+            runCatching { repo.profile() }
+                .onSuccess { profile -> _state.update { it.copy(profile = profile) } }
+                .onFailure { failure ->
+                    _state.update { state ->
+                        when (failure.rentalCode()) {
+                            RentalErrorCode.TOKEN_AUDIENCE -> state.asStale()
+                            RentalErrorCode.UNAUTHORIZED -> state.asSignedOut()
+                            // Not being able to read the profile is no reason
+                            // to hide the area — booking may still work.
+                            else -> state
+                        }
+                    }
+                }
+        }
+    }
+
+    /** My bookings. Only makes sense signed in; [load] takes care of that. */
+    fun loadBookings() {
+        viewModelScope.launch {
+            runCatching { repo.myBookings() }
+                .onSuccess { list ->
+                    _state.update { it.copy(bookings = list, bookingsOffline = false) }
+                }
+                .onFailure { failure ->
+                    _state.update { state ->
+                        when (failure.rentalCode()) {
+                            RentalErrorCode.TOKEN_AUDIENCE -> state.asStale()
+                            RentalErrorCode.UNAUTHORIZED -> state.asSignedOut()
+                            else -> state.copy(bookingsOffline = true)
+                        }
+                    }
+                }
+        }
+    }
+
+    // --- Detail sheet --------------------------------------------------------
+
+    /**
+     * Opens a device.
+     *
+     * The pictures and the taken periods are fetched afterwards; the sheet is
+     * on screen immediately with what the list already knows. Neither of the
+     * two is allowed to keep it shut.
+     */
+    fun open(device: RentalDevice) {
+        _state.update {
+            it.copy(
+                selected = device,
+                images = emptyList(),
+                occupancy = emptyList(),
+                availability = null,
+                period = null,
+                notice = null,
+                missingFields = emptyList(),
+            )
+        }
+        viewModelScope.launch {
+            runCatching { repo.device(device.id) }.onSuccess { detail ->
+                // Only if the same device is still open — somebody may have
+                // closed the sheet and opened the next one in the meantime.
+                _state.update { state ->
+                    if (state.selected?.id == device.id) {
+                        state.copy(selected = detail.device, images = detail.images)
+                    } else {
+                        state
+                    }
+                }
+            }
+        }
+        loadOccupancy(device.id)
+    }
+
+    /** The taken periods of one device — public, so it needs no sign-in. */
+    fun loadOccupancy(deviceId: String) {
+        viewModelScope.launch {
+            runCatching { repo.occupancy(deviceId) }.onSuccess { periods ->
+                _state.update { state ->
+                    if (state.selected?.id == deviceId) state.copy(occupancy = periods) else state
+                }
+            }
+        }
+    }
+
+    fun close() = _state.update {
+        it.copy(
+            selected = null,
+            images = emptyList(),
+            occupancy = emptyList(),
+            availability = null,
+            period = null,
+            notice = null,
+            missingFields = emptyList(),
+        )
+    }
+
+    /**
+     * A chosen period. Whether it is free is asked at once, because that is
+     * the question people came with — and it is the server's answer, not one
+     * the app reads out of the occupancy it has just drawn.
+     */
+    fun setPeriod(period: RentalPeriod) {
+        _state.update { it.copy(period = period, availability = null, notice = null) }
+        val device = _state.value.selected ?: return
+        checkJob?.cancel()
+        checkJob = viewModelScope.launch {
+            _state.update { it.copy(checking = true) }
+            runCatching { repo.availability(device.id, period) }
+                .onSuccess { answer ->
+                    _state.update { it.copy(checking = false, availability = answer) }
+                }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(checking = false, availability = null).after(failure)
+                    }
+                }
+        }
+    }
+
+    /**
+     * Sends the request. The owner decides afterwards.
+     *
+     * The three personal fields stay empty in the ordinary case: the server
+     * takes name and telephone from the profile. They are passed only after
+     * the server has said it misses them.
+     */
+    fun book(
+        notes: String? = null,
+        firstName: String? = null,
+        lastName: String? = null,
+        phone: String? = null,
+    ) {
+        val current = _state.value
+        val device = current.selected ?: return
+        val period = current.period ?: return
+        if (!current.canBook) return
+        // Der Vermerk „läuft" muss stehen, bevor der Ablauf zurückkehrt —
+        // sonst kommt ein zweiter Tipp am selben Prüfpunkt vorbei.
+        _state.update { it.copy(booking = true, notice = null) }
+        viewModelScope.launch {
+            runCatching {
+                repo.book(
+                    BookingRequest(
+                        deviceId = device.id,
+                        period = period,
+                        notes = notes,
+                        firstName = firstName,
+                        lastName = lastName,
+                        phone = phone,
+                    ),
+                )
+            }
+                .onSuccess {
+                    _state.update {
+                        it.copy(
+                            booking = false,
+                            selected = null,
+                            images = emptyList(),
+                            occupancy = emptyList(),
+                            availability = null,
+                            period = null,
+                            missingFields = emptyList(),
+                        )
+                    }
+                    _events.emit(RentalEvent.Booked)
+                    loadBookings()
+                }
+                .onFailure { failure ->
+                    _state.update { it.copy(booking = false).after(failure) }
+                    // A period taken in the meantime is the ordinary race
+                    // between drawing the calendar and tapping the button:
+                    // fetch it again instead of leaving a stale picture.
+                    if (failure.rentalCode() == RentalErrorCode.OCCUPIED) {
+                        loadOccupancy(device.id)
+                    }
+                }
+        }
+    }
+
+    /** Withdraws one of my bookings — if the server allows it. */
+    fun cancel(bookingId: String) {
+        if (bookingId in _state.value.cancelling) return
+        // Wie beim Anfragen: erst vermerken, dann losschicken.
+        _state.update { it.copy(cancelling = it.cancelling + bookingId, notice = null) }
+        viewModelScope.launch {
+            runCatching { repo.cancel(bookingId) }
+                .onSuccess {
+                    _state.update { it.copy(cancelling = it.cancelling - bookingId) }
+                    _events.emit(RentalEvent.Cancelled)
+                    loadBookings()
+                }
+                .onFailure { failure ->
+                    _state.update {
+                        it.copy(cancelling = it.cancelling - bookingId).after(failure)
+                    }
+                    // "Already cancelled" and friends: the list over there
+                    // knows better than the one on screen.
+                    loadBookings()
+                }
+        }
+    }
+
+    /** Clears a refusal once it has been read. */
+    fun clearNotice() = _state.update { it.copy(notice = null) }
+
+    /**
+     * One failure, three kinds of consequence.
+     *
+     * A refusal of the platform keeps its wording and is shown. A token that
+     * does not count over there turns into the request to sign in again.
+     * Everything else is the network, and for that the area has its hint.
+     */
+    private fun RentalUiState.after(failure: Throwable): RentalUiState {
+        val error = failure as? RentalApiException
+            ?: return copy(offline = true)
+        return when (error.code) {
+            RentalErrorCode.TOKEN_AUDIENCE -> asStale()
+            RentalErrorCode.UNAUTHORIZED -> asSignedOut()
+            RentalErrorCode.PROFILE_INCOMPLETE -> copy(
+                notice = RentalNotice(error.code, error.message),
+                // What the server misses is what the sheet asks for. The app
+                // has no list of its own.
+                missingFields = error.missingFields,
+            )
+
+            else -> copy(notice = RentalNotice(error.code, error.message))
+        }
+    }
+}
+
+/** Signed in, but with a token from before the changeover. */
+private fun RentalUiState.asStale() =
+    copy(staleSignIn = true, signedIn = false, bookings = emptyList(), profile = null)
+
+/** The sign-in is gone — the ordinary way back is the login screen. */
+private fun RentalUiState.asSignedOut() =
+    copy(signedIn = false, staleSignIn = false, bookings = emptyList(), profile = null)
+
+/** The platform's code, or null when the failure was not one of its answers. */
+private fun Throwable.rentalCode(): RentalErrorCode? = (this as? RentalApiException)?.code
+
+/** Long enough that a typed word is one request, short enough to feel live. */
+const val SEARCH_DELAY = 300L

--- a/android/app/src/main/java/de/roessing/app/ui/RentalViewModel.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/RentalViewModel.kt
@@ -15,6 +15,7 @@ import de.roessing.app.data.RentalPeriod
 import de.roessing.app.data.RentalProfile
 import de.roessing.app.data.RentalRepository
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -313,13 +314,29 @@ class RentalViewModel(
         checkJob?.cancel()
         checkJob = viewModelScope.launch {
             _state.update { it.copy(checking = true) }
-            runCatching { repo.availability(device.id, period) }
-                .onSuccess { answer ->
-                    _state.update { it.copy(checking = false, availability = answer) }
+            val answer = runCatching { repo.availability(device.id, period) }
+            // Ein Abbruch ist kein Ausfall. `runCatching` fängt auch die
+            // CancellationException — ohne diese Zeile meldete jede zweite
+            // Änderung des Zeitraums „nicht erreichbar", weil die abgelöste
+            // Prüfung noch ihren Zustand schriebe.
+            if (!isActive) return@launch
+            // Eine Antwort gilt nur für den Zeitraum, für den sie kam: Wer die
+            // Tage verschiebt, hat keine Antwort mehr, sonst fragte jemand ein
+            // freies Wochenende auf einem belegten an. Der Abbruch oben sorgt
+            // schon dafür, dass keine überholte Antwort ankommt; dass sie zur
+            // Frage gehört, wird hier trotzdem nachgesehen — es ist eine Zeile,
+            // und der Preis eines Irrtums wäre eine falsche Buchung.
+            answer
+                .onSuccess { free ->
+                    _state.update {
+                        if (it.period != period) it.copy(checking = false)
+                        else it.copy(checking = false, availability = free)
+                    }
                 }
                 .onFailure { failure ->
                     _state.update {
-                        it.copy(checking = false, availability = null).after(failure)
+                        if (it.period != period) it.copy(checking = false)
+                        else it.copy(checking = false, availability = null).after(failure)
                     }
                 }
         }

--- a/android/app/src/main/java/de/roessing/app/ui/StartScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/StartScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Handyman
 import androidx.compose.material.icons.filled.LocalFlorist
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.outlined.Lightbulb
@@ -46,7 +47,7 @@ import de.roessing.app.ui.theme.statusFarben
  * Die Bereiche der App. „Mithelfen" ist der erste — weitere kommen, deshalb
  * ist die Startseite eine Übersicht und nicht die Gieß-Karte.
  */
-enum class Bereich { START, MITHELFEN, VERANSTALTUNGEN, PROFIL, DORFBEWOHNER, IDEEN, CHAT }
+enum class Bereich { START, MITHELFEN, VERANSTALTUNGEN, VERLEIH, PROFIL, DORFBEWOHNER, IDEEN, CHAT }
 
 /**
  * Startseite: freundlicher Einstieg mit dem Namen aus dem Profil, darunter
@@ -121,6 +122,16 @@ fun StartScreen(
             symbol = Icons.Filled.Event,
             testTag = "bereich-veranstaltungen",
             onClick = { onBereich(Bereich.VERANSTALTUNGEN) },
+        )
+
+        // Der Maschinchenring: Nachbarn verleihen ihre Geräte. Die Liste kommt
+        // unmittelbar von mieten.rössing.de — gepflegt wird sie dort.
+        BereichKachel(
+            titel = stringResource(R.string.area_rental_title),
+            text = stringResource(R.string.area_rental_subtitle),
+            symbol = Icons.Filled.Handyman,
+            testTag = "bereich-verleih",
+            onClick = { onBereich(Bereich.VERLEIH) },
         )
 
         Row(

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -229,4 +229,109 @@
     <string name="events_organizer">Veranstalter</string>
     <string name="events_source_link">Auf rössing.de ansehen</string>
     <string name="events_source_note">Gepflegt wird der Termin auf rössing.de. Dort steht immer der neueste Stand.</string>
+    <!-- Maschinchenring: der Verleih von Gerät zu Gerät im Dorf. Die Daten
+         kommen unmittelbar von mieten.rössing.de; die App entscheidet nichts,
+         sie zeigt an, was der Server sagt. -->
+    <string name="area_rental_title">Maschinchenring</string>
+    <string name="area_rental_subtitle">Geräte im Dorf leihen.</string>
+    <string name="rental_title">Maschinchenring</string>
+    <string name="rental_intro">Nachbarn verleihen ihre Geräte. Ansehen und suchen geht ohne Anmeldung; gebucht wird mit der Rössing-ID, und der Eigentümer entscheidet.</string>
+    <string name="rental_search_label">Gerät suchen</string>
+    <string name="rental_search_placeholder">Zum Beispiel: Rasenmäher</string>
+    <string name="rental_search_clear">Suche leeren</string>
+    <string name="rental_empty">Hier steht gerade kein Gerät. Sobald jemand eines einstellt, findest du es hier.</string>
+    <string name="rental_empty_search">Zu deiner Suche ist nichts eingestellt.</string>
+    <string name="rental_offline">Der Maschinchenring ist gerade nicht erreichbar. Besteht eine Verbindung?</string>
+    <string name="rental_offline_stale">Gerade keine Verbindung — die Liste ist möglicherweise nicht mehr aktuell.</string>
+    <string name="rental_retry">Erneut versuchen</string>
+
+    <!-- Anmeldung: ansehen geht ohne, buchen nicht. -->
+    <string name="rental_signin_title">Zum Buchen brauchst du deine Rössing-ID</string>
+    <string name="rental_signin_body">Ansehen und suchen geht auch ohne. Buchen, eigene Buchungen sehen und stornieren nur angemeldet.</string>
+    <string name="rental_signin_button">Mit Rössing-ID anmelden</string>
+    <!-- Der Fall, der wie ein Defekt aussieht und keiner ist: Ein Gerät, das
+         schon angemeldet war, behält seinen Token-Satz über die
+         Aktualisierung hinweg — und der gilt für den Maschinchenring nicht. -->
+    <string name="rental_stale_title">Bitte einmal neu anmelden</string>
+    <string name="rental_stale_body">Deine Anmeldung stammt aus der Zeit vor dem Maschinchenring und gilt dort noch nicht. Einmal neu anmelden genügt — deine Buchungen bleiben erhalten.</string>
+    <string name="rental_stale_button">Jetzt neu anmelden</string>
+
+    <!-- Eigene Buchungen -->
+    <string name="rental_bookings_title">Meine Buchungen</string>
+    <string name="rental_bookings_empty">Du hast gerade nichts gebucht.</string>
+    <string name="rental_bookings_offline">Deine Buchungen konnten nicht geladen werden.</string>
+    <string name="rental_cancel_booking">Stornieren</string>
+    <string name="rental_cancelled">Die Buchung ist storniert.</string>
+    <string name="rental_booked">Deine Anfrage ist raus — der Eigentümer entscheidet.</string>
+    <!-- Die vier Zustände, die der Vertrag festlegt. -->
+    <string name="rental_status_pending">Angefragt — der Eigentümer entscheidet</string>
+    <string name="rental_status_approved">Bestätigt</string>
+    <string name="rental_status_rejected">Abgelehnt</string>
+    <string name="rental_status_cancelled">Storniert</string>
+    <string name="rental_pickup_title">Abholung</string>
+    <string name="rental_pickup_phone">Telefon: %1$s</string>
+    <string name="rental_note">Deine Nachricht: %1$s</string>
+
+    <!-- Gerät -->
+    <string name="rental_price_day">%1$s pro Tag</string>
+    <string name="rental_price_weekend">%1$s pro Wochenende</string>
+    <string name="rental_price_week">%1$s pro Woche</string>
+    <string name="rental_deposit">Kaution: %1$s</string>
+    <!-- Bewusst keine Summe: Welcher Tarif bei welcher Dauer gilt, legt der
+         Maschinchenring nirgends fest — eine erfundene Rechnung in der App
+         wäre genau der Bruch zwischen Web und App, den wir vermeiden. -->
+    <string name="rental_price_note">Was am Ende zu zahlen ist, macht ihr beim Abholen aus.</string>
+    <string name="rental_no_price">Kein Preis hinterlegt.</string>
+    <string name="rental_product_link">Herstellerseite ansehen</string>
+    <string name="rental_web_link">Im Browser ansehen</string>
+    <string name="rental_images">%1$d Bilder auf der Webseite</string>
+    <string name="rental_manage_hint">Geräte einstellen und pflegen läuft über die Webseite des Maschinchenrings.</string>
+
+    <!-- Zeitraum und Verfügbarkeit -->
+    <string name="rental_choose_period">Zeitraum wählen</string>
+    <string name="rental_change_period">Zeitraum ändern</string>
+    <string name="rental_period_ok">Übernehmen</string>
+    <string name="rental_period_abort">Abbrechen</string>
+    <!-- Der Rückgabetag gehört nicht mehr zur Buchung: Wer vom 5. bis zum 6.
+         bucht, gibt am 7. zurück, und ab dann kann jemand anders. -->
+    <string name="rental_return_day">Rückgabe am %1$s</string>
+    <string name="rental_checking">Wird geprüft …</string>
+    <string name="rental_free">Frei — du kannst anfragen.</string>
+    <string name="rental_taken">In diesem Zeitraum belegt.</string>
+    <string name="rental_occupied_title">Schon belegt</string>
+    <string name="rental_occupied_pending">angefragt</string>
+    <string name="rental_occupied_approved">vergeben</string>
+    <string name="rental_occupied_blocked">gesperrt</string>
+    <string name="rental_occupied_none">Für dieses Gerät ist nichts eingetragen.</string>
+    <string name="rental_notes_label">Nachricht an den Eigentümer (freiwillig)</string>
+    <string name="rental_book">Anfragen</string>
+    <string name="rental_booking">Wird gesendet …</string>
+
+    <!-- Fehlt dem Maschinchenring etwas am Profil, sagt er, was — die App
+         fragt genau das ab und denkt sich keine eigene Liste aus. -->
+    <string name="rental_missing_title">Der Maschinchenring braucht noch etwas von dir</string>
+    <string name="rental_missing_first_name">Vorname</string>
+    <string name="rental_missing_last_name">Nachname</string>
+    <string name="rental_missing_phone">Telefon</string>
+    <string name="rental_missing_web">Das Übrige trägst du auf der Webseite des Maschinchenrings ein.</string>
+
+    <!-- Ersatzworte für den Fall, dass der Server keinen Satz mitschickt.
+         Entschieden wird immer am Code, nie an der Meldung. -->
+    <string name="rental_error_occupied">In diesem Zeitraum ist das Gerät inzwischen belegt.</string>
+    <string name="rental_error_invalid_period">Der Zeitraum passt nicht: Die Rückgabe muss nach dem Beginn liegen.</string>
+    <string name="rental_error_bad_request">Die Anfrage war unvollständig.</string>
+    <string name="rental_error_profile_incomplete">Für die Buchung fehlen noch Angaben.</string>
+    <string name="rental_error_forbidden">Dazu bist du nicht berechtigt.</string>
+    <string name="rental_error_not_found">Das gibt es nicht mehr.</string>
+    <string name="rental_error_conflict">Das geht gerade nicht mehr — der Stand hat sich geändert.</string>
+    <string name="rental_error_rate_limited">Das ging zu schnell hintereinander. Bitte später noch einmal.</string>
+    <string name="rental_error_internal">Beim Maschinchenring ist etwas schiefgegangen.</string>
+    <string name="rental_error_unknown">Das hat nicht geklappt.</string>
+
+    <string name="rental_browse_public">Geräte im Maschinchenring ansehen</string>
+    <string name="rental_back_to_login">Zurück zur Anmeldung</string>
+    <plurals name="rental_days">
+        <item quantity="one">%1$d Tag</item>
+        <item quantity="other">%1$d Tage</item>
+    </plurals>
 </resources>

--- a/android/app/src/test/java/de/roessing/app/LoginScopesTest.kt
+++ b/android/app/src/test/java/de/roessing/app/LoginScopesTest.kt
@@ -1,7 +1,10 @@
 package de.roessing.app
 
 import de.roessing.app.auth.LOGIN_SCOPES
+import de.roessing.app.auth.MIETEN_AUDIENCE_SCOPE
 import de.roessing.app.auth.ROLLEN_SCOPE
+import de.roessing.app.auth.RentalAudience
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -36,6 +39,33 @@ class LoginScopesTest {
         assertTrue(
             "Erwartet wird der Scope mit „projects\" (Plural): $ROLLEN_SCOPE",
             ROLLEN_SCOPE == "urn:zitadel:iam:org:projects:roles",
+        )
+    }
+
+    /**
+     * Ohne den Empfänger-Scope gilt das Token für die Mietplattform nicht:
+     * Sie prüft die `aud` und weist jede angemeldete Anfrage ab. Der Bereich
+     * „Maschinchenring" wäre dann für alle lesend und für niemanden buchbar —
+     * und niemand sähe, woran es liegt.
+     */
+    @Test
+    fun `der Login fordert die Mietplattform als Empfaenger mit an`() {
+        assertTrue(
+            "Die App fordert $MIETEN_AUDIENCE_SCOPE nicht an — dann kann niemand " +
+                "buchen: $LOGIN_SCOPES",
+            LOGIN_SCOPES.contains(MIETEN_AUDIENCE_SCOPE),
+        )
+    }
+
+    /**
+     * Die Projektkennung gehört in die Build-Einstellungen, nicht in den
+     * Quelltext — sonst lässt sie sich in CI und Tests nicht übersteuern.
+     */
+    @Test
+    fun `die Projektkennung kommt aus den Build-Einstellungen`() {
+        assertEquals(
+            RentalAudience.scopeFor(BuildConfig.MIETEN_PROJECT_ID),
+            MIETEN_AUDIENCE_SCOPE,
         )
     }
 

--- a/android/app/src/test/java/de/roessing/app/RentalApiTest.kt
+++ b/android/app/src/test/java/de/roessing/app/RentalApiTest.kt
@@ -1,0 +1,350 @@
+package de.roessing.app
+
+import de.roessing.app.auth.RentalSignIn
+import de.roessing.app.auth.TokenResult
+import de.roessing.app.data.BookingRequest
+import de.roessing.app.data.BookingStatus
+import de.roessing.app.data.LenderStatus
+import de.roessing.app.data.MietenApi
+import de.roessing.app.data.MietenRentalRepository
+import de.roessing.app.data.OccupancyStatus
+import de.roessing.app.data.RentalApiException
+import de.roessing.app.data.RentalErrorCode
+import de.roessing.app.data.RentalPeriod
+import kotlinx.coroutines.test.runTest
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.time.LocalDate
+
+/**
+ * Der Vertrag mit der Mietplattform: So sehen ihre Antworten aus, und so
+ * werden sie gelesen. Die Beispiele stammen Wort für Wort aus
+ * `docs/mieten-api.md` und liegen unter `android/e2e/fixtures/mieten/` —
+ * ändert sich die Form drüben, muss es hier auffallen und nicht erst als
+ * leere Liste auf dem Telefon.
+ *
+ * Der Server ist ein MockWebServer im selben Prozess. Kein Test dieser Datei
+ * fasst einen entfernten Dienst an.
+ */
+class RentalApiTest {
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun vorher() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun nachher() = server.shutdown()
+
+    /** Die Beispieldatei zu einer Route. */
+    private fun beispiel(name: String): String {
+        val kandidaten = listOf(
+            File("../e2e/fixtures/mieten/$name"),
+            File("android/e2e/fixtures/mieten/$name"),
+        )
+        val datei = kandidaten.firstOrNull { it.isFile }
+            ?: error("Beispieldatei nicht gefunden: $name (${File(".").absolutePath})")
+        return datei.readText()
+    }
+
+    private fun antwort(name: String, code: Int = 200) = MockResponse()
+        .setResponseCode(code)
+        .setHeader("Content-Type", "application/json; charset=utf-8")
+        .setBody(beispiel(name))
+
+    private fun repo(
+        signIn: RentalSignIn = RentalSignIn.VALID,
+        token: TokenResult = TokenResult.Token("wert"),
+    ) = MietenRentalRepository(
+        MietenApi.create(server.url("/").toString()) { token },
+        signIn = { signIn },
+    )
+
+    @Test
+    fun `die Geraeteliste kommt in ihrer Huelle und ohne Eigentuemer`() = runTest {
+        server.enqueue(antwort("items.json"))
+
+        val geraete = repo().devices()
+
+        assertEquals(3, geraete.size)
+        val maeher = geraete.first()
+        assertEquals("as-585-km-kreiselmaeher", maeher.id)
+        assertEquals("AS 585 KM Kreiselmäher", maeher.name)
+        assertEquals(25.0, maeher.pricePerDay!!, 0.001)
+        assertEquals(40.0, maeher.pricePerWeekend!!, 0.001)
+        assertEquals(120.0, maeher.pricePerWeek!!, 0.001)
+        assertEquals(100.0, maeher.deposit!!, 0.001)
+        assertEquals(listOf("garten", "motorgeraet"), maeher.tags)
+
+        // Fehlende Tarife bleiben fehlend — sie sind nicht null-gleich-null.
+        val walze = geraete[1]
+        assertNull(walze.pricePerWeekend)
+        assertNull(walze.deposit)
+        assertNull(walze.description)
+        assertNull(walze.thumbnailUrl)
+
+        assertEquals("/api/v1/items", server.takeRequest().path)
+    }
+
+    @Test
+    fun `die oeffentlichen Routen schicken kein Token mit`() = runTest {
+        server.enqueue(antwort("items.json"))
+
+        repo(token = TokenResult.Token("streng-geheim")).devices()
+
+        // Wer nur schaut, gibt nichts von sich preis — und der Bereich
+        // funktioniert vor jeder Anmeldung.
+        assertNull(server.takeRequest().getHeader("Authorization"))
+    }
+
+    @Test
+    fun `das Geraet im Detail bringt seine Bilder mit`() = runTest {
+        server.enqueue(antwort("item-detail.json"))
+
+        val detail = repo().device("as-585-km-kreiselmaeher")
+
+        assertEquals("AS 585 KM Kreiselmäher", detail.device.name)
+        assertEquals(2, detail.images.size)
+        assertTrue(detail.images.first().isThumbnail)
+        assertEquals("/api/v1/items/as-585-km-kreiselmaeher", server.takeRequest().path)
+    }
+
+    @Test
+    fun `die Suche fragt den Server und sortiert nicht um`() = runTest {
+        server.enqueue(antwort("search.json"))
+
+        val treffer = repo().search("rasen")
+
+        // Nach Passung, nicht nach Namen — die Reihenfolge ist die des Servers.
+        assertEquals(
+            listOf("as-585-km-kreiselmaeher", "018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11"),
+            treffer.map { it.id },
+        )
+        val pfad = server.takeRequest().path!!
+        assertTrue(pfad, pfad.startsWith("/api/v1/search?"))
+        assertTrue(pfad, pfad.contains("q=rasen"))
+        assertTrue(pfad, pfad.contains("limit=20"))
+    }
+
+    @Test
+    fun `die Verfuegbarkeit beantwortet der Server, nicht die App`() = runTest {
+        server.enqueue(antwort("availability-taken.json"))
+
+        val zeitraum = RentalPeriod(LocalDate.parse("2026-09-05"), LocalDate.parse("2026-09-07"))
+        val antwort = repo().availability("as-585-km-kreiselmaeher", zeitraum)
+
+        assertEquals(false, antwort.available)
+        // „occupied" ist eine Kennung, kein Satz für die Anzeige.
+        assertEquals("occupied", antwort.reason)
+
+        val pfad = server.takeRequest().path!!
+        assertTrue(pfad, pfad.contains("deviceId=as-585-km-kreiselmaeher"))
+        assertTrue(pfad, pfad.contains("startDate=2026-09-05"))
+        // Der Rückgabetag geht so hinaus, wie der Vertrag ihn versteht.
+        assertTrue(pfad, pfad.contains("endDate=2026-09-07"))
+    }
+
+    @Test
+    fun `belegt ist belegt, gleich aus welchem Grund`() = runTest {
+        server.enqueue(antwort("occupancy.json"))
+
+        val belegt = repo().occupancy("as-585-km-kreiselmaeher")
+
+        assertEquals(
+            listOf(OccupancyStatus.APPROVED, OccupancyStatus.PENDING, OccupancyStatus.BLOCKED),
+            belegt.map { it.status },
+        )
+        // Der erste Eintrag belegt den 5. und den 6. — nicht den 7.
+        assertEquals(LocalDate.parse("2026-09-06"), belegt.first().period.lastDay)
+    }
+
+    @Test
+    fun `die angemeldeten Routen tragen das Token`() = runTest {
+        server.enqueue(antwort("my-bookings.json"))
+
+        val buchungen = repo(token = TokenResult.Token("abc123")).myBookings()
+
+        assertEquals(3, buchungen.size)
+        assertEquals("Bearer abc123", server.takeRequest().getHeader("Authorization"))
+
+        val bestaetigt = buchungen.first()
+        assertEquals(BookingStatus.APPROVED, bestaetigt.status)
+        assertTrue(bestaetigt.canCancel)
+        // Die Abholadresse steht erst nach der Zusage da.
+        assertEquals("Hauptstraße 1, 31171 Nordstemmen", bestaetigt.pickup?.address)
+        assertNull(buchungen[1].pickup)
+        assertEquals(BookingStatus.REJECTED, buchungen[2].status)
+        assertEquals(false, buchungen[2].canCancel)
+    }
+
+    @Test
+    fun `das Profil sagt selbst, was ihm fehlt`() = runTest {
+        server.enqueue(antwort("me.json"))
+
+        val profil = repo().profile()
+
+        assertEquals("Erika Musterfrau", profil.name)
+        assertEquals(LenderStatus.NONE, profil.lenderStatus)
+        assertTrue(profil.profileComplete)
+        assertTrue(profil.missingFields.isEmpty())
+    }
+
+    /**
+     * Der Normalfall der Buchung: Name und Telefon nimmt der Server aus dem
+     * Profil. Wer sie trotzdem mitschickt, macht aus einer Auslassung eine
+     * zweite Pflegestelle.
+     */
+    @Test
+    fun `eine Buchung laesst die Personenfelder weg`() = runTest {
+        server.enqueue(antwort("booking-created.json", code = 201))
+
+        val buchung = repo().book(
+            BookingRequest(
+                deviceId = "as-585-km-kreiselmaeher",
+                period = RentalPeriod(
+                    LocalDate.parse("2026-09-05"),
+                    LocalDate.parse("2026-09-07"),
+                ),
+                notes = "Hole ich Samstag früh ab.",
+            ),
+        )
+
+        assertEquals(BookingStatus.PENDING, buchung.status)
+        val koerper = server.takeRequest().body.readUtf8()
+        assertTrue(koerper, koerper.contains("\"deviceId\":\"as-585-km-kreiselmaeher\""))
+        assertTrue(koerper, koerper.contains("\"startDate\":\"2026-09-05\""))
+        assertTrue(koerper, koerper.contains("\"endDate\":\"2026-09-07\""))
+        assertFalse(koerper, koerper.contains("firstName"))
+        assertFalse(koerper, koerper.contains("phone"))
+    }
+
+    @Test
+    fun `ein belegter Zeitraum kommt als Kennung, nicht als Absturz`() = runTest {
+        server.enqueue(antwort("error-occupied.json", code = 409))
+
+        val fehler = fehlerVon {
+            repo().book(
+                BookingRequest(
+                    deviceId = "as-585-km-kreiselmaeher",
+                    period = RentalPeriod(
+                        LocalDate.parse("2026-09-05"),
+                        LocalDate.parse("2026-09-07"),
+                    ),
+                ),
+            )
+        }
+
+        assertEquals(RentalErrorCode.OCCUPIED, fehler.code)
+        // Die Meldung ist deutsch und darf so gezeigt werden.
+        assertEquals("In diesem Zeitraum ist das Gerät schon vergeben", fehler.message)
+    }
+
+    @Test
+    fun `ein unvollstaendiges Profil sagt, welche Felder fehlen`() = runTest {
+        server.enqueue(antwort("error-profile-incomplete.json", code = 400))
+
+        val fehler = fehlerVon {
+            repo().book(
+                BookingRequest(
+                    deviceId = "as-585-km-kreiselmaeher",
+                    period = RentalPeriod(
+                        LocalDate.parse("2026-09-05"),
+                        LocalDate.parse("2026-09-07"),
+                    ),
+                ),
+            )
+        }
+
+        assertEquals(RentalErrorCode.PROFILE_INCOMPLETE, fehler.code)
+        assertEquals(
+            listOf("phone", "addressStreet", "addressZip", "addressCity"),
+            fehler.missingFields,
+        )
+    }
+
+    /**
+     * Der Stolperstein dieses Projekts: Ein Gerät, das schon angemeldet war,
+     * behält seinen Token-Satz über die Aktualisierung hinweg. Die
+     * Mietplattform sagt dazu `token_audience` — und das heißt „neu
+     * anmelden", nicht „abgemeldet".
+     */
+    @Test
+    fun `ein Token ohne Empfaenger wird als solches erkannt`() = runTest {
+        server.enqueue(antwort("error-token-audience.json", code = 401))
+
+        val fehler = fehlerVon { repo().myBookings() }
+
+        assertEquals(RentalErrorCode.TOKEN_AUDIENCE, fehler.code)
+    }
+
+    /**
+     * Steht schon vor dem Absenden fest, dass das Token drüben nicht gilt,
+     * geht die Anfrage gar nicht erst hinaus.
+     */
+    @Test
+    fun `ein veraltetes Token kostet keinen vergeblichen Abruf`() = runTest {
+        val fehler = fehlerVon { repo(signIn = RentalSignIn.STALE).myBookings() }
+
+        assertEquals(RentalErrorCode.TOKEN_AUDIENCE, fehler.code)
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `ohne Anmeldung geht keine persoenliche Anfrage hinaus`() = runTest {
+        val fehler = fehlerVon { repo(signIn = RentalSignIn.MISSING).myBookings() }
+
+        assertEquals(RentalErrorCode.UNAUTHORIZED, fehler.code)
+        assertEquals(0, server.requestCount)
+    }
+
+    /**
+     * Nicht fragen zu können ist kein Nein: Läuft die Erneuerung gerade ins
+     * Leere, geht die Anfrage nicht ohne Kopfzeile hinaus — sie käme als 401
+     * zurück, und die App hielte eine gültige Anmeldung für beendet.
+     */
+    @Test
+    fun `ohne erneuerbares Token geht die Anfrage nicht nackt hinaus`() {
+        val anfrage = Request.Builder()
+            .url("https://mieten.example.invalid/api/v1/me")
+            .header(de.roessing.app.data.AUTH_MARKER, "required")
+            .build()
+
+        org.junit.Assert.assertThrows(java.io.IOException::class.java) {
+            MietenApi.authorized(anfrage, TokenResult.Unreachable)
+        }
+    }
+
+    @Test
+    fun `eine unmarkierte Anfrage bleibt unangetastet`() {
+        val anfrage = Request.Builder()
+            .url("https://mieten.example.invalid/api/v1/items")
+            .build()
+
+        val hinaus = MietenApi.authorized(anfrage, TokenResult.Token("abc"))
+
+        assertNull(hinaus.header("Authorization"))
+    }
+
+    /**
+     * Der erwartete Fehler der Mietplattform. Ohne Umweg über runBlocking:
+     * ein zweiter Ablaufplan mitten in einem Test ist eine Quelle von
+     * Hängern, die mit der Sache nichts zu tun haben.
+     */
+    private suspend fun fehlerVon(block: suspend () -> Unit): RentalApiException = try {
+        block()
+        throw AssertionError("Es kam kein Fehler der Mietplattform zurück.")
+    } catch (erwartet: RentalApiException) {
+        erwartet
+    }
+}

--- a/android/app/src/test/java/de/roessing/app/RentalAudienceTest.kt
+++ b/android/app/src/test/java/de/roessing/app/RentalAudienceTest.kt
@@ -1,0 +1,89 @@
+package de.roessing.app
+
+import de.roessing.app.auth.RentalAudience
+import de.roessing.app.auth.RentalSignIn
+import de.roessing.app.auth.TokenResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.Base64
+
+/**
+ * Gilt das Token dieses Geräts für die Mietplattform?
+ *
+ * Der Scope, der ihr Projekt in die `aud` legt, wirkt erst bei der
+ * **nächsten** Anmeldung. Ein Gerät, das schon angemeldet war, behält seinen
+ * Token-Satz über die Aktualisierung hinweg — und bekommt von der
+ * Mietplattform auf jede Anfrage ein 401. Wer das nicht vorher ansieht, zeigt
+ * eine leere Liste und weiß nicht, warum.
+ */
+class RentalAudienceTest {
+    private val projekt = "377276525071827047"
+
+    private fun token(nutzlast: String): String {
+        val teil = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(nutzlast.toByteArray(Charsets.UTF_8))
+        return "kopf.$teil.unterschrift"
+    }
+
+    @Test
+    fun `der Scope traegt die Projektkennung`() {
+        assertEquals(
+            "urn:zitadel:iam:org:project:id:$projekt:aud",
+            RentalAudience.scopeFor(projekt),
+        )
+    }
+
+    @Test
+    fun `eine Empfaengerliste wird gelesen`() {
+        val jwt = token("""{"aud":["dorf-app","$projekt"],"sub":"erna"}""")
+
+        assertEquals(listOf("dorf-app", projekt), RentalAudience.audiences(jwt))
+        assertEquals(true, RentalAudience.namesProject(jwt, projekt))
+    }
+
+    /** RFC 7519 lässt `aud` auch als einzelne Zeichenkette zu. */
+    @Test
+    fun `ein einzelner Empfaenger wird ebenso gelesen`() {
+        val jwt = token("""{"aud":"dorf-app"}""")
+
+        assertEquals(listOf("dorf-app"), RentalAudience.audiences(jwt))
+        assertEquals(false, RentalAudience.namesProject(jwt, projekt))
+    }
+
+    /**
+     * Ein undurchsichtiges Token ist kein Nein. Die App darf niemandem auf
+     * Verdacht sagen, er solle sich neu anmelden — dann entscheidet der
+     * Server.
+     */
+    @Test
+    fun `ein unlesbares Token laesst die Frage offen`() {
+        assertNull(RentalAudience.audiences("kein-jwt"))
+        assertNull(RentalAudience.namesProject("kein-jwt", projekt))
+        assertEquals(RentalSignIn.VALID, RentalAudience.state(TokenResult.Token("x"), projekt))
+    }
+
+    @Test
+    fun `ein Token von vor der Umstellung heisst neu anmelden`() {
+        val alt = TokenResult.Token(token("""{"aud":["dorf-app"]}"""))
+
+        assertEquals(RentalSignIn.STALE, RentalAudience.state(alt, projekt))
+    }
+
+    @Test
+    fun `ein Token mit der Mietplattform gilt`() {
+        val neu = TokenResult.Token(token("""{"aud":["dorf-app","$projekt"]}"""))
+
+        assertEquals(RentalSignIn.VALID, RentalAudience.state(neu, projekt))
+    }
+
+    /**
+     * Nicht fragen zu können ist kein Nein: Die Anmeldung steht, das Netz
+     * nicht. Der Bereich zeigt „nicht erreichbar", nicht „neu anmelden".
+     */
+    @Test
+    fun `ein Funkloch ist keine abgelaufene Anmeldung`() {
+        assertEquals(RentalSignIn.UNREACHABLE, RentalAudience.state(TokenResult.Unreachable, projekt))
+        assertEquals(RentalSignIn.MISSING, RentalAudience.state(TokenResult.LoggedOut, projekt))
+    }
+}

--- a/android/app/src/test/java/de/roessing/app/RentalPeriodTest.kt
+++ b/android/app/src/test/java/de/roessing/app/RentalPeriodTest.kt
@@ -1,0 +1,139 @@
+package de.roessing.app
+
+import de.roessing.app.data.RentalPeriod
+import de.roessing.app.data.euroText
+import de.roessing.app.data.markdownAsPlainText
+import de.roessing.app.ui.periodOfPicked
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Der halboffene Zeitraum ist die eine Stelle des Vertrags, an der ein
+ * Missverständnis einen ganzen Tag kostet: `endDate` ist der **Rückgabetag**
+ * und gehört nicht mehr zur Buchung. Wer vom 5. bis zum 7. bucht, hat das
+ * Gerät am 5. und am 6.; am 7. kann jemand anders anfangen.
+ *
+ * Genau dazwischen liegt der Kalender: Er gibt die Tage her, an denen jemand
+ * das Gerät haben will. Die Umrechnung passiert an einer Stelle, und die
+ * steht hier unter Beobachtung.
+ */
+class RentalPeriodTest {
+    @Test
+    fun `der Rueckgabetag gehoert nicht mehr zur Buchung`() {
+        val zeitraum = RentalPeriod(LocalDate.parse("2026-09-05"), LocalDate.parse("2026-09-07"))
+
+        assertEquals(LocalDate.parse("2026-09-06"), zeitraum.lastDay)
+        assertEquals(2, zeitraum.days)
+        assertTrue(zeitraum.isValid)
+    }
+
+    @Test
+    fun `ein einziger Tag ist ein Tag, nicht null`() {
+        val zeitraum = RentalPeriod(LocalDate.parse("2026-09-05"), LocalDate.parse("2026-09-06"))
+
+        assertEquals(1, zeitraum.days)
+        assertEquals("5. September 2026", zeitraum.text)
+    }
+
+    @Test
+    fun `ein Zeitraum ohne Dauer ist keiner`() {
+        val gleich = RentalPeriod(LocalDate.parse("2026-09-05"), LocalDate.parse("2026-09-05"))
+        val verdreht = RentalPeriod(LocalDate.parse("2026-09-05"), LocalDate.parse("2026-09-04"))
+
+        assertFalse(gleich.isValid)
+        assertFalse(verdreht.isValid)
+    }
+
+    @Test
+    fun `der Text nennt die Tage, an denen das Geraet draussen ist`() {
+        fun text(von: String, bis: String) =
+            RentalPeriod(LocalDate.parse(von), LocalDate.parse(bis)).text
+
+        assertEquals("5.–6. September 2026", text("2026-09-05", "2026-09-07"))
+        assertEquals("30. September – 2. Oktober 2026", text("2026-09-30", "2026-10-03"))
+        assertEquals("30. Dezember 2026 – 1. Januar 2027", text("2026-12-30", "2027-01-02"))
+    }
+
+    /**
+     * Der Kalender gibt UTC-Mitternachten heraus. Wer sie in Ortszeit
+     * zurückliest, landet in der Sommerzeit auf dem Vortag — und der
+     * angetippte Tag wäre nicht der gebuchte.
+     */
+    @Test
+    fun `aus zwei angetippten Tagen wird ein Zeitraum mit Rueckgabetag`() {
+        val erster = tag("2026-09-05")
+        val letzter = tag("2026-09-06")
+
+        val zeitraum = periodOfPicked(erster, letzter)!!
+
+        assertEquals(LocalDate.parse("2026-09-05"), zeitraum.start)
+        assertEquals(LocalDate.parse("2026-09-07"), zeitraum.end)
+        assertEquals(2, zeitraum.days)
+    }
+
+    @Test
+    fun `ein einzeln angetippter Tag ergibt einen Miettag`() {
+        val zeitraum = periodOfPicked(tag("2026-09-05"), null)!!
+
+        assertEquals(LocalDate.parse("2026-09-05"), zeitraum.start)
+        assertEquals(LocalDate.parse("2026-09-06"), zeitraum.end)
+        assertEquals(1, zeitraum.days)
+        assertTrue(zeitraum.isValid)
+    }
+
+    @Test
+    fun `ohne Auswahl gibt es keinen Zeitraum`() {
+        assertNull(periodOfPicked(null, null))
+        assertNull(periodOfPicked(null, tag("2026-09-06")))
+    }
+
+    @Test
+    fun `ein Preis wird deutsch geschrieben und nicht verrechnet`() {
+        assertEquals("25 €", euroText(25.0))
+        assertEquals("12,50 €", euroText(12.5))
+        assertEquals("8 €", euroText(8.0))
+        assertEquals("0,99 €", euroText(0.99))
+    }
+
+    /**
+     * Beschreibungen kommen als Markdown. Roh mit Sternchen wäre keine
+     * Lösung; die App zeigt sie deshalb bewusst als Klartext.
+     */
+    @Test
+    fun `Markdown wird lesbarer Klartext`() {
+        val roh = """
+            ## Kreiselmäher
+
+            Für **hohes** Gras und *Böschungen*.
+
+            - Arbeitsbreite 85 cm
+            - Benzin, [Herstellerseite](https://example.invalid/as-585)
+        """.trimIndent()
+
+        assertEquals(
+            """
+            Kreiselmäher
+
+            Für hohes Gras und Böschungen.
+
+            • Arbeitsbreite 85 cm
+            • Benzin, Herstellerseite
+            """.trimIndent(),
+            markdownAsPlainText(roh),
+        )
+    }
+
+    @Test
+    fun `ein Unterstrich mitten im Wort bleibt stehen`() {
+        // Sonst zerlegte die Übersetzung Namen wie `as_585_km`.
+        assertEquals("Typ as_585_km", markdownAsPlainText("Typ as_585_km"))
+    }
+
+    private fun tag(datum: String): Long =
+        LocalDate.parse(datum).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+}

--- a/android/app/src/test/java/de/roessing/app/RentalViewModelTest.kt
+++ b/android/app/src/test/java/de/roessing/app/RentalViewModelTest.kt
@@ -18,6 +18,7 @@ import de.roessing.app.data.RentalProfile
 import de.roessing.app.data.RentalRepository
 import de.roessing.app.ui.RentalEvent
 import de.roessing.app.ui.RentalViewModel
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -53,6 +54,13 @@ private class FakeRental : RentalRepository {
     var occupancy: List<RentalOccupancy> = emptyList()
     var availability: RentalAvailability? = null
     var profile: RentalProfile = profil()
+
+    /**
+     * Hält eine Verfügbarkeitsprüfung an, solange sie nicht freigegeben ist.
+     * Ohne sie ist eine abgelöste Prüfung schon vorbei, bevor sie abgebrochen
+     * werden kann — und der Fall, um den es geht, träte gar nicht ein.
+     */
+    var availabilityGate: CompletableDeferred<Unit>? = null
 
     /** Was der nächste Abruf werfen soll, statt zu antworten. */
     var devicesFailure: Throwable? = null
@@ -96,8 +104,12 @@ private class FakeRental : RentalRepository {
         deviceId: String,
         period: RentalPeriod,
     ): RentalAvailability {
+        availabilityGate?.await()
         availabilityFailure?.let { throw it }
-        return availability ?: RentalAvailability(period, available = false, reason = "occupied")
+        // Die Antwort trägt den Zeitraum, für den gefragt wurde — genau
+        // darauf kommt es an, wenn zwei Prüfungen unterwegs sind.
+        return availability?.copy(period = period)
+            ?: RentalAvailability(period, available = false, reason = "occupied")
     }
 
     override suspend fun profile(): RentalProfile {
@@ -439,6 +451,103 @@ class RentalViewModelTest {
         vm.setPeriod(zeitraum())
         advanceUntilIdle()
         assertTrue(vm.state.value.canBook)
+    }
+
+    /**
+     * Eine Antwort auf „ist es frei?" gilt für **den** Zeitraum, für den sie
+     * kam. Wer die Tage verschiebt, hat keine Antwort mehr — sonst fragte
+     * jemand ein freies Wochenende auf einem belegten an.
+     */
+    @Test
+    fun `eine Antwort auf einen alten Zeitraum zaehlt nicht`() = runTest(dispatcher) {
+        val repo = FakeRental().apply { devices = listOf(geraet("maeher")) }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+        vm.open(repo.devices.first())
+        advanceUntilIdle()
+
+        repo.availability = RentalAvailability(zeitraum(), available = true, reason = null)
+        vm.setPeriod(zeitraum())
+        advanceUntilIdle()
+        assertTrue(vm.state.value.canBook)
+
+        // Ein anderer Zeitraum: Die alte Zusage darf ihn nicht mittragen —
+        // weder gleich beim Umstellen noch, wenn die neue Antwort da ist.
+        val anderer = zeitraum("2026-10-01", "2026-10-03")
+        vm.setPeriod(anderer)
+        assertNull(vm.state.value.availability)
+        assertFalse(vm.state.value.canBook)
+
+        advanceUntilIdle()
+        assertEquals(anderer, vm.state.value.availability?.period)
+    }
+
+    /**
+     * Und derselbe Fall von der anderen Seite: Eine Antwort, die zu einem
+     * inzwischen abgelösten Zeitraum gehört, darf den neuen nicht freigeben.
+     */
+    @Test
+    fun `eine ueberholte Zusage gibt den neuen Zeitraum nicht frei`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            devices = listOf(geraet("maeher"))
+            availability = RentalAvailability(zeitraum(), available = true, reason = null)
+            availabilityGate = CompletableDeferred()
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+        vm.open(repo.devices.first())
+        advanceUntilIdle()
+
+        val alter = zeitraum()
+        vm.setPeriod(alter)
+        advanceUntilIdle()
+        // Die Prüfung hängt noch an der Schranke.
+        assertTrue(vm.state.value.checking)
+        assertNull(vm.state.value.availability)
+
+        val neuer = zeitraum("2026-10-01", "2026-10-03")
+        vm.setPeriod(neuer)
+        repo.availabilityGate?.complete(Unit)
+        advanceUntilIdle()
+
+        // Die Antwort, die ankommt, gehört zum neuen Zeitraum.
+        assertEquals(neuer, vm.state.value.availability?.period)
+    }
+
+    /**
+     * Wer schnell zweimal einen Zeitraum wählt, bricht die erste Prüfung ab.
+     * Ein Abbruch ist kein Ausfall — sonst stünde „nicht erreichbar" da,
+     * obwohl nichts fehlt.
+     */
+    @Test
+    fun `eine abgeloeste Pruefung meldet keinen Ausfall`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            devices = listOf(geraet("maeher"))
+            availability = RentalAvailability(zeitraum(), available = true, reason = null)
+            availabilityGate = CompletableDeferred()
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+        vm.open(repo.devices.first())
+        advanceUntilIdle()
+
+        vm.setPeriod(zeitraum())
+        // Erst laufen lassen, damit die Prüfung wirklich an der Schranke
+        // hängt — sonst wird sie abgebrochen, bevor sie begonnen hat, und der
+        // Fall, um den es geht, träte nie ein.
+        advanceUntilIdle()
+        assertTrue(vm.state.value.checking)
+
+        vm.setPeriod(zeitraum("2026-10-01", "2026-10-03"))
+        repo.availabilityGate?.complete(Unit)
+        advanceUntilIdle()
+
+        // Der Abbruch der ersten Prüfung ist kein Ausfall der Mietplattform.
+        assertFalse(vm.state.value.offline)
+        assertFalse(vm.state.value.checking)
     }
 
     @Test

--- a/android/app/src/test/java/de/roessing/app/RentalViewModelTest.kt
+++ b/android/app/src/test/java/de/roessing/app/RentalViewModelTest.kt
@@ -1,0 +1,637 @@
+package de.roessing.app
+
+import de.roessing.app.auth.RentalSignIn
+import de.roessing.app.data.BookingRequest
+import de.roessing.app.data.BookingStatus
+import de.roessing.app.data.LenderStatus
+import de.roessing.app.data.OccupancyStatus
+import de.roessing.app.data.RentalApiException
+import de.roessing.app.data.RentalAvailability
+import de.roessing.app.data.RentalBooking
+import de.roessing.app.data.RentalDevice
+import de.roessing.app.data.RentalDeviceDetail
+import de.roessing.app.data.RentalErrorCode
+import de.roessing.app.data.RentalImage
+import de.roessing.app.data.RentalOccupancy
+import de.roessing.app.data.RentalPeriod
+import de.roessing.app.data.RentalProfile
+import de.roessing.app.data.RentalRepository
+import de.roessing.app.ui.RentalEvent
+import de.roessing.app.ui.RentalViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+import java.time.LocalDate
+
+/**
+ * Der Bereich „Maschinchenring" in der App.
+ *
+ * Geprüft wird vor allem, was leicht schiefgeht und was ausdrücklich **nicht**
+ * die App entscheidet: Der Knopf zum Anfragen hängt an der Antwort des
+ * Servers, nicht an einer eigenen Rechnung; ein Token von vor der Umstellung
+ * führt zu einem Satz, den jemand befolgen kann, statt zu einer leeren Liste;
+ * und ein Ausfall der Mietplattform lässt die zuletzt geholte Liste stehen.
+ */
+private class FakeRental : RentalRepository {
+    var devices: List<RentalDevice> = emptyList()
+    var searchResults: List<RentalDevice> = emptyList()
+    var bookings: List<RentalBooking> = emptyList()
+    var occupancy: List<RentalOccupancy> = emptyList()
+    var availability: RentalAvailability? = null
+    var profile: RentalProfile = profil()
+
+    /** Was der nächste Abruf werfen soll, statt zu antworten. */
+    var devicesFailure: Throwable? = null
+    var bookingsFailure: Throwable? = null
+    var profileFailure: Throwable? = null
+    var bookFailure: Throwable? = null
+    var cancelFailure: Throwable? = null
+    var availabilityFailure: Throwable? = null
+
+    var deviceCalls = 0
+    var searchCalls = 0
+    var occupancyCalls = 0
+    var bookingCalls = 0
+    var lastRequest: BookingRequest? = null
+    var cancelled = mutableListOf<String>()
+
+    override suspend fun devices(): List<RentalDevice> {
+        deviceCalls++
+        devicesFailure?.let { throw it }
+        return devices
+    }
+
+    override suspend fun device(id: String): RentalDeviceDetail =
+        RentalDeviceDetail(
+            device = devices.firstOrNull { it.id == id } ?: geraet(id),
+            images = listOf(RentalImage("img-1", "https://bild.example.invalid/1.jpg", true)),
+        )
+
+    override suspend fun search(query: String): List<RentalDevice> {
+        searchCalls++
+        devicesFailure?.let { throw it }
+        return searchResults
+    }
+
+    override suspend fun occupancy(deviceId: String): List<RentalOccupancy> {
+        occupancyCalls++
+        return occupancy
+    }
+
+    override suspend fun availability(
+        deviceId: String,
+        period: RentalPeriod,
+    ): RentalAvailability {
+        availabilityFailure?.let { throw it }
+        return availability ?: RentalAvailability(period, available = false, reason = "occupied")
+    }
+
+    override suspend fun profile(): RentalProfile {
+        profileFailure?.let { throw it }
+        return profile
+    }
+
+    override suspend fun myBookings(): List<RentalBooking> {
+        bookingCalls++
+        bookingsFailure?.let { throw it }
+        return bookings
+    }
+
+    override suspend fun book(request: BookingRequest): RentalBooking {
+        lastRequest = request
+        bookFailure?.let { throw it }
+        return buchung("neu", request.period)
+    }
+
+    override suspend fun cancel(bookingId: String) {
+        cancelFailure?.let { throw it }
+        cancelled += bookingId
+    }
+}
+
+private fun geraet(id: String, name: String = "Kreiselmäher") = RentalDevice(
+    id = id,
+    name = name,
+    description = "Für hohes Gras.",
+    pricePerDay = 25.0,
+    pricePerWeekend = null,
+    pricePerWeek = null,
+    deposit = 100.0,
+    tags = listOf("garten"),
+    thumbnailUrl = null,
+    productUrl = null,
+    webUrl = "https://mieten.example.invalid/geraete/$id/",
+)
+
+private fun zeitraum(von: String = "2026-09-05", bis: String = "2026-09-07") =
+    RentalPeriod(LocalDate.parse(von), LocalDate.parse(bis))
+
+private fun buchung(
+    id: String,
+    period: RentalPeriod = zeitraum(),
+    canCancel: Boolean = true,
+) = RentalBooking(
+    id = id,
+    deviceId = "maeher",
+    setId = null,
+    deviceName = "Kreiselmäher",
+    period = period,
+    status = BookingStatus.PENDING,
+    rawStatus = "pending",
+    notes = null,
+    canCancel = canCancel,
+    pickup = null,
+)
+
+private fun profil(missing: List<String> = emptyList()) = RentalProfile(
+    name = "Erika Musterfrau",
+    email = "erika@example.invalid",
+    phone = "+49 5069 123456",
+    addressStreet = "Hauptstraße 1",
+    addressZip = "31171",
+    addressCity = "Nordstemmen",
+    lender = false,
+    lenderStatus = LenderStatus.NONE,
+    profileComplete = missing.isEmpty(),
+    missingFields = missing,
+)
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RentalViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun vorher() = Dispatchers.setMain(dispatcher)
+
+    @After fun nachher() = Dispatchers.resetMain()
+
+    private fun vm(
+        repo: RentalRepository,
+        signIn: RentalSignIn = RentalSignIn.MISSING,
+    ) = RentalViewModel(repo, signIn = { signIn }, searchDelay = 0L)
+
+    // --- Ansehen und suchen, ohne Anmeldung ---------------------------------
+
+    @Test
+    fun `ohne Anmeldung stehen die Geraete trotzdem da`() = runTest(dispatcher) {
+        val repo = FakeRental().apply { devices = listOf(geraet("maeher"), geraet("walze")) }
+        val vm = vm(repo)
+
+        vm.load()
+        advanceUntilIdle()
+
+        assertEquals(listOf("maeher", "walze"), vm.state.value.devices.map { it.id })
+        assertFalse(vm.state.value.signedIn)
+        assertFalse(vm.state.value.offline)
+        // Ohne Anmeldung wird nichts Persönliches abgerufen.
+        assertEquals(0, repo.bookingCalls)
+    }
+
+    @Test
+    fun `ein leerer Maschinchenring ist kein Fehler`() = runTest(dispatcher) {
+        val vm = vm(FakeRental())
+
+        vm.load()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.empty)
+        assertFalse(vm.state.value.offline)
+    }
+
+    @Test
+    fun `ohne Netz steht ein Hinweis ueber der zuletzt geholten Liste`() = runTest(dispatcher) {
+        val repo = FakeRental().apply { devices = listOf(geraet("maeher")) }
+        val vm = vm(repo)
+        vm.load()
+        advanceUntilIdle()
+        assertEquals(1, vm.state.value.devices.size)
+
+        repo.devicesFailure = IOException("kein Netz")
+        vm.refresh()
+        advanceUntilIdle()
+
+        // Lieber ein Hinweis über einer alten Liste als eine leere Seite.
+        assertTrue(vm.state.value.offline)
+        assertEquals(listOf("maeher"), vm.state.value.devices.map { it.id })
+        assertFalse(vm.state.value.empty)
+    }
+
+    /** Ein Ausfall der Mietplattform ist für die Liste dasselbe wie kein Netz. */
+    @Test
+    fun `auch ein Serverfehler laesst die alte Liste stehen`() = runTest(dispatcher) {
+        val repo = FakeRental().apply { devices = listOf(geraet("maeher")) }
+        val vm = vm(repo)
+        vm.load()
+        advanceUntilIdle()
+
+        repo.devicesFailure = RentalApiException(RentalErrorCode.INTERNAL, "Kaputt")
+        vm.refresh()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.offline)
+        assertEquals(1, vm.state.value.devices.size)
+    }
+
+    @Test
+    fun `gesucht wird auf dem Server, nicht in der Liste`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            devices = listOf(geraet("maeher"), geraet("walze"))
+            searchResults = listOf(geraet("walze", "Rasenwalze"))
+        }
+        val vm = vm(repo)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.setQuery("rasen")
+        advanceUntilIdle()
+
+        assertEquals(1, repo.searchCalls)
+        assertEquals(listOf("walze"), vm.state.value.devices.map { it.id })
+    }
+
+    @Test
+    fun `eine leere Suche bringt die ganze Liste zurueck`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            devices = listOf(geraet("maeher"), geraet("walze"))
+            searchResults = emptyList()
+        }
+        val vm = vm(repo)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.setQuery("nichts")
+        advanceUntilIdle()
+        assertTrue(vm.state.value.empty || vm.state.value.devices.isEmpty())
+
+        vm.setQuery("")
+        advanceUntilIdle()
+
+        assertEquals(2, vm.state.value.devices.size)
+    }
+
+    @Test
+    fun `ein zweites Oeffnen holt die Liste nicht noch einmal`() = runTest(dispatcher) {
+        val repo = FakeRental().apply { devices = listOf(geraet("maeher")) }
+        val vm = vm(repo)
+
+        vm.load()
+        advanceUntilIdle()
+        vm.load()
+        advanceUntilIdle()
+
+        assertEquals(1, repo.deviceCalls)
+
+        vm.refresh()
+        advanceUntilIdle()
+        assertEquals(2, repo.deviceCalls)
+    }
+
+    // --- Anmeldung ----------------------------------------------------------
+
+    @Test
+    fun `angemeldet kommen Profil und eigene Buchungen dazu`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            devices = listOf(geraet("maeher"))
+            bookings = listOf(buchung("b-1"))
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+
+        vm.load()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.signedIn)
+        assertFalse(vm.state.value.staleSignIn)
+        assertEquals(listOf("b-1"), vm.state.value.bookings.map { it.id })
+        assertEquals("Erika Musterfrau", vm.state.value.profile?.name)
+    }
+
+    /**
+     * Der Stolperstein: Ein Gerät, das schon angemeldet war, behält seinen
+     * Token-Satz über die Aktualisierung hinweg. Das Token gilt für die
+     * Mietplattform nicht — und daran ist von hier aus nichts zu reparieren
+     * außer einer neuen Anmeldung. Eine leere Liste wäre keine Antwort.
+     */
+    @Test
+    fun `ein Token von vor der Umstellung fuehrt zur Bitte um neue Anmeldung`() =
+        runTest(dispatcher) {
+            val repo = FakeRental().apply { devices = listOf(geraet("maeher")) }
+            val vm = vm(repo, RentalSignIn.STALE)
+
+            vm.load()
+            advanceUntilIdle()
+
+            assertTrue(vm.state.value.staleSignIn)
+            assertFalse(vm.state.value.signedIn)
+            assertTrue(vm.state.value.bookings.isEmpty())
+            // Die Geräte stehen trotzdem da — sie sind öffentlich.
+            assertEquals(1, vm.state.value.devices.size)
+            assertEquals(0, repo.bookingCalls)
+        }
+
+    /**
+     * Dasselbe, nur andersherum: Das Token ließ sich nicht ansehen, der
+     * Server sagt nein. Auch das heißt „neu anmelden", nicht „abgemeldet".
+     */
+    @Test
+    fun `sagt der Server token_audience, wird ebenso neu angemeldet`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            bookingsFailure = RentalApiException(RentalErrorCode.TOKEN_AUDIENCE, null)
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+
+        vm.load()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.staleSignIn)
+        assertFalse(vm.state.value.signedIn)
+    }
+
+    @Test
+    fun `ein abgelaufenes Token ist kein Fall fuer die Neuanmeldung`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            bookingsFailure = RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+
+        vm.load()
+        advanceUntilIdle()
+
+        // Das ist die gewöhnliche Anmeldung, nicht der Sonderfall.
+        assertFalse(vm.state.value.staleSignIn)
+        assertFalse(vm.state.value.signedIn)
+    }
+
+    @Test
+    fun `Buchungen ohne Netz kosten nicht die ganze Ansicht`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            devices = listOf(geraet("maeher"))
+            bookingsFailure = IOException("kein Netz")
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+
+        vm.load()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.bookingsOffline)
+        assertTrue(vm.state.value.signedIn)
+        assertEquals(1, vm.state.value.devices.size)
+    }
+
+    // --- Zeitraum und Buchen ------------------------------------------------
+
+    @Test
+    fun `belegte Zeitraeume kommen vom Server, sobald ein Geraet offen ist`() =
+        runTest(dispatcher) {
+            val repo = FakeRental().apply {
+                devices = listOf(geraet("maeher"))
+                occupancy = listOf(
+                    RentalOccupancy("maeher", null, zeitraum(), OccupancyStatus.APPROVED),
+                )
+            }
+            val vm = vm(repo)
+            vm.load()
+            advanceUntilIdle()
+
+            vm.open(repo.devices.first())
+            advanceUntilIdle()
+
+            assertEquals(1, vm.state.value.occupancy.size)
+            assertEquals(1, vm.state.value.images.size)
+            assertEquals(1, repo.occupancyCalls)
+        }
+
+    /**
+     * Der Kern der Sache: Ob angefragt werden darf, sagt der Server. Die App
+     * liest es nicht aus den belegten Zeiträumen ab, die sie eben gezeichnet
+     * hat — sonst stünde die Regel in zwei Fassungen im Haus.
+     */
+    @Test
+    fun `angefragt werden darf erst, wenn der Server frei sagt`() = runTest(dispatcher) {
+        val repo = FakeRental().apply { devices = listOf(geraet("maeher")) }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+        vm.open(repo.devices.first())
+        advanceUntilIdle()
+
+        // Ohne Zeitraum: nichts.
+        assertFalse(vm.state.value.canBook)
+
+        repo.availability = RentalAvailability(zeitraum(), available = false, reason = "occupied")
+        vm.setPeriod(zeitraum())
+        advanceUntilIdle()
+        assertFalse(vm.state.value.canBook)
+
+        repo.availability = RentalAvailability(zeitraum(), available = true, reason = null)
+        vm.setPeriod(zeitraum())
+        advanceUntilIdle()
+        assertTrue(vm.state.value.canBook)
+    }
+
+    @Test
+    fun `ohne Anmeldung fuehrt kein Weg zum Anfragen`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            devices = listOf(geraet("maeher"))
+            availability = RentalAvailability(zeitraum(), available = true, reason = null)
+        }
+        val vm = vm(repo)
+        vm.load()
+        advanceUntilIdle()
+        vm.open(repo.devices.first())
+        vm.setPeriod(zeitraum())
+        advanceUntilIdle()
+
+        assertFalse(vm.state.value.canBook)
+        vm.book("egal")
+        advanceUntilIdle()
+        assertNull(repo.lastRequest)
+    }
+
+    @Test
+    fun `eine Anfrage geht hinaus und die eigenen Buchungen kommen neu`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            devices = listOf(geraet("maeher"))
+            availability = RentalAvailability(zeitraum(), available = true, reason = null)
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        val ereignisse = mutableListOf<RentalEvent>()
+        val lauscher = launch { ereignisse += vm.events.first() }
+
+        vm.load()
+        advanceUntilIdle()
+        vm.open(repo.devices.first())
+        vm.setPeriod(zeitraum())
+        advanceUntilIdle()
+
+        val vorher = repo.bookingCalls
+        vm.book("Hole ich Samstag früh ab.")
+        advanceUntilIdle()
+        lauscher.join()
+
+        assertEquals("Hole ich Samstag früh ab.", repo.lastRequest?.notes)
+        // Der Normalfall: Name und Telefon holt sich der Server aus dem Profil.
+        assertNull(repo.lastRequest?.firstName)
+        assertNull(repo.lastRequest?.phone)
+        assertEquals(listOf(RentalEvent.Booked), ereignisse)
+        assertNull(vm.state.value.selected)
+        assertEquals(vorher + 1, repo.bookingCalls)
+    }
+
+    /**
+     * Der gewöhnliche Wettlauf: Zwischen dem Zeichnen des Kalenders und dem
+     * Tippen kann eine Minute liegen. Das ist ein Hinweis und ein neuer
+     * Kalender, kein Absturz.
+     */
+    @Test
+    fun `ein inzwischen belegter Zeitraum ist ein Hinweis, kein Absturz`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            devices = listOf(geraet("maeher"))
+            availability = RentalAvailability(zeitraum(), available = true, reason = null)
+            bookFailure = RentalApiException(RentalErrorCode.OCCUPIED, "Schon vergeben")
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+        vm.open(repo.devices.first())
+        vm.setPeriod(zeitraum())
+        advanceUntilIdle()
+        val vorher = repo.occupancyCalls
+
+        vm.book()
+        advanceUntilIdle()
+
+        assertEquals(RentalErrorCode.OCCUPIED, vm.state.value.notice?.code)
+        assertEquals("Schon vergeben", vm.state.value.notice?.text)
+        // Das Gerät bleibt offen, damit ein anderer Zeitraum gewählt werden kann.
+        assertEquals("maeher", vm.state.value.selected?.id)
+        assertEquals(vorher + 1, repo.occupancyCalls)
+    }
+
+    /**
+     * Was dem Server am Profil fehlt, sagt er selbst. Die App fragt genau das
+     * nach und denkt sich keine eigene Liste aus.
+     */
+    @Test
+    fun `fehlt dem Profil etwas, sagt der Server welche Felder`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            devices = listOf(geraet("maeher"))
+            availability = RentalAvailability(zeitraum(), available = true, reason = null)
+            bookFailure = RentalApiException(
+                RentalErrorCode.PROFILE_INCOMPLETE,
+                "Dein Profil ist unvollständig",
+                missingFields = listOf("phone"),
+            )
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+        vm.open(repo.devices.first())
+        vm.setPeriod(zeitraum())
+        advanceUntilIdle()
+
+        vm.book()
+        advanceUntilIdle()
+
+        assertEquals(listOf("phone"), vm.state.value.missingFields)
+        assertEquals(RentalErrorCode.PROFILE_INCOMPLETE, vm.state.value.notice?.code)
+
+        // Beim zweiten Anlauf gehen die nachgefragten Angaben mit.
+        repo.bookFailure = null
+        vm.book(notes = "", firstName = "Erika", lastName = "Musterfrau", phone = "0123")
+        advanceUntilIdle()
+
+        assertEquals("0123", repo.lastRequest?.phone)
+        assertEquals("Erika", repo.lastRequest?.firstName)
+    }
+
+    @Test
+    fun `eine Buchung ohne Verbindung meldet den Ausfall, nicht eine Absage`() =
+        runTest(dispatcher) {
+            val repo = FakeRental().apply {
+                devices = listOf(geraet("maeher"))
+                availability = RentalAvailability(zeitraum(), available = true, reason = null)
+                bookFailure = IOException("kein Netz")
+            }
+            val vm = vm(repo, RentalSignIn.VALID)
+            vm.load()
+            advanceUntilIdle()
+            vm.open(repo.devices.first())
+            vm.setPeriod(zeitraum())
+            advanceUntilIdle()
+
+            vm.book()
+            advanceUntilIdle()
+
+            assertTrue(vm.state.value.offline)
+            assertNull(vm.state.value.notice)
+            assertFalse(vm.state.value.booking)
+        }
+
+    // --- Stornieren ---------------------------------------------------------
+
+    @Test
+    fun `eine Buchung laesst sich stornieren, wenn der Server es erlaubt`() = runTest(dispatcher) {
+        val repo = FakeRental().apply { bookings = listOf(buchung("b-1")) }
+        val vm = vm(repo, RentalSignIn.VALID)
+        val ereignisse = mutableListOf<RentalEvent>()
+        val lauscher = launch { ereignisse += vm.events.first() }
+        vm.load()
+        advanceUntilIdle()
+
+        vm.cancel("b-1")
+        advanceUntilIdle()
+        lauscher.join()
+
+        assertEquals(listOf("b-1"), repo.cancelled)
+        assertEquals(listOf(RentalEvent.Cancelled), ereignisse)
+        assertTrue(vm.state.value.cancelling.isEmpty())
+    }
+
+    @Test
+    fun `eine schon stornierte Buchung meldet den Grund und holt die Liste neu`() =
+        runTest(dispatcher) {
+            val repo = FakeRental().apply {
+                bookings = listOf(buchung("b-1"))
+                cancelFailure = RentalApiException(RentalErrorCode.CONFLICT, "Schon storniert")
+            }
+            val vm = vm(repo, RentalSignIn.VALID)
+            vm.load()
+            advanceUntilIdle()
+            val vorher = repo.bookingCalls
+
+            vm.cancel("b-1")
+            advanceUntilIdle()
+
+            assertEquals(RentalErrorCode.CONFLICT, vm.state.value.notice?.code)
+            assertEquals("Schon storniert", vm.state.value.notice?.text)
+            assertEquals(vorher + 1, repo.bookingCalls)
+            assertTrue(vm.state.value.cancelling.isEmpty())
+        }
+
+    @Test
+    fun `zweimal auf Stornieren tippen storniert nicht zweimal`() = runTest(dispatcher) {
+        val repo = FakeRental().apply { bookings = listOf(buchung("b-1")) }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.cancel("b-1")
+        vm.cancel("b-1")
+        advanceUntilIdle()
+
+        assertEquals(listOf("b-1"), repo.cancelled)
+    }
+}

--- a/android/ci-e2e.sh
+++ b/android/ci-e2e.sh
@@ -17,6 +17,7 @@
 #   E2E_API_BASE_URL      Backend im Dev-Login-Modus (Schritte 1 und 1b)
 #   E2E_WEBSITE_BASE_URL  lokale Ablage mit events.json
 #   E2E_MAP_STYLE_URL     lokaler Kartenstil
+#   E2E_MIETEN_BASE_URL   lokale Ablage anstelle der Mietplattform
 #   E2E_OIDC_ISSUER       lokales Zitadel aus dem docker compose (nur API 35)
 #   E2E_OIDC_CLIENT_ID    Client-ID der dort angelegten nativen App
 #   E2E_OIDC_API_BASE_URL Backend im OIDC-Modus gegen dieses Zitadel
@@ -27,6 +28,13 @@ set -euo pipefail
 API_BASE_URL="${E2E_API_BASE_URL:-http://10.0.2.2:8099}"
 WEBSITE_BASE_URL="${E2E_WEBSITE_BASE_URL:-http://10.0.2.2:8097}"
 MAP_STYLE_URL="${E2E_MAP_STYLE_URL:-http://10.0.2.2:8097/map-style.json}"
+# Die Mietplattform ist ein eigener, entfernter Dienst. Im Testlauf zeigt die
+# App auf den Runner: sonst holte der Bereich „Maschinchenring" beim ersten
+# Öffnen seine Geräteliste aus der Produktion. Die statische Ablage kennt die
+# Routen unter /api/v1/ nicht — der Bereich zeigt dann seinen Hinweis „gerade
+# nicht erreichbar", und genau das ist hier richtig: Was der Bereich mit
+# echten Antworten macht, prüfen RentalUiTest und RentalApiTest ohne Netz.
+MIETEN_BASE_URL="${E2E_MIETEN_BASE_URL:-http://10.0.2.2:8097}"
 
 # --- Beweisaufnahme ---------------------------------------------------------
 # „Instrumentation run failed due to Process crashed" sagt für sich genommen
@@ -97,6 +105,7 @@ adb emu geo fix 9.8162 52.1843 || true
   -PapiBaseUrl="$API_BASE_URL" \
   -PwebsiteBaseUrl="$WEBSITE_BASE_URL" \
   -PmapStyleUrl="$MAP_STYLE_URL" \
+  -PmietenBaseUrl="$MIETEN_BASE_URL" \
   -PdevAuth=true \
   -Pandroid.testInstrumentationRunnerArguments.e2e=true
 
@@ -160,6 +169,7 @@ if [ "${API_LEVEL:-}" = "35" ] && [ -n "${E2E_OIDC_ISSUER:-}" ] && [ -n "${E2E_O
     -PoidcClientId="$E2E_OIDC_CLIENT_ID" \
     -PwebsiteBaseUrl="$WEBSITE_BASE_URL" \
     -PmapStyleUrl="$MAP_STYLE_URL" \
+    -PmietenBaseUrl="$MIETEN_BASE_URL" \
     -Pandroid.testInstrumentationRunnerArguments.class=de.roessing.app.RealLoginE2eTest \
     -Pandroid.testInstrumentationRunnerArguments.realLoginUser="${E2E_LOGIN_USER:?E2E_LOGIN_USER fehlt}" \
     -Pandroid.testInstrumentationRunnerArguments.realLoginPassword="${E2E_LOGIN_PASSWORD:?E2E_LOGIN_PASSWORD fehlt}" \

--- a/android/e2e/fixtures/mieten/README.md
+++ b/android/e2e/fixtures/mieten/README.md
@@ -1,0 +1,27 @@
+# Beispielantworten der Mietplattform
+
+Ausschnitte aus `docs/mieten-api.md` — je Route eine Datei, in genau der
+Form, die der Vertrag festlegt. Sie sind die Vorlage für die Tests des
+Bereichs „Maschinchenring" (`RentalApiTest`), damit ein geänderter Vertrag
+hier auffällt und nicht erst als leere Liste auf dem Telefon.
+
+Adressen in den Beispielen zeigen bewusst auf `example.invalid`: Ein Test
+fasst keinen entfernten Server an, und eine echte Adresse in einer
+Testdatei wäre eine Einladung dazu.
+
+| Datei | Route |
+| --- | --- |
+| `items.json` | 1 — `GET /api/v1/items` |
+| `item-detail.json` | 2 — `GET /api/v1/items/{id}` |
+| `search.json` | 3 — `GET /api/v1/search` |
+| `availability-free.json`, `availability-taken.json` | 5 — `GET /api/v1/availability` |
+| `occupancy.json` | 6 — `GET /api/v1/occupancy` |
+| `me.json` | 7 — `GET /api/v1/me` |
+| `my-bookings.json` | 10 — `GET /api/v1/bookings/mine` |
+| `booking-created.json` | 11 — `POST /api/v1/bookings` |
+| `error-occupied.json` | 409 auf Route 11 |
+| `error-profile-incomplete.json` | 400 auf Route 11 |
+| `error-token-audience.json` | 401 auf jeder angemeldeten Route |
+
+Sets (Route 4) und die Vermieterseite (Routen 13 bis 19) hat der Bereich
+bewusst nicht — deshalb liegen dafür auch keine Beispiele hier.

--- a/android/e2e/fixtures/mieten/availability-free.json
+++ b/android/e2e/fixtures/mieten/availability-free.json
@@ -1,0 +1,1 @@
+{ "available": true, "reason": null }

--- a/android/e2e/fixtures/mieten/availability-taken.json
+++ b/android/e2e/fixtures/mieten/availability-taken.json
@@ -1,0 +1,1 @@
+{ "available": false, "reason": "occupied" }

--- a/android/e2e/fixtures/mieten/booking-created.json
+++ b/android/e2e/fixtures/mieten/booking-created.json
@@ -1,0 +1,14 @@
+{
+  "booking": {
+    "id": "8f14c2b0-91ae-4c77-b1b2-0a3d5e7c9f01",
+    "deviceId": "as-585-km-kreiselmaeher",
+    "setId": null,
+    "deviceName": "AS 585 KM Kreiselmäher",
+    "startDate": "2026-09-05",
+    "endDate": "2026-09-07",
+    "status": "pending",
+    "notes": "Hole ich Samstag früh ab.",
+    "canCancel": true,
+    "pickup": null
+  }
+}

--- a/android/e2e/fixtures/mieten/error-occupied.json
+++ b/android/e2e/fixtures/mieten/error-occupied.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": "occupied",
+    "message": "In diesem Zeitraum ist das Gerät schon vergeben"
+  }
+}

--- a/android/e2e/fixtures/mieten/error-profile-incomplete.json
+++ b/android/e2e/fixtures/mieten/error-profile-incomplete.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "profile_incomplete",
+    "message": "Dein Profil ist unvollständig",
+    "missingFields": ["phone", "addressStreet", "addressZip", "addressCity"]
+  }
+}

--- a/android/e2e/fixtures/mieten/error-token-audience.json
+++ b/android/e2e/fixtures/mieten/error-token-audience.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": "token_audience",
+    "message": "Token gilt nicht für die Mietplattform"
+  }
+}

--- a/android/e2e/fixtures/mieten/item-detail.json
+++ b/android/e2e/fixtures/mieten/item-detail.json
@@ -1,0 +1,27 @@
+{
+  "item": {
+    "id": "as-585-km-kreiselmaeher",
+    "name": "AS 585 KM Kreiselmäher",
+    "description": "Kreiselmäher für hohes Gras und Böschungen.\n\n- Arbeitsbreite 85 cm\n- **Benzin**, Radantrieb",
+    "pricePerDay": 25,
+    "pricePerWeekend": 40,
+    "pricePerWeek": 120,
+    "deposit": 100,
+    "tags": ["garten", "motorgeraet"],
+    "thumbnailUrl": "https://cdn.example.invalid/sIgn/resize:fill:600:450/plain/local:///items/as-585-km-kreiselmaeher/front.jpg",
+    "productUrl": "https://www.example.invalid/as-585",
+    "webUrl": "https://mieten.example.invalid/geraete/as-585-km-kreiselmaeher/",
+    "images": [
+      {
+        "id": "img-7f3a",
+        "url": "https://cdn.example.invalid/sIgn/resize:fill:600:450/plain/local:///items/as-585-km-kreiselmaeher/front.jpg",
+        "isThumbnail": true
+      },
+      {
+        "id": "img-9b21",
+        "url": "https://cdn.example.invalid/sIgn/resize:fill:600:450/plain/local:///items/as-585-km-kreiselmaeher/seite.jpg",
+        "isThumbnail": false
+      }
+    ]
+  }
+}

--- a/android/e2e/fixtures/mieten/items.json
+++ b/android/e2e/fixtures/mieten/items.json
@@ -1,0 +1,43 @@
+{
+  "items": [
+    {
+      "id": "as-585-km-kreiselmaeher",
+      "name": "AS 585 KM Kreiselmäher",
+      "description": "Kreiselmäher für hohes Gras und Böschungen.\n\n- Arbeitsbreite 85 cm\n- **Benzin**, Radantrieb",
+      "pricePerDay": 25,
+      "pricePerWeekend": 40,
+      "pricePerWeek": 120,
+      "deposit": 100,
+      "tags": ["garten", "motorgeraet"],
+      "thumbnailUrl": "https://cdn.example.invalid/sIgn/resize:fill:600:450/plain/local:///items/as-585-km-kreiselmaeher/front.jpg",
+      "productUrl": "https://www.example.invalid/as-585",
+      "webUrl": "https://mieten.example.invalid/geraete/as-585-km-kreiselmaeher/"
+    },
+    {
+      "id": "018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11",
+      "name": "Rasenwalze",
+      "description": null,
+      "pricePerDay": 8,
+      "pricePerWeekend": null,
+      "pricePerWeek": null,
+      "deposit": null,
+      "tags": ["garten"],
+      "thumbnailUrl": null,
+      "productUrl": null,
+      "webUrl": "https://mieten.example.invalid/geraete/018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11/"
+    },
+    {
+      "id": "fallschutzmatten",
+      "name": "Fallschutzmatten (10 Stück)",
+      "description": "Für Feste mit Hüpfburg.",
+      "pricePerDay": 12.5,
+      "pricePerWeekend": null,
+      "pricePerWeek": null,
+      "deposit": null,
+      "tags": ["feste"],
+      "thumbnailUrl": null,
+      "productUrl": null,
+      "webUrl": "https://mieten.example.invalid/geraete/fallschutzmatten/"
+    }
+  ]
+}

--- a/android/e2e/fixtures/mieten/me.json
+++ b/android/e2e/fixtures/mieten/me.json
@@ -1,0 +1,14 @@
+{
+  "profile": {
+    "name": "Erika Musterfrau",
+    "email": "erika@example.invalid",
+    "phone": "+49 5069 123456",
+    "addressStreet": "Hauptstraße 1",
+    "addressZip": "31171",
+    "addressCity": "Nordstemmen",
+    "lender": false,
+    "lenderStatus": "none",
+    "profileComplete": true,
+    "missingFields": []
+  }
+}

--- a/android/e2e/fixtures/mieten/my-bookings.json
+++ b/android/e2e/fixtures/mieten/my-bookings.json
@@ -1,0 +1,43 @@
+{
+  "bookings": [
+    {
+      "id": "8f14c2b0-91ae-4c77-b1b2-0a3d5e7c9f01",
+      "deviceId": "as-585-km-kreiselmaeher",
+      "setId": null,
+      "deviceName": "AS 585 KM Kreiselmäher",
+      "startDate": "2026-09-05",
+      "endDate": "2026-09-07",
+      "status": "approved",
+      "notes": "Hole ich Samstag früh ab.",
+      "canCancel": true,
+      "pickup": {
+        "address": "Hauptstraße 1, 31171 Nordstemmen",
+        "phone": "+49 5069 123456"
+      }
+    },
+    {
+      "id": "1c9e77a3-1234-4bb8-9a0e-77ce31d2a456",
+      "deviceId": "018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11",
+      "setId": null,
+      "deviceName": "Rasenwalze",
+      "startDate": "2026-10-01",
+      "endDate": "2026-10-03",
+      "status": "pending",
+      "notes": null,
+      "canCancel": true,
+      "pickup": null
+    },
+    {
+      "id": "3ab0f1de-5c22-4f88-9f10-3c7b2e5d1a90",
+      "deviceId": "fallschutzmatten",
+      "setId": null,
+      "deviceName": "Fallschutzmatten (10 Stück)",
+      "startDate": "2026-07-11",
+      "endDate": "2026-07-13",
+      "status": "rejected",
+      "notes": null,
+      "canCancel": false,
+      "pickup": null
+    }
+  ]
+}

--- a/android/e2e/fixtures/mieten/occupancy.json
+++ b/android/e2e/fixtures/mieten/occupancy.json
@@ -1,0 +1,25 @@
+{
+  "periods": [
+    {
+      "deviceId": "as-585-km-kreiselmaeher",
+      "setId": null,
+      "startDate": "2026-09-05",
+      "endDate": "2026-09-07",
+      "status": "approved"
+    },
+    {
+      "deviceId": "as-585-km-kreiselmaeher",
+      "setId": null,
+      "startDate": "2026-09-12",
+      "endDate": "2026-09-14",
+      "status": "pending"
+    },
+    {
+      "deviceId": "as-585-km-kreiselmaeher",
+      "setId": null,
+      "startDate": "2026-10-01",
+      "endDate": "2026-10-08",
+      "status": "blocked"
+    }
+  ]
+}

--- a/android/e2e/fixtures/mieten/search.json
+++ b/android/e2e/fixtures/mieten/search.json
@@ -1,0 +1,32 @@
+{
+  "results": [
+    {
+      "id": "as-585-km-kreiselmaeher",
+      "name": "AS 585 KM Kreiselmäher",
+      "description": "Kreiselmäher für hohes Gras und Böschungen.",
+      "pricePerDay": 25,
+      "pricePerWeekend": 40,
+      "pricePerWeek": 120,
+      "deposit": 100,
+      "tags": ["garten", "motorgeraet"],
+      "thumbnailUrl": null,
+      "productUrl": null,
+      "webUrl": "https://mieten.example.invalid/geraete/as-585-km-kreiselmaeher/",
+      "score": 0.913
+    },
+    {
+      "id": "018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11",
+      "name": "Rasenwalze",
+      "description": null,
+      "pricePerDay": 8,
+      "pricePerWeekend": null,
+      "pricePerWeek": null,
+      "deposit": null,
+      "tags": ["garten"],
+      "thumbnailUrl": null,
+      "productUrl": null,
+      "webUrl": "https://mieten.example.invalid/geraete/018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11/",
+      "score": 0.402
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #69

Der Verleih („Maschinchenring") ist jetzt ein Bereich der Android-App. Er
redet **unmittelbar** mit `mieten.xn--rssing-wxa.de` — das Go-Backend ist
kein Weiterleiter und weiß nichts davon, genau wie bei den Veranstaltungen.
Eigener kleiner Client (`data/RentalApi.kt`), eigenes Vokabular
(`data/Rental.kt`), ein ViewModel, ein Screen. Die Datenform stammt
ausschließlich aus `docs/mieten-api.md`.

## Was der Bereich kann

**Ohne Anmeldung** — drüben ist der lesende Teil öffentlich:

- Geräte durchsehen (Route 1), Gerät im Detail mit Bildzahl (2), suchen (3).
  Gesucht wird auf dem Server; seine hybride Sortierung wird nicht umsortiert.
- Belegte Zeiträume eines Geräts (6) und Verfügbarkeit eines Zeitraums (5).
- Erreichbar auch **vom Anmeldeschirm aus** („Geräte im Maschinchenring
  ansehen") — niemand muss einen Namen hergeben, um zu sehen, was das Dorf
  verleiht.

**Mit Rössing-ID:**

- Eigenes Profil (7) — der erste Aufruf legt drüben still das Konto an.
- Eigene Buchungen (10), anfragen (11), stornieren (12).
- Die Abholadresse steht erst nach der Zusage da und nirgends sonst.

**Wenn es klemmt:**

- Mietplattform nicht erreichbar → Hinweis **über** der zuletzt geholten
  Liste, nicht statt ihrer. Ein `500` von drüben zählt dabei wie kein Netz.
- Zeitraum inzwischen belegt (`409 occupied`) → der Satz des Servers, das
  Gerät bleibt offen, die belegten Zeiträume werden neu geholt.
- Profil unvollständig (`400 profile_incomplete`) → die App fragt **genau
  die Felder** nach, die der Server nennt, und schickt sie beim zweiten
  Anlauf mit. Eine eigene Liste hat sie nicht.

## Der Fall, der wie ein Defekt aussieht

Damit ein Token drüben gilt, muss ihr Zitadel-Projekt in der `aud` stehen.
Der Scope dafür steht jetzt in `LOGIN_SCOPES`, die Projektkennung in
`BuildConfig.MIETEN_PROJECT_ID` (Build-Einstellungen, nicht Quelltext).

Er wirkt aber erst bei der **nächsten** Anmeldung, und ein Gerät, das schon
angemeldet war, behält seinen Token-Satz über die Aktualisierung hinweg. Die
App sieht deshalb vor jeder angemeldeten Anfrage in ihr eigenes Token
(`auth/RentalAudience.kt`, reine Funktionen, im Unit-Test abgedeckt): Steht
die Mietplattform nicht in der `aud`, geht die Anfrage gar nicht erst hinaus,
und über der Liste steht „Bitte einmal neu anmelden" mit einem Knopf. Ist das
Token undurchsichtig, geht die Anfrage hinaus und `token_audience` vom Server
hat das letzte Wort. Beides führt zum selben Satz.

**Neu anmelden, nicht abmelden.** Der Knopf stößt eine Anmeldung an, ohne die
bestehende vorher wegzuwerfen (`onReauthenticate`) — bricht jemand im Browser
ab, bleibt alles, wie es war. Abmelden wäre der grobe Weg gewesen.

## Was der Bereich bewusst nicht kann

- **Geräte anlegen oder ändern.** Das läuft über den Chat und die Webfassung
  der Mietplattform und soll dort bleiben; der Vertrag kennt dafür keine
  Route. Ein Satz am Ende der Liste sagt das.
- **Vermieteransicht** (Routen 13 bis 19: fremde Buchungen bestätigen und
  ablehnen, eigene Geräte, Sperren). Nicht Teil von „ansehen, buchen,
  stornieren"; ein eigener Zug, wenn er gebraucht wird.
- **Sets** (Route 4). Der Vertrag sagt selbst, dass Stornieren, Bestätigen und
  Ablehnen von Set-Buchungen serverseitig noch nicht umgesetzt sind und mit
  `409` antworten — ein Set anzuzeigen, das man nicht wieder loswird, wäre ein
  Versprechen, das die App nicht halten kann.
- **Profil ändern** (Route 8) und **Vermieter werden** (9). Fehlt dem Server
  etwas fürs Buchen, fragt die Buchungsstrecke es nach; Adressfelder führen
  auf die Webseite.
- **Eine Summe.** Die Tarife stehen einzeln da (`25 € pro Tag`, `40 € pro
  Wochenende`). Welcher bei welcher Dauer gilt, legt die Mietplattform
  nirgends fest — eine erfundene Rechnung hier wäre genau der Bruch zwischen
  Web und App, den der Vertrag vermeiden will. Stattdessen ein Satz: „Was am
  Ende zu zahlen ist, macht ihr beim Abholen aus."
- **Bilder.** Die App hat keine Bibliothek zum Nachladen von Bildern, und eine
  dafür aufzunehmen ist eine eigene Entscheidung. Der Bereich nennt die Zahl
  der Bilder und führt in den Browser.
- **Push.** Buchungsanfragen und Entscheidungen laufen über E-Mail; Push ist
  laut Plan ein eigenes Paket.

## Was am Rand mitkam

- Beschreibungen kommen als **Markdown**. Roh mit Sternchen wäre keine Lösung,
  ein Renderer eine neue Bibliothek — die App zeigt sie deshalb bewusst als
  Klartext (`markdownAsPlainText`, reine Funktion, im Test abgedeckt).
- **Halboffene Zeiträume.** `endDate` ist der Rückgabetag. Der Kalender gibt
  die Tage her, an denen jemand das Gerät haben will; die Umrechnung passiert
  an **einer** Stelle (`RentalPeriod.ofPickedDays`) und steht unter Test.
  Angezeigt wird immer der letzte Miettag, nie `endDate`.
- Die Wache über die lokalen Tests
  (`.github/scripts/pruefe_lokale_tests.py`) kennt die neue Adresse: Sie
  verlangt `-PmietenBaseUrl` in jedem E2E-Lauf und beanstandet die
  Produktions-Mietplattform in Testquellen. Ohne das wäre genau der alte
  Fehler wieder möglich — eine vergessene Übersteuerung, und der Testlauf
  zeigt auf die Produktion.

## Wie geprüft wurde

- `cd android && ./gradlew testDebugUnitTest assembleDebug assembleDebugAndroidTest`
  — grün, **188 Unit-Tests** (vorher 179 ohne die neuen).
- `python3 .github/scripts/pruefe_lokale_tests.py` und `--selbsttest` — grün.
- **Kein Test fasst einen entfernten Server an.** `RentalApiTest` fährt die
  Beispielantworten aus `android/e2e/fixtures/mieten/` (Wort für Wort aus
  `docs/mieten-api.md`) über einen MockWebServer im selben Prozess;
  `RentalViewModelTest` und `RentalUiTest` gegen ein Doppel. Adressen in den
  Beispielen zeigen auf `example.invalid`.
- `RentalUiTest` ist geschrieben, aber **hier nicht gelaufen** — es gibt in
  dieser Umgebung keinen Emulator, er wird nur übersetzt. Ausführen tut ihn
  die CI. Der Tipp, der in den Browser führt, benutzt nicht den echten
  `UriHandler`, sondern ein Notizbuch — sonst wäre die App im Hintergrund und
  der Test ohne Oberfläche.
- Keine neue Abhängigkeit, kein DI-Framework: Verdrahtung von Hand über
  `AppContainer`, `gradle/libs.versions.toml` unverändert.

## Was offen bleibt

- **iOS ist noch nicht dabei.** Die Fassung entsteht parallel auf
  `feat/ios-maschinchenring` gegen denselben Vertrag; ein Stand ist erst
  draußen, wenn er in beiden Kanälen liegt.
- **Der Vertrag ist noch nicht ausgerollt.** `docs/mieten-api.md` sagt, dass
  die Routen unter `/api/v1/…` festgelegt, aber drüben noch nicht live sind.
  Bis dahin zeigt der Bereich seinen Hinweis „gerade nicht erreichbar" — was
  genau das richtige Verhalten ist und hier auch geprüft wird.
