### PR TITLE
iOS: Der Maschinchenring als eigener Bereich

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -101,7 +101,10 @@ jobs:
       # CI-Lauf sie anfassen — Kartenstil holen, Terminfeed laden, im
       # schlimmsten Fall an der echten Rössing-ID anklopfen. Genau so ist der
       # Fehler auf Android entstanden (dort -PapiBaseUrl usw.), deshalb steht
-      # jede der vier Adressen an jedem xcodebuild-Aufruf. Die Wache
+      # jede der fünf Adressen an jedem xcodebuild-Aufruf — auch die des
+      # Maschinchenrings, die kein Test anfasst: Eine Adresse, die nur
+      # deswegen fehlt, weil sie heute niemand braucht, fehlt morgen aus
+      # Versehen. Die Wache
       # .github/scripts/pruefe_lokale_tests.py prüft das bei jeder Änderung.
       # 127.0.0.1 ist der Runner selbst: Dort horcht in diesem Job niemand,
       # ein hinausgehender Zugriff schlägt also hörbar fehl, statt still die
@@ -116,7 +119,8 @@ jobs:
             API_BASE_URL=http://127.0.0.1:8099 \
             WEBSITE_BASE_URL=http://127.0.0.1:8097 \
             OIDC_ISSUER=http://127.0.0.1:8123 \
-            MAP_STYLE_URL=http://127.0.0.1:8097/map-style.json
+            MAP_STYLE_URL=http://127.0.0.1:8097/map-style.json \
+            RENTAL_BASE_URL=http://127.0.0.1:8098
 
       - name: Unit-Tests auf dem Simulator
         if: env.SIMULATOR_VORHANDEN == 'ja'
@@ -129,7 +133,8 @@ jobs:
             API_BASE_URL=http://127.0.0.1:8099 \
             WEBSITE_BASE_URL=http://127.0.0.1:8097 \
             OIDC_ISSUER=http://127.0.0.1:8123 \
-            MAP_STYLE_URL=http://127.0.0.1:8097/map-style.json
+            MAP_STYLE_URL=http://127.0.0.1:8097/map-style.json \
+            RENTAL_BASE_URL=http://127.0.0.1:8098
 
       # Immer, nicht nur bei Fehlschlag: Das Ergebnisbündel eines grünen Laufs
       # ist der Vergleichsmaßstab, an dem eine neue Warnung überhaupt auffällt.

--- a/ios/Dorf/Anmeldung/Anmeldung.swift
+++ b/ios/Dorf/Anmeldung/Anmeldung.swift
@@ -13,8 +13,30 @@ import Foundation
 /// Android-App — siehe README, Abschnitt „Identität".
 let ROLLEN_SCOPE = "urn:zitadel:iam:org:projects:roles"
 
+/// The scope that puts another Zitadel project into the token's `aud`.
+///
+/// A token is only valid for the project it was issued for. The rental
+/// platform („Maschinchenring") is a project of its own, so it rejects our
+/// token with 401 unless we ask for it here. Zitadel spells that wish as
+/// `urn:zitadel:iam:org:project:id:<id>:aud` (see README, „Identität").
+///
+/// A plain function so it can be checked without touching the build settings.
+func projectAudienceScope(_ projectId: String) -> String {
+    "urn:zitadel:iam:org:project:id:\(projectId):aud"
+}
+
 /// `offline_access` hält die Sitzung über den Neustart hinweg.
-let ANMELDE_SCOPES = ["openid", "profile", "email", "offline_access", ROLLEN_SCOPE]
+///
+/// Careful when rolling this out: a device that is already signed in keeps
+/// its token set across an app update, so it keeps getting tokens **without**
+/// the rental platform's audience. That is why `RentalError.signInOutdated`
+/// exists — the rental area asks for a fresh sign-in instead of showing an
+/// empty list. Browsing the catalogue is unaffected: those routes are public
+/// and go out without a token at all.
+let ANMELDE_SCOPES = [
+    "openid", "profile", "email", "offline_access", ROLLEN_SCOPE,
+    projectAudienceScope(Konfiguration.rentalProjectId),
+]
 
 enum Sitzungszustand: Equatable, Sendable {
     case laedt

--- a/ios/Dorf/Anmeldung/AnmeldungView.swift
+++ b/ios/Dorf/Anmeldung/AnmeldungView.swift
@@ -10,6 +10,15 @@ struct AnmeldungView: View {
     @State private var fehler: String?
 
     var body: some View {
+        // Ein Stapel, damit der Blick in den Maschinchenring von hier aus
+        // möglich ist: Die Geräteliste ist öffentlich, und wer noch keine
+        // Rössing-ID hat, soll sich erst umsehen dürfen.
+        NavigationStack {
+            inhalt
+        }
+    }
+
+    private var inhalt: some View {
         VStack(spacing: 24) {
             Spacer()
 
@@ -51,6 +60,17 @@ struct AnmeldungView: View {
             .disabled(laeuft)
             .padding(.horizontal, 32)
             .accessibilityIdentifier("anmeldung-knopf")
+
+            // Umsehen geht ohne Konto: Die Geräteliste des Maschinchenrings
+            // ist öffentlich. Zum Buchen fragt der Bereich selbst nach der
+            // Rössing-ID — an der Stelle, an der sie wirklich gebraucht wird.
+            NavigationLink {
+                RentalCatalogView()
+            } label: {
+                Label("Erst einmal umsehen: Maschinchenring", systemImage: "wrench.and.screwdriver")
+                    .font(.subheadline)
+            }
+            .accessibilityIdentifier("anmeldung-maschinchenring")
 
             if Konfiguration.entwicklerLoginErlaubt {
                 VStack(spacing: 4) {

--- a/ios/Dorf/Bereiche/Rental/RentalBookingPresentation.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalBookingPresentation.swift
@@ -1,0 +1,346 @@
+import Foundation
+
+/// Bookings, blocks and the profile, prepared for the screens.
+///
+/// Same rule as everywhere in this area: nothing here decides anything.
+/// `canCancel`, `canDecide` and `lenderStatus` arrive from the platform and
+/// are carried through; the buttons follow them.
+
+// MARK: - How far along a booking is
+
+/// The four states of `docs/mieten-api.md` — and everything else the platform
+/// might invent, which keeps its own wording rather than being squeezed into
+/// one of ours.
+nonisolated enum RentalBookingState: Hashable, Sendable {
+    case pending
+    case approved
+    case rejected
+    case cancelled
+    case other(String)
+
+    init(raw: String) {
+        switch raw.lowercased() {
+        case "pending": self = .pending
+        case "approved": self = .approved
+        case "rejected": self = .rejected
+        case "cancelled": self = .cancelled
+        default: self = .other(raw)
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .pending: return "Angefragt"
+        case .approved: return "Bestätigt"
+        case .rejected: return "Abgelehnt"
+        case .cancelled: return "Storniert"
+        case .other(let raw): return raw.isEmpty ? "Unbekannt" : raw
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .pending: return "hourglass"
+        case .approved: return "checkmark.seal.fill"
+        case .rejected: return "xmark.circle"
+        case .cancelled: return "slash.circle"
+        case .other: return "questionmark.circle"
+        }
+    }
+}
+
+// MARK: - My bookings
+
+/// One booking of mine, ready for the list.
+nonisolated struct RentalBooking: Identifiable, Hashable, Sendable {
+    let id: String
+    let deviceId: String?
+    let setId: String?
+    let deviceName: String
+    /// The days the thing is mine.
+    let periodText: String
+    /// „Rückgabe: So, 07.09.2026" — the day it goes back.
+    let returnText: String?
+    let state: RentalBookingState
+    let statusLabel: String
+    /// Whether route 12 has any prospect. The platform decides, not the app.
+    let canCancel: Bool
+    /// Only ever filled once the booking is confirmed. It is the one place in
+    /// this whole interface carrying somebody else's address, and it is not
+    /// stored anywhere beyond this screen.
+    let pickupAddress: String?
+    let pickupPhone: String?
+    let notes: String?
+    let start: Date?
+    /// The return day.
+    let end: Date?
+
+    /// Over and done with — the return day has come.
+    func isPast(_ now: Date, zone: TimeZone = RentalDay.villageZone) -> Bool {
+        guard let end else { return false }
+        return end <= RentalDay.calendar(zone).startOfDay(for: now)
+    }
+}
+
+nonisolated extension RentalBookingDto {
+    func asBooking(zone: TimeZone = RentalDay.villageZone) -> RentalBooking? {
+        let id = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        if id.isEmpty { return nil }
+        let state = RentalBookingState(raw: status)
+        let name = deviceName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return RentalBooking(
+            id: id,
+            deviceId: deviceId,
+            setId: setId,
+            deviceName: name.isEmpty ? (deviceId ?? setId ?? "Gerät") : name,
+            periodText: RentalDay.occupiedText(
+                startDate: startDate, endDate: endDate, zone: zone
+            ),
+            returnText: RentalDay.returnText(endDate: endDate, zone: zone),
+            state: state,
+            statusLabel: state.label,
+            canCancel: canCancel,
+            pickupAddress: pickup?.address?.rentalNonEmpty,
+            pickupPhone: pickup?.phone?.rentalNonEmpty,
+            notes: notes?.rentalNonEmpty,
+            start: RentalDay.parse(startDate, zone: zone),
+            end: RentalDay.parse(endDate, zone: zone)
+        )
+    }
+}
+
+nonisolated extension Collection where Element == RentalBookingDto {
+    /// My bookings in the order they matter: what is still ahead first, in
+    /// the order it happens, and the finished ones behind it, the most recent
+    /// of them on top.
+    func asBookings(now: Date, zone: TimeZone = RentalDay.villageZone) -> [RentalBooking] {
+        let all = compactMap { $0.asBooking(zone: zone) }
+        let ahead = all.filter { !$0.isPast(now, zone: zone) }
+            .sorted { ($0.start ?? .distantFuture) < ($1.start ?? .distantFuture) }
+        let over = all.filter { $0.isPast(now, zone: zone) }
+            .sorted { ($0.start ?? .distantPast) > ($1.start ?? .distantPast) }
+        return ahead + over
+    }
+}
+
+// MARK: - Bookings on my own devices
+
+/// One booking seen by the person the device belongs to.
+nonisolated struct RentalOwnerBooking: Identifiable, Hashable, Sendable {
+    let id: String
+    let deviceId: String?
+    let deviceName: String
+    let periodText: String
+    let returnText: String?
+    let state: RentalBookingState
+    let statusLabel: String
+    /// Here so the handover can be arranged — and nowhere else.
+    let renterName: String?
+    let renterPhone: String?
+    let notes: String?
+    /// Whether routes 14 and 15 work right now.
+    let canDecide: Bool
+    let canCancel: Bool
+    let start: Date?
+    let end: Date?
+
+    func isPast(_ now: Date, zone: TimeZone = RentalDay.villageZone) -> Bool {
+        guard let end else { return false }
+        return end <= RentalDay.calendar(zone).startOfDay(for: now)
+    }
+}
+
+nonisolated extension RentalOwnerBookingDto {
+    func asOwnerBooking(zone: TimeZone = RentalDay.villageZone) -> RentalOwnerBooking? {
+        let id = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        if id.isEmpty { return nil }
+        let state = RentalBookingState(raw: status)
+        let name = deviceName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return RentalOwnerBooking(
+            id: id,
+            deviceId: deviceId,
+            deviceName: name.isEmpty ? (deviceId ?? "Gerät") : name,
+            periodText: RentalDay.occupiedText(
+                startDate: startDate, endDate: endDate, zone: zone
+            ),
+            returnText: RentalDay.returnText(endDate: endDate, zone: zone),
+            state: state,
+            statusLabel: state.label,
+            renterName: renterName?.rentalNonEmpty,
+            renterPhone: renterPhone?.rentalNonEmpty,
+            notes: notes?.rentalNonEmpty,
+            canDecide: canDecide,
+            canCancel: canCancel,
+            start: RentalDay.parse(startDate, zone: zone),
+            end: RentalDay.parse(endDate, zone: zone)
+        )
+    }
+}
+
+nonisolated extension Collection where Element == RentalOwnerBookingDto {
+    /// What waits for a decision comes first — that is the whole reason
+    /// somebody opens this screen. After that the same order as everywhere:
+    /// upcoming by date, finished ones behind.
+    func asOwnerBookings(now: Date, zone: TimeZone = RentalDay.villageZone) -> [RentalOwnerBooking] {
+        let all = compactMap { $0.asOwnerBooking(zone: zone) }
+        let waiting = all.filter { $0.canDecide }
+            .sorted { ($0.start ?? .distantFuture) < ($1.start ?? .distantFuture) }
+        let ahead = all.filter { !$0.canDecide && !$0.isPast(now, zone: zone) }
+            .sorted { ($0.start ?? .distantFuture) < ($1.start ?? .distantFuture) }
+        let over = all.filter { !$0.canDecide && $0.isPast(now, zone: zone) }
+            .sorted { ($0.start ?? .distantPast) > ($1.start ?? .distantPast) }
+        return waiting + ahead + over
+    }
+}
+
+// MARK: - Blocks
+
+/// A stretch the lender keeps for themselves.
+nonisolated struct RentalBlock: Identifiable, Hashable, Sendable {
+    let id: String
+    let deviceId: String
+    let deviceName: String
+    let periodText: String
+    let returnText: String?
+    let reason: String?
+    let start: Date?
+    let end: Date?
+}
+
+nonisolated extension RentalBlockDto {
+    func asBlock(zone: TimeZone = RentalDay.villageZone) -> RentalBlock? {
+        let id = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        if id.isEmpty { return nil }
+        let name = deviceName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return RentalBlock(
+            id: id,
+            deviceId: deviceId,
+            deviceName: name.isEmpty ? deviceId : name,
+            periodText: RentalDay.occupiedText(
+                startDate: startDate, endDate: endDate, zone: zone
+            ),
+            returnText: RentalDay.returnText(endDate: endDate, zone: zone),
+            reason: reason?.rentalNonEmpty,
+            start: RentalDay.parse(startDate, zone: zone),
+            end: RentalDay.parse(endDate, zone: zone)
+        )
+    }
+}
+
+nonisolated extension Collection where Element == RentalBlockDto {
+    /// Blocks that are over are of no use to anybody; the rest by date.
+    func asBlocks(now: Date, zone: TimeZone = RentalDay.villageZone) -> [RentalBlock] {
+        let today = RentalDay.calendar(zone).startOfDay(for: now)
+        return compactMap { $0.asBlock(zone: zone) }
+            .filter { block in
+                guard let end = block.end else { return true }
+                return end > today
+            }
+            .sorted { ($0.start ?? .distantFuture) < ($1.start ?? .distantFuture) }
+    }
+}
+
+// MARK: - Profile
+
+/// Whether somebody may lend things out. The platform says so; nobody works
+/// it out here.
+nonisolated enum RentalLenderStatus: String, Hashable, Sendable {
+    case none
+    case pending
+    case approved
+    case unknown
+
+    init(raw: String) {
+        self = RentalLenderStatus(rawValue: raw.lowercased()) ?? .unknown
+    }
+
+    var label: String {
+        switch self {
+        case .none: return "Du verleihst noch nichts."
+        case .pending: return "Deine Anfrage als Verleiher liegt vor."
+        case .approved: return "Du bist als Verleiher freigeschaltet."
+        case .unknown: return "Unbekannter Stand."
+        }
+    }
+}
+
+/// The profile as the screen shows it.
+nonisolated struct RentalProfile: Hashable, Sendable {
+    let name: String
+    /// Comes from the Rössing-ID and cannot be changed here.
+    let email: String
+    let phone: String
+    let addressStreet: String
+    let addressZip: String
+    let addressCity: String
+    let lenderStatus: RentalLenderStatus
+    let complete: Bool
+    /// What the platform is still missing, in German and readable.
+    let missingLabels: [String]
+
+    /// Whether the lender's side is shown at all. **The platform's answer** —
+    /// `approved`, nothing else.
+    var showsLenderArea: Bool { lenderStatus == .approved }
+
+    /// Whether asking to become a lender is worth offering.
+    var canAskToLend: Bool { lenderStatus == .none }
+}
+
+nonisolated extension RentalProfileDto {
+    func asProfile() -> RentalProfile {
+        RentalProfile(
+            name: name?.rentalNonEmpty ?? "",
+            email: email?.rentalNonEmpty ?? "",
+            phone: phone?.rentalNonEmpty ?? "",
+            addressStreet: addressStreet?.rentalNonEmpty ?? "",
+            addressZip: addressZip?.rentalNonEmpty ?? "",
+            addressCity: addressCity?.rentalNonEmpty ?? "",
+            lenderStatus: RentalLenderStatus(raw: lenderStatus),
+            complete: profileComplete,
+            missingLabels: RentalFieldNames.labels(missingFields)
+        )
+    }
+}
+
+/// The platform names its fields in English (`addressZip`); a person reads
+/// German. One table, used by the profile screen and by every
+/// `profile_incomplete` refusal.
+nonisolated enum RentalFieldNames {
+    static let german: [String: String] = [
+        "name": "Name",
+        "phone": "Telefonnummer",
+        "addressStreet": "Straße und Hausnummer",
+        "addressZip": "Postleitzahl",
+        "addressCity": "Ort",
+    ]
+
+    /// Unknown field names are passed through rather than dropped: a person
+    /// reading „addressCountry" at least knows something is missing.
+    static func labels(_ fields: [String]) -> [String] {
+        fields.compactMap { field in
+            let key = field.trimmingCharacters(in: .whitespacesAndNewlines)
+            if key.isEmpty { return nil }
+            return german[key] ?? key
+        }
+    }
+
+    /// „Telefonnummer, Ort" — for a single line above a form.
+    static func sentence(_ fields: [String]) -> String? {
+        let list = labels(fields)
+        if list.isEmpty { return nil }
+        return list.joined(separator: ", ")
+    }
+}
+
+// MARK: - Small helpers
+
+/// Prefixed rather than plain `nonEmpty`: this is a convenience of this area,
+/// not a new habit for the whole app.
+nonisolated extension String {
+    /// The text, or nothing at all — „a name made of spaces" appears a dozen
+    /// times in this area and is never worth showing.
+    var rentalNonEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalBookingsModel.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalBookingsModel.swift
@@ -1,0 +1,96 @@
+import Combine
+import Foundation
+
+/// „Meine Buchungen": what I asked for, what was confirmed, what I can still
+/// withdraw.
+///
+/// This is one of the screens that needs a token, and therefore one of the
+/// places where the stumbling block of the audience scope shows up: a device
+/// that was signed in before the update carries a token the rental platform
+/// does not accept. It answers `token_audience`, and the screen asks for a
+/// fresh sign-in instead of showing an empty list. Browsing the catalogue is
+/// untouched by all of this — those routes are public.
+///
+/// Whether a booking may be withdrawn is not decided here: `canCancel` comes
+/// from the platform, the button follows it.
+final class RentalBookingsModel: ObservableObject {
+    @Published private(set) var bookings: [RentalBooking] = []
+    @Published private(set) var loading = false
+    @Published private(set) var trouble: RentalTrouble?
+    /// Which booking is being withdrawn right now — one row at a time keeps
+    /// the rest of the list usable.
+    @Published private(set) var cancelling: Set<String> = []
+
+    private var fetched = false
+    private let source: RentalSource
+    private let now: () -> Date
+
+    init(source: RentalSource, now: @escaping () -> Date = Date.init) {
+        self.source = source
+        self.now = now
+    }
+
+    var empty: Bool { bookings.isEmpty && !loading && trouble == nil }
+
+    /// The note above the list — and, when a list is already standing, the
+    /// gentler wording: it may be out of date, it is not gone.
+    var hint: String? {
+        guard let trouble else { return nil }
+        if bookings.isEmpty { return trouble.message }
+        return "Gerade keine Verbindung zum Maschinchenring — die Liste ist "
+            + "möglicherweise nicht mehr aktuell."
+    }
+
+    /// Whether the screen should offer a sign-in rather than „try again".
+    /// Both sign-in cases end up here; the wording differs, the button is the
+    /// same one.
+    var needsSignIn: Bool { trouble?.wantsSignIn == true }
+
+    func load() async {
+        if fetched { return }
+        await fetch()
+    }
+
+    func refresh() async {
+        await fetch()
+    }
+
+    private func fetch() async {
+        if loading { return }
+        loading = true
+        defer { loading = false }
+        do {
+            let raw = try await source.myBookings()
+            bookings = raw.asBookings(now: now())
+            fetched = true
+            trouble = nil
+        } catch {
+            trouble = RentalTrouble(error)
+        }
+    }
+
+    /// Withdraws a booking. The platform decides whether that is allowed —
+    /// the list is fetched again afterwards so its answer, not our guess,
+    /// ends up on screen.
+    func cancel(_ booking: RentalBooking) async {
+        if cancelling.contains(booking.id) { return }
+        cancelling.insert(booking.id)
+        defer { cancelling.remove(booking.id) }
+        do {
+            try await source.cancel(booking.id)
+            trouble = nil
+            let raw = try await source.myBookings()
+            bookings = raw.asBookings(now: now())
+        } catch {
+            // Nothing is removed from the list on a failure: a row that
+            // vanishes while the platform still holds the booking is the one
+            // mistake nobody notices until the device is gone.
+            trouble = RentalTrouble(error)
+        }
+    }
+
+    /// After a fresh sign-in the next attempt should start clean.
+    func clearTrouble() {
+        trouble = nil
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalBookingsView.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalBookingsView.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+
+/// „Meine Buchungen" — what I asked for, what was confirmed, and where to
+/// pick it up once it was.
+struct RentalBookingsView: View {
+    @EnvironmentObject private var umgebung: AppUmgebung
+    @State private var model: RentalBookingsModel?
+
+    var body: some View {
+        Group {
+            if let model {
+                RentalBookingsList(model: model)
+            } else {
+                ProgressView().controlSize(.large)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle("Meine Buchungen")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            let existing = model ?? RentalBookingsModel(source: .from(umgebung.rental))
+            model = existing
+            await existing.load()
+        }
+    }
+}
+
+struct RentalBookingsList: View {
+    @ObservedObject var model: RentalBookingsModel
+    /// The booking somebody is about to withdraw. Nobody cancels by accident.
+    @State private var aboutToCancel: RentalBooking?
+
+    var body: some View {
+        List {
+            if let trouble = model.trouble, trouble.wantsSignIn {
+                Section {
+                    // The one case where „try again" would be a lie: the
+                    // token is the problem, and a sign-in is the fix.
+                    RentalSignInNotice(trouble: trouble) {
+                        model.clearTrouble()
+                        await model.refresh()
+                    }
+                }
+            } else if let hint = model.hint {
+                Section {
+                    RentalNotice(text: hint) {
+                        Task { await model.refresh() }
+                    }
+                }
+            }
+
+            Section {
+                if model.loading && model.bookings.isEmpty {
+                    HStack(spacing: 10) {
+                        ProgressView()
+                        Text("Buchungen werden geholt …").foregroundStyle(.secondary)
+                    }
+                    .accessibilityIdentifier("rental-bookings-loading")
+                }
+
+                ForEach(model.bookings) { booking in
+                    VStack(alignment: .leading, spacing: 8) {
+                        RentalBookingRow(booking: booking)
+
+                        // Withdrawing is offered because the platform says it
+                        // is allowed — the app does not work that out.
+                        if booking.canCancel {
+                            Button(role: .destructive) {
+                                aboutToCancel = booking
+                            } label: {
+                                HStack(spacing: 8) {
+                                    if model.cancelling.contains(booking.id) {
+                                        ProgressView().controlSize(.small)
+                                    }
+                                    Text("Buchung zurückziehen")
+                                }
+                            }
+                            .buttonStyle(.borderless)
+                            .disabled(model.cancelling.contains(booking.id))
+                            .accessibilityIdentifier("rental-cancel-\(booking.id)")
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+
+                if model.empty {
+                    Text("Du hast noch nichts gebucht. Such dir im Maschinchenring "
+                        + "ein Gerät und frag es für deinen Zeitraum an.")
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("rental-bookings-empty")
+                }
+            } footer: {
+                Text("Ob eine Anfrage angenommen wird, entscheidet, wem das Gerät "
+                    + "gehört. Die Abholadresse steht hier, sobald zugesagt wurde.")
+            }
+        }
+        .accessibilityIdentifier("rental-bookings")
+        .refreshable { await model.refresh() }
+        .alert(
+            "Buchung zurückziehen?",
+            isPresented: Binding(
+                get: { aboutToCancel != nil },
+                set: { if !$0 { aboutToCancel = nil } }
+            ),
+            presenting: aboutToCancel
+        ) { booking in
+            Button("Zurückziehen", role: .destructive) {
+                Task { await model.cancel(booking) }
+            }
+            Button("Behalten", role: .cancel) {}
+        } message: { booking in
+            Text("\(booking.deviceName), \(booking.periodText)")
+        }
+    }
+}
+
+/// One booking, in the list and after it was made.
+struct RentalBookingRow: View {
+    let booking: RentalBooking
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(booking.deviceName)
+                .font(.headline)
+
+            Label(booking.periodText, systemImage: "calendar")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            if let back = booking.returnText {
+                Text(back)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Label(booking.statusLabel, systemImage: booking.state.symbol)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(colour)
+
+            // Personal data only ever appears once the platform hands it
+            // over, which it does for one's own confirmed bookings and
+            // nowhere else. It is not stored beyond this screen.
+            if let address = booking.pickupAddress {
+                Label(address, systemImage: "mappin.and.ellipse")
+                    .font(.subheadline)
+            }
+            if let phone = booking.pickupPhone {
+                Label(phone, systemImage: "phone")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            if let note = booking.notes {
+                Text(note)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("rental-booking-\(booking.id)")
+    }
+
+    /// Colour follows the state, and nothing else does.
+    private var colour: Color {
+        switch booking.state {
+        case .approved: return .green
+        case .rejected, .cancelled: return .secondary
+        case .pending, .other: return .primary
+        }
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalCatalogModel.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalCatalogModel.swift
@@ -1,0 +1,125 @@
+import Combine
+import Foundation
+
+/// The state of the catalogue („Maschinchenring": which devices are there?).
+///
+/// The rule of this area is the same as in the events: **an error is not
+/// „nothing there".** If a list is already standing it stays standing and
+/// gets a note above it. An empty page without an explanation would be the
+/// worst possible answer — and it is the one somebody gets whenever a second
+/// service is down and nobody thought about it.
+///
+/// Searching is the platform's job: it weighs meaning and wording together
+/// and hands back an order (`docs/mieten-api.md`, route 3), which this model
+/// does not touch. Only when that route cannot be reached does the model fall
+/// back to filtering the list it already holds — a filter over text, so that
+/// looking around keeps working while the platform is away.
+final class RentalCatalogModel: ObservableObject {
+    @Published private(set) var devices: [RentalDevice] = []
+    @Published private(set) var sets: [RentalSet] = []
+    @Published private(set) var loading = false
+    @Published private(set) var trouble: RentalTrouble?
+    @Published var query = ""
+
+    /// What the platform answered for the current query — `nil` while nobody
+    /// is searching.
+    @Published private(set) var results: [RentalDevice]?
+    @Published private(set) var searching = false
+    /// Set when the search route could not be reached and the list on the
+    /// device was filtered instead. Said out loud, because the result is a
+    /// different one.
+    @Published private(set) var searchedLocally = false
+
+    private var fetched = false
+    private let source: RentalSource
+
+    init(source: RentalSource) {
+        self.source = source
+    }
+
+    /// What the list shows right now.
+    var visible: [RentalDevice] { results ?? devices }
+
+    /// Nothing there, nothing on the way, nothing broken — then the platform
+    /// really has nothing to lend.
+    var empty: Bool { devices.isEmpty && !loading && trouble == nil }
+
+    /// Somebody searched and there is nothing. Different from `empty`, and it
+    /// deserves a different sentence.
+    var withoutMatch: Bool { results?.isEmpty == true && !searching }
+
+    /// Whether the sets are worth a section of their own.
+    var showsSets: Bool { !sets.isEmpty && results == nil }
+
+    /// The note above the list. If an older list is still standing it says so
+    /// instead of claiming there is nothing.
+    var hint: String? {
+        if searchedLocally {
+            return "Die Suche des Maschinchenrings ist gerade nicht erreichbar. "
+                + "Durchsucht wird die Liste, die schon geladen war."
+        }
+        guard let trouble else { return nil }
+        if devices.isEmpty { return trouble.message }
+        return "Gerade keine Verbindung zum Maschinchenring — die Liste ist "
+            + "möglicherweise nicht mehr aktuell."
+    }
+
+    /// When the area is opened. What is already here is not fetched again.
+    func load() async {
+        if fetched { return }
+        await fetch()
+    }
+
+    /// Pulling down, or „Erneut versuchen".
+    func refresh() async {
+        await fetch()
+        if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            await runSearch()
+        }
+    }
+
+    private func fetch() async {
+        if loading { return }
+        loading = true
+        defer { loading = false }
+        do {
+            let raw = try await source.items()
+            devices = raw.asDevices()
+            fetched = true
+            trouble = nil
+        } catch {
+            // The old list stays; the note goes above it.
+            trouble = RentalTrouble(error)
+        }
+        // The sets are an addition, not the point of the screen: if they do
+        // not arrive, the catalogue is still a catalogue.
+        if let raw = try? await source.sets() {
+            sets = raw.asSets()
+        }
+    }
+
+    /// Asks the platform. Called by the screen once typing has settled — the
+    /// waiting happens there so this stays a plain, testable step.
+    func runSearch() async {
+        let wanted = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !wanted.isEmpty else {
+            results = nil
+            searchedLocally = false
+            return
+        }
+        searching = true
+        defer { searching = false }
+        do {
+            let raw = try await source.search(wanted)
+            // The platform's order is the answer; sorting it again here would
+            // throw the ranking away.
+            results = raw.asDevices()
+            searchedLocally = false
+        } catch {
+            // Away, but not helpless: what is already on the device can still
+            // be filtered, and the screen says that this is what happened.
+            results = devices.filter { $0.matches(wanted) }
+            searchedLocally = true
+        }
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalCatalogView.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalCatalogView.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+
+/// „Maschinchenring" — the devices the village lends to the village.
+///
+/// The catalogue is public: it is here before anybody signs in, and it stays
+/// here when the sign-in has gone stale. Booking is the part that needs the
+/// Rössing-ID, and it says so where it is needed, not in front of the door.
+struct RentalCatalogView: View {
+    @EnvironmentObject private var umgebung: AppUmgebung
+    @State private var model: RentalCatalogModel?
+
+    var body: some View {
+        Group {
+            if let model {
+                RentalCatalogList(model: model)
+            } else {
+                ProgressView().controlSize(.large)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle("Maschinchenring")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            let existing = model ?? RentalCatalogModel(source: .from(umgebung.rental))
+            model = existing
+            await existing.load()
+        }
+    }
+}
+
+/// The list itself, once the model stands.
+struct RentalCatalogList: View {
+    @ObservedObject var model: RentalCatalogModel
+
+    var body: some View {
+        List {
+            // The note first, then the (possibly older) list. An empty page
+            // without an explanation would be the worst result.
+            if let hint = model.hint {
+                Section {
+                    RentalNotice(text: hint) {
+                        Task { await model.refresh() }
+                    }
+                }
+            }
+
+            Section {
+                if model.loading && model.devices.isEmpty {
+                    HStack(spacing: 10) {
+                        ProgressView()
+                        Text("Geräte werden geholt …").foregroundStyle(.secondary)
+                    }
+                    .accessibilityIdentifier("rental-loading")
+                }
+
+                ForEach(model.visible) { device in
+                    NavigationLink {
+                        RentalDeviceView(device: device)
+                    } label: {
+                        RentalDeviceRow(device: device)
+                    }
+                    .accessibilityIdentifier("rental-device-\(device.id)")
+                }
+
+                if model.withoutMatch {
+                    Text("Dazu gibt es kein Gerät. Versuch es mit einem anderen Wort.")
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("rental-no-match")
+                }
+
+                if model.empty {
+                    Text("Im Maschinchenring steht gerade nichts zum Ausleihen. "
+                        + "Sobald jemand ein Gerät einstellt, steht es hier.")
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("rental-empty")
+                }
+            } footer: {
+                Text("Die Geräte gehören Leuten aus dem Dorf. Gepflegt werden sie "
+                    + "im Maschinchenring — hier stehen sie nur.")
+            }
+
+            if model.showsSets {
+                setsSection
+            }
+
+            mineSection
+        }
+        .accessibilityIdentifier("rental-catalog")
+        .searchable(text: $model.query, prompt: "Gerät suchen")
+        .task(id: model.query) {
+            // Wait until the typing has settled, then ask the platform: its
+            // search weighs meaning and wording together, and asking on every
+            // keystroke would be a lot of noise for one word.
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            if Task.isCancelled { return }
+            await model.runSearch()
+        }
+        .refreshable { await model.refresh() }
+    }
+
+    /// Sets are shown, not booked. Cancelling, confirming and turning down a
+    /// set booking is not implemented on the server yet, so the app does not
+    /// lead into it either (`docs/mieten-api.md`, route 4).
+    private var setsSection: some View {
+        Section {
+            ForEach(model.sets) { set in
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(set.name).font(.headline)
+                    if let text = set.description {
+                        Text(text)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    ForEach(set.tariffs, id: \.self) { tariff in
+                        Text(tariff)
+                            .font(.footnote.weight(.medium))
+                            .foregroundStyle(.tint)
+                    }
+                    if let deposit = set.depositText {
+                        Text(deposit).font(.footnote).foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.vertical, 2)
+                .accessibilityElement(children: .combine)
+                .accessibilityIdentifier("rental-set-\(set.id)")
+            }
+        } header: {
+            Text("Sets")
+        } footer: {
+            Text("Sets werden im Maschinchenring gebucht — in der App stehen sie "
+                + "nur zur Übersicht.")
+        }
+    }
+
+    private var mineSection: some View {
+        Section("Meins") {
+            NavigationLink {
+                RentalBookingsView()
+            } label: {
+                Label("Meine Buchungen", systemImage: "calendar.badge.clock")
+            }
+            .accessibilityIdentifier("rental-my-bookings")
+
+            NavigationLink {
+                RentalProfileView()
+            } label: {
+                Label("Mein Profil im Maschinchenring", systemImage: "person.text.rectangle")
+            }
+            .accessibilityIdentifier("rental-profile")
+        }
+    }
+}
+
+/// One row of the catalogue.
+struct RentalDeviceRow: View {
+    let device: RentalDevice
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            RentalThumbnail(url: device.thumbnailURL)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(device.name)
+                    .font(.headline)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if !device.summary.isEmpty {
+                    Text(device.summary)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+
+                // The first tariff the platform has. Never added up with the
+                // others: which one applies to which duration is nowhere
+                // written down.
+                if let first = device.tariffs.first {
+                    Text(first)
+                        .font(.footnote.weight(.medium))
+                        .foregroundStyle(.tint)
+                }
+
+                if !device.tags.isEmpty {
+                    Text(device.tags.joined(separator: " · "))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if device.active == false {
+                    Text("Abgeschaltet — für andere unsichtbar.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalClient.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalClient.swift
@@ -1,0 +1,422 @@
+import Foundation
+
+/// The error codes of the rental platform, one for one from
+/// `docs/mieten-api.md`, section „Fehler".
+///
+/// They exist as a type because **the app branches on the code, never on the
+/// message**: the wording may be improved over there at any time, the code
+/// may not. Anything unknown lands on `unknown` and is shown with the
+/// platform's own sentence — a new code must not turn into a silent nothing.
+nonisolated enum RentalErrorCode: String, Sendable {
+    case badRequest = "bad_request"
+    case invalidPeriod = "invalid_period"
+    case profileIncomplete = "profile_incomplete"
+    case unauthorized
+    case tokenAudience = "token_audience"
+    case forbidden
+    case notALender = "not_a_lender"
+    case notFound = "not_found"
+    case occupied
+    case conflict
+    case rateLimited = "rate_limited"
+    case serverFault = "internal"
+    case unknown
+
+    init(raw: String) {
+        self = RentalErrorCode(rawValue: raw) ?? .unknown
+    }
+
+    /// What we say when the platform sent no sentence of its own. Its own
+    /// wording always wins — these are the fallbacks.
+    var fallbackMessage: String {
+        switch self {
+        case .badRequest: return "Die Anfrage war unvollständig."
+        case .invalidPeriod: return "Der Zeitraum stimmt nicht: Das Ende muss nach dem Anfang liegen."
+        case .profileIncomplete: return "Für diesen Schritt fehlen noch Angaben in deinem Profil."
+        case .unauthorized: return "Dafür brauchst du deine Rössing-ID."
+        case .tokenAudience:
+            return "Deine Anmeldung kennt den Maschinchenring noch nicht. "
+                + "Melde dich einmal neu an, dann geht es weiter."
+        case .forbidden: return "Das darfst du hier nicht."
+        case .notALender: return "Das geht nur, wenn du als Verleiher freigeschaltet bist."
+        case .notFound: return "Das gibt es dort nicht (mehr)."
+        case .occupied: return "Der Zeitraum ist inzwischen belegt."
+        case .conflict: return "Das geht in diesem Zustand nicht mehr."
+        case .rateLimited: return "Das ging zu schnell hintereinander. Versuch es später noch einmal."
+        case .serverFault: return "Der Maschinchenring hat gerade einen Fehler."
+        case .unknown: return "Der Maschinchenring hat die Anfrage abgelehnt."
+        }
+    }
+}
+
+/// A refusal of the platform: what it answered, in the shape it answers in.
+nonisolated struct RentalRefusal: Equatable, Sendable {
+    let status: Int
+    let code: RentalErrorCode
+    /// German and meant for the screen — the platform's own sentence where
+    /// it sent one.
+    let message: String
+    /// Only with `profile_incomplete`.
+    let missingFields: [String]
+
+    init(status: Int, code: RentalErrorCode, message: String = "", missingFields: [String] = []) {
+        self.status = status
+        self.code = code
+        self.message = message.isEmpty ? code.fallbackMessage : message
+        self.missingFields = missingFields
+    }
+}
+
+/// What can go wrong on the way to the rental platform.
+///
+/// The two sign-in cases are the reason this is not just a status code. „You
+/// are not signed in" and „your sign-in does not know the Maschinchenring
+/// yet" are both a 401 on the wire, but they need opposite answers from the
+/// person holding the phone — and the platform tells them apart for us with
+/// `unauthorized` versus `token_audience`.
+nonisolated enum RentalError: Error, Sendable, Equatable {
+    case network(String)
+    /// Something arrived that was not the payload — an error page, a portal,
+    /// a moved route. It must never pass as „nothing there".
+    case unreadable
+    case refused(RentalRefusal)
+
+    /// The sentence shown to the person. German, like everything visible.
+    var message: String {
+        switch self {
+        case .network:
+            return "Der Maschinchenring ist gerade nicht erreichbar. Besteht eine Verbindung?"
+        case .unreadable:
+            return "Die Antwort des Maschinchenrings war nicht lesbar."
+        case .refused(let refusal):
+            return refusal.message
+        }
+    }
+
+    var code: RentalErrorCode? {
+        if case .refused(let refusal) = self { return refusal.code }
+        return nil
+    }
+
+    /// The device kept its token set across the update that added the
+    /// audience scope. Only a fresh sign-in fixes that — see `ANMELDE_SCOPES`.
+    var needsFreshSignIn: Bool { code == .tokenAudience }
+
+    /// Nobody is signed in, or the token has expired: the ordinary sign-in.
+    var needsSignIn: Bool { code == .unauthorized }
+
+    /// Which fields the platform is missing before it lets this through.
+    var missingFields: [String] {
+        if case .refused(let refusal) = self { return refusal.missingFields }
+        return []
+    }
+
+    /// Nobody is signed in on this device at all — built here rather than at
+    /// three call sites, so it reads like every other refusal.
+    static let signInRequired = RentalError.refused(RentalRefusal(
+        status: 401, code: .unauthorized,
+        message: "Zum Buchen brauchst du deine Rössing-ID."
+    ))
+}
+
+/// The way to the rental platform („Maschinchenring").
+///
+/// A client of its own, deliberately: `mieten.…` is **not** the village
+/// backend, so the rule „exactly one way to the backend: `DorfApi`" does not
+/// cover it (`CLAUDE.md`; `docs/mietplattform-in-den-apps.md`, AP 4). The
+/// events area has the same shape for the same reason — a second server, a
+/// small client of its own, `URLSession` and `Codable` and nothing else.
+///
+/// The one difference to the events: a token goes along, but **only where it
+/// has to.** Catalogue, detail, search, sets, availability and occupancy are
+/// public over there and are fetched without an `Authorization` header. That
+/// is not thrift, it is the difference between a working and a broken area:
+/// a device whose token predates the audience scope would otherwise get a 401
+/// on the catalogue as well, and looking around would break for exactly the
+/// people who are already signed in.
+nonisolated final class RentalClient: Sendable {
+    private let base: URL
+    private let session: URLSession
+    private let tokenProvider: @Sendable () async -> Tokenlage
+
+    init(base: URL = Konfiguration.rentalBaseUrl,
+         session: URLSession = .rentalSession,
+         tokenProvider: @escaping @Sendable () async -> Tokenlage) {
+        self.base = base
+        self.session = session
+        self.tokenProvider = tokenProvider
+    }
+
+    // MARK: Public routes — no token goes out here
+
+    /// Route 1: all active devices, sorted by name over there. No paging, and
+    /// none planned.
+    func items() async throws -> [RentalItemDto] {
+        let answer: RentalItemsDto = try await get(RentalRoutes.items)
+        return answer.items
+    }
+
+    /// Route 2: one device with all its pictures.
+    func item(id: String) async throws -> RentalItemDto {
+        let answer: RentalItemEnvelopeDto = try await get(RentalRoutes.item(id))
+        return answer.item
+    }
+
+    /// Route 3: the hybrid search of the platform — semantic and literal,
+    /// weighted over there. **The order that comes back is the answer**; the
+    /// app does not sort it again.
+    func search(_ text: String, tags: [String] = [], limit: Int? = nil) async throws -> [RentalItemDto] {
+        var query = [RentalRoutes.queryText: text]
+        if !tags.isEmpty { query[RentalRoutes.queryTags] = tags.joined(separator: ",") }
+        if let limit { query[RentalRoutes.queryLimit] = String(limit) }
+        let answer: RentalSearchDto = try await get(RentalRoutes.search, query: query)
+        return answer.results
+    }
+
+    /// Route 4: the sets.
+    func sets() async throws -> [RentalSetDto] {
+        let answer: RentalSetsDto = try await get(RentalRoutes.sets)
+        return answer.sets
+    }
+
+    /// Route 5: „is it free from … to …?" — asked and answered over there,
+    /// even though the calendar from route 6 is already on screen. Exactly
+    /// one of `deviceId` and `setId`.
+    func availability(deviceId: String? = nil, setId: String? = nil,
+                      startDate: String, endDate: String) async throws -> RentalAvailabilityDto {
+        var query = [
+            RentalRoutes.queryStartDate: startDate,
+            RentalRoutes.queryEndDate: endDate,
+        ]
+        if let deviceId { query[RentalRoutes.queryDeviceId] = deviceId }
+        if let setId { query[RentalRoutes.querySetId] = setId }
+        return try await get(RentalRoutes.availability, query: query)
+    }
+
+    /// Route 6: taken stretches of days, without a single personal datum.
+    /// Without a device it is the whole village's calendar.
+    func occupancy(deviceId: String? = nil, setId: String? = nil) async throws -> [RentalPeriodDto] {
+        var query: [String: String] = [:]
+        if let deviceId { query[RentalRoutes.queryDeviceId] = deviceId }
+        if let setId { query[RentalRoutes.querySetId] = setId }
+        let answer: RentalOccupancyDto = try await get(RentalRoutes.occupancy, query: query)
+        return answer.periods
+    }
+
+    // MARK: Routes that need a token
+
+    /// Route 7. The first call with a new Rössing-ID quietly creates the
+    /// account over there; the app does nothing for that.
+    func profile() async throws -> RentalProfileDto {
+        let answer: RentalProfileEnvelopeDto = try await get(RentalRoutes.me, withToken: true)
+        return answer.profile
+    }
+
+    /// Route 8. Only what is sent changes.
+    func updateProfile(_ patch: RentalProfilePatchDto) async throws -> RentalProfileDto {
+        let data = try await perform(request("PATCH", RentalRoutes.me, body: patch, withToken: true))
+        let answer: RentalProfileEnvelopeDto = try decode(data)
+        return answer.profile
+    }
+
+    /// Route 9. An acknowledgement, not a permission — a person decides that,
+    /// in the web version.
+    func requestLender() async throws -> RentalLenderRequestDto {
+        let data = try await perform(request("POST", RentalRoutes.lenderRequest, withToken: true))
+        return try decode(data)
+    }
+
+    /// Route 10.
+    func myBookings() async throws -> [RentalBookingDto] {
+        let answer: RentalBookingsDto = try await get(RentalRoutes.myBookings, withToken: true)
+        return answer.bookings
+    }
+
+    /// Route 11. Creates a request, confirms nothing.
+    func book(_ wish: RentalBookingRequestDto) async throws -> RentalBookingDto {
+        let data = try await perform(request("POST", RentalRoutes.bookings,
+                                             body: wish, withToken: true))
+        let answer: RentalBookingEnvelopeDto = try decode(data)
+        return answer.booking
+    }
+
+    /// Route 12.
+    @discardableResult
+    func cancel(bookingId: String) async throws -> String {
+        let data = try await perform(request("POST", RentalRoutes.cancel(bookingId), withToken: true))
+        let answer: RentalStatusDto = try decode(data)
+        return answer.status
+    }
+
+    // MARK: The lender's side
+
+    /// Route 13. Somebody without devices gets an empty list, not an error.
+    func ownerBookings() async throws -> [RentalOwnerBookingDto] {
+        let answer: RentalOwnerBookingsDto = try await get(RentalRoutes.ownerBookings, withToken: true)
+        return answer.bookings
+    }
+
+    /// Route 14.
+    @discardableResult
+    func approve(bookingId: String) async throws -> String {
+        let data = try await perform(request("POST", RentalRoutes.approve(bookingId), withToken: true))
+        let answer: RentalStatusDto = try decode(data)
+        return answer.status
+    }
+
+    /// Route 15. No reason is recorded.
+    @discardableResult
+    func reject(bookingId: String) async throws -> String {
+        let data = try await perform(request("POST", RentalRoutes.reject(bookingId), withToken: true))
+        let answer: RentalStatusDto = try decode(data)
+        return answer.status
+    }
+
+    /// Route 16. The disabled ones are in here too — they are missing from
+    /// route 1.
+    func ownerItems() async throws -> [RentalItemDto] {
+        let answer: RentalItemsDto = try await get(RentalRoutes.ownerItems, withToken: true)
+        return answer.items
+    }
+
+    /// Route 17.
+    func blocks() async throws -> [RentalBlockDto] {
+        let answer: RentalBlocksDto = try await get(RentalRoutes.ownerBlocks, withToken: true)
+        return answer.blocks
+    }
+
+    /// Route 18. An existing booking is never pushed aside — the platform
+    /// answers `occupied` instead.
+    func addBlock(_ wish: RentalBlockRequestDto) async throws -> RentalBlockDto {
+        let data = try await perform(request("POST", RentalRoutes.ownerBlocks,
+                                             body: wish, withToken: true))
+        let answer: RentalBlockEnvelopeDto = try decode(data)
+        return answer.block
+    }
+
+    /// Route 19.
+    func removeBlock(id: String) async throws {
+        _ = try await perform(request("DELETE", RentalRoutes.ownerBlock(id), withToken: true))
+    }
+
+    // MARK: Transport
+
+    private func address(_ path: String, query: [String: String]) -> URL {
+        var url = base.appending(path: path)
+        if !query.isEmpty {
+            url.append(queryItems: query.sorted { $0.key < $1.key }
+                .map { URLQueryItem(name: $0.key, value: $0.value) })
+        }
+        return url
+    }
+
+    /// Builds the request — a step of its own so a test can see what would go
+    /// out (path, method, body, and whether a token is attached) without a
+    /// network anywhere near it.
+    func request(_ method: String, _ path: String,
+                 query: [String: String] = [:],
+                 body: (any Encodable)? = nil,
+                 withToken: Bool) async throws -> URLRequest {
+        var outgoing = URLRequest(url: address(path, query: query))
+        outgoing.httpMethod = method
+        outgoing.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let body {
+            outgoing.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            outgoing.httpBody = try? JSONEncoder().encode(body)
+        }
+        guard withToken else { return outgoing }
+
+        switch await tokenProvider() {
+        case .token(let token):
+            outgoing.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        case .abgemeldet:
+            throw RentalError.signInRequired
+        case .nichtErreichbar:
+            // The sign-in holds, it just could not be refreshed. Sending
+            // nothing would come back as 401 and we would tell somebody their
+            // sign-in is stale when it is the network that is stale.
+            throw RentalError.network("Die Anmeldung ließ sich gerade nicht erneuern.")
+        }
+        return outgoing
+    }
+
+    private func get<T: Decodable>(_ path: String, query: [String: String] = [:],
+                                   withToken: Bool = false) async throws -> T {
+        let data = try await perform(request("GET", path, query: query, withToken: withToken))
+        return try decode(data)
+    }
+
+    private func decode<T: Decodable>(_ data: Data) throws -> T {
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw RentalError.unreadable
+        }
+    }
+
+    private func perform(_ outgoing: URLRequest) async throws -> Data {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: outgoing)
+        } catch {
+            throw RentalError.network(error.localizedDescription)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw RentalError.network("Unerwartete Antwort")
+        }
+        guard (200 ..< 300).contains(http.statusCode) else {
+            throw Self.error(status: http.statusCode, data: data)
+        }
+        return data
+    }
+
+    /// The platform's refusal, read the way the contract writes it: the
+    /// **code** decides, the message is only shown. A plain function, so it
+    /// can be checked without a network.
+    ///
+    /// When nothing readable came back — a gateway page, an empty body — the
+    /// status stands in for the code. That keeps a 401 from a proxy from
+    /// looking like a fresh-sign-in case that it is not.
+    static func error(status: Int, data: Data) -> RentalError {
+        guard let dto = try? JSONDecoder().decode(RentalErrorDto.self, from: data),
+              !dto.code.isEmpty || !dto.message.isEmpty
+        else {
+            return RentalError.refused(RentalRefusal(
+                status: status, code: codeForStatus(status)
+            ))
+        }
+        let code = dto.code.isEmpty ? codeForStatus(status) : RentalErrorCode(raw: dto.code)
+        return .refused(RentalRefusal(
+            status: status, code: code, message: dto.message, missingFields: dto.missingFields
+        ))
+    }
+
+    /// A stand-in for a missing code. Deliberately coarse: it only has to
+    /// carry a status into something the screens can react to.
+    private static func codeForStatus(_ status: Int) -> RentalErrorCode {
+        switch status {
+        case 400: return .badRequest
+        case 401: return .unauthorized
+        case 403: return .forbidden
+        case 404: return .notFound
+        case 409: return .conflict
+        case 429: return .rateLimited
+        case 500 ..< 600: return .serverFault
+        default: return .unknown
+        }
+    }
+}
+
+nonisolated extension URLSession {
+    /// A session of its own for the rental platform — separate from the
+    /// backend's, so nothing that only concerns the village API ever rides
+    /// along. Same deadlines as everywhere else in this app.
+    static let rentalSession: URLSession = {
+        let k = URLSessionConfiguration.default
+        k.timeoutIntervalForRequest = 20
+        k.timeoutIntervalForResource = 30
+        k.waitsForConnectivity = false
+        return URLSession(configuration: k)
+    }()
+}

--- a/ios/Dorf/Bereiche/Rental/RentalContract.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalContract.swift
@@ -1,0 +1,701 @@
+import Foundation
+
+/// The contract with the rental platform („Maschinchenring", `mieten.…`) —
+/// routes and payloads, and nothing else.
+///
+/// **The single source for this file is `docs/mieten-api.md`.** Every type
+/// below mirrors one of its nineteen routes; every field name is spelled the
+/// way the platform spells it. Nothing here is invented: where the document
+/// is silent, this file is silent too, and the answer is fetched from the
+/// platform rather than guessed (`docs/mieten-api.md`, section 6).
+///
+/// Two habits keep this survivable, both taken from the events area:
+///  - every field falls back to a default, so the platform may add fields
+///    without older app versions going blank;
+///  - the app reads decisions, it does not compute them. `available`,
+///    `canCancel`, `canDecide`, `lenderStatus` and every message come from
+///    the server. The app may grey a button out because the server said so;
+///    it must not know the condition (`docs/mieten-api.md`, „Was die App
+///    nicht entscheidet").
+
+// MARK: - Routes
+
+/// Where the things live. Paths only — the host comes from
+/// `Konfiguration.rentalBaseUrl`, so CI and tests can point elsewhere.
+nonisolated enum RentalRoutes {
+    /// Public: the catalogue (1).
+    static let items = "api/v1/items"
+    /// Public: one device with its pictures (2).
+    static func item(_ id: String) -> String { "api/v1/items/\(id)" }
+    /// Public: hybrid search, ranked by the platform (3).
+    static let search = "api/v1/search"
+    /// Public: the sets (4).
+    static let sets = "api/v1/sets"
+    /// Public: „is it free from … to …?" — the platform's answer, not ours (5).
+    static let availability = "api/v1/availability"
+    /// Public: occupied periods, without any personal data (6).
+    static let occupancy = "api/v1/occupancy"
+
+    /// Needs a token: own profile (7, 8).
+    static let me = "api/v1/me"
+    /// Needs a token: ask to become a lender (9).
+    static let lenderRequest = "api/v1/me/lender-request"
+    /// Needs a token: my own bookings (10).
+    static let myBookings = "api/v1/bookings/mine"
+    /// Needs a token: book a device or a set (11).
+    static let bookings = "api/v1/bookings"
+    /// Needs a token: withdraw a booking (12).
+    static func cancel(_ id: String) -> String { "api/v1/bookings/\(id)/cancel" }
+
+    /// Needs a token: bookings on my own devices (13).
+    static let ownerBookings = "api/v1/owner/bookings"
+    /// Needs a token: confirm (14) and turn down (15) a booking.
+    static func approve(_ id: String) -> String { "api/v1/bookings/\(id)/approve" }
+    static func reject(_ id: String) -> String { "api/v1/bookings/\(id)/reject" }
+    /// Needs a token: my own devices, disabled ones included (16).
+    static let ownerItems = "api/v1/owner/items"
+    /// Needs a token: my own blocked periods (17, 18).
+    static let ownerBlocks = "api/v1/owner/blocks"
+    /// Needs a token: lift one of them (19).
+    static func ownerBlock(_ id: String) -> String { "api/v1/owner/blocks/\(id)" }
+
+    // Query parameters, spelled once.
+    static let queryText = "q"
+    static let queryTags = "tags"
+    static let queryLimit = "limit"
+    static let queryDeviceId = "deviceId"
+    static let querySetId = "setId"
+    static let queryStartDate = "startDate"
+    static let queryEndDate = "endDate"
+}
+
+// MARK: - Catalogue
+
+/// One picture of a device (route 2).
+nonisolated struct RentalImageDto: Codable, Hashable, Sendable {
+    var id: String = ""
+    var url: String = ""
+    var isThumbnail: Bool = false
+
+    enum CodingKeys: String, CodingKey { case id, url, isThumbnail }
+
+    init(id: String = "", url: String = "", isThumbnail: Bool = false) {
+        self.id = id; self.url = url; self.isThumbnail = isThumbnail
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = c.wert(.id, "")
+        url = c.wert(.url, "")
+        isThumbnail = c.wert(.isThumbnail, false)
+    }
+}
+
+/// One device, as routes 1, 2, 3 and 16 all spell it.
+///
+/// The fields that only some of those routes carry are optional and default
+/// to nothing: `images` (2), `score` (3), `active` (16). One type for four
+/// routes is honest here — the platform really does send the same object.
+///
+/// **There is no owner in this payload and there will not be one.** Who lends
+/// a device out appears in no public answer; that is a rule of the platform,
+/// not an omission (`docs/mieten-api.md`, route 1).
+nonisolated struct RentalItemDto: Codable, Hashable, Sendable {
+    var id: String = ""
+    var name: String = ""
+    /// Markdown. May be `null`.
+    var description: String?
+    /// Euro, as a plain number. `null` means: this tariff does not exist —
+    /// **not** zero, and nothing to calculate with.
+    var pricePerDay: Double?
+    var pricePerWeekend: Double?
+    var pricePerWeek: Double?
+    var deposit: Double?
+    var tags: [String] = []
+    /// A finished, signed address (imgproxy, 600×450). `null` means no picture.
+    var thumbnailUrl: String?
+    /// The manufacturer's page, if there is one.
+    var productUrl: String?
+    /// The same device in the web version.
+    var webUrl: String?
+    /// Route 2 only.
+    var images: [RentalImageDto] = []
+    /// Route 3 only: how well it matched. For sorting, never for showing.
+    var score: Double?
+    /// Route 16 only: `false` means the device is invisible to everybody else.
+    var active: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, description
+        case pricePerDay, pricePerWeekend, pricePerWeek, deposit
+        case tags, thumbnailUrl, productUrl, webUrl, images, score, active
+    }
+
+    init(id: String = "", name: String = "", description: String? = nil,
+         pricePerDay: Double? = nil, pricePerWeekend: Double? = nil,
+         pricePerWeek: Double? = nil, deposit: Double? = nil, tags: [String] = [],
+         thumbnailUrl: String? = nil, productUrl: String? = nil, webUrl: String? = nil,
+         images: [RentalImageDto] = [], score: Double? = nil, active: Bool? = nil) {
+        self.id = id; self.name = name; self.description = description
+        self.pricePerDay = pricePerDay; self.pricePerWeekend = pricePerWeekend
+        self.pricePerWeek = pricePerWeek; self.deposit = deposit; self.tags = tags
+        self.thumbnailUrl = thumbnailUrl; self.productUrl = productUrl; self.webUrl = webUrl
+        self.images = images; self.score = score; self.active = active
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = c.wert(.id, "")
+        name = c.wert(.name, "")
+        description = c.wertOptional(.description)
+        pricePerDay = c.wertOptional(.pricePerDay)
+        pricePerWeekend = c.wertOptional(.pricePerWeekend)
+        pricePerWeek = c.wertOptional(.pricePerWeek)
+        deposit = c.wertOptional(.deposit)
+        tags = c.wert(.tags, [])
+        thumbnailUrl = c.wertOptional(.thumbnailUrl)
+        productUrl = c.wertOptional(.productUrl)
+        webUrl = c.wertOptional(.webUrl)
+        images = c.wert(.images, [])
+        score = c.wertOptional(.score)
+        active = c.wertOptional(.active)
+    }
+}
+
+/// Routes 1 and 16: `{"items": […]}`. A hull object, never a bare array — so
+/// a field can grow next to it without breaking the contract.
+nonisolated struct RentalItemsDto: Codable, Sendable {
+    var items: [RentalItemDto] = []
+
+    enum CodingKeys: String, CodingKey { case items }
+
+    init(items: [RentalItemDto] = []) { self.items = items }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        items = c.wert(.items, [])
+    }
+}
+
+/// Route 2: `{"item": {…}}`.
+nonisolated struct RentalItemEnvelopeDto: Codable, Sendable {
+    var item: RentalItemDto = RentalItemDto()
+
+    enum CodingKeys: String, CodingKey { case item }
+
+    init(item: RentalItemDto = RentalItemDto()) { self.item = item }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        item = c.wert(.item, RentalItemDto())
+    }
+}
+
+/// Route 3: `{"results": […]}`. No hit is not an error.
+nonisolated struct RentalSearchDto: Codable, Sendable {
+    var results: [RentalItemDto] = []
+
+    enum CodingKeys: String, CodingKey { case results }
+
+    init(results: [RentalItemDto] = []) { self.results = results }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        results = c.wert(.results, [])
+    }
+}
+
+/// Route 4: several devices at one price of their own.
+nonisolated struct RentalSetDto: Codable, Hashable, Sendable {
+    var id: String = ""
+    var name: String = ""
+    /// Plain text here, **not** Markdown — unlike a device's description.
+    var description: String?
+    var pricePerDay: Double?
+    var deposit: Double?
+    var itemIds: [String] = []
+
+    enum CodingKeys: String, CodingKey { case id, name, description, pricePerDay, deposit, itemIds }
+
+    init(id: String = "", name: String = "", description: String? = nil,
+         pricePerDay: Double? = nil, deposit: Double? = nil, itemIds: [String] = []) {
+        self.id = id; self.name = name; self.description = description
+        self.pricePerDay = pricePerDay; self.deposit = deposit; self.itemIds = itemIds
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = c.wert(.id, "")
+        name = c.wert(.name, "")
+        description = c.wertOptional(.description)
+        pricePerDay = c.wertOptional(.pricePerDay)
+        deposit = c.wertOptional(.deposit)
+        itemIds = c.wert(.itemIds, [])
+    }
+}
+
+nonisolated struct RentalSetsDto: Codable, Sendable {
+    var sets: [RentalSetDto] = []
+
+    enum CodingKeys: String, CodingKey { case sets }
+
+    init(sets: [RentalSetDto] = []) { self.sets = sets }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        sets = c.wert(.sets, [])
+    }
+}
+
+// MARK: - Availability and occupancy
+
+/// Route 5. Two fields, and the app owns neither of them.
+///
+/// `available` defaults to `false`: an answer we could not read must never
+/// read as „go ahead".
+nonisolated struct RentalAvailabilityDto: Codable, Sendable {
+    var available: Bool = false
+    /// `null` or `"occupied"`. Why exactly it is taken is deliberately not
+    /// said — that would be somebody else's business.
+    var reason: String?
+
+    enum CodingKeys: String, CodingKey { case available, reason }
+
+    init(available: Bool = false, reason: String? = nil) {
+        self.available = available; self.reason = reason
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        available = c.wert(.available, false)
+        reason = c.wertOptional(.reason)
+    }
+}
+
+/// Route 6: one taken stretch of days. **Half open** — `startDate` belongs to
+/// it, `endDate` does not; `endDate` is the day it comes back.
+nonisolated struct RentalPeriodDto: Codable, Hashable, Sendable {
+    var deviceId: String?
+    var setId: String?
+    var startDate: String = ""
+    var endDate: String = ""
+    /// `"pending"`, `"approved"` or `"blocked"` — all three mean taken. The
+    /// difference is for the drawing, not for the decision.
+    var status: String = ""
+
+    enum CodingKeys: String, CodingKey { case deviceId, setId, startDate, endDate, status }
+
+    init(deviceId: String? = nil, setId: String? = nil, startDate: String = "",
+         endDate: String = "", status: String = "") {
+        self.deviceId = deviceId; self.setId = setId
+        self.startDate = startDate; self.endDate = endDate; self.status = status
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        deviceId = c.wertOptional(.deviceId)
+        setId = c.wertOptional(.setId)
+        startDate = c.wert(.startDate, "")
+        endDate = c.wert(.endDate, "")
+        status = c.wert(.status, "")
+    }
+}
+
+nonisolated struct RentalOccupancyDto: Codable, Sendable {
+    var periods: [RentalPeriodDto] = []
+
+    enum CodingKeys: String, CodingKey { case periods }
+
+    init(periods: [RentalPeriodDto] = []) { self.periods = periods }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        periods = c.wert(.periods, [])
+    }
+}
+
+// MARK: - Profile
+
+/// Route 7 and 8. `admin` is deliberately absent from this payload: letting
+/// somebody lend is decided in the web version, and the app has nothing to do
+/// with it.
+nonisolated struct RentalProfileDto: Codable, Hashable, Sendable {
+    var name: String?
+    /// Comes from the Rössing-ID and cannot be changed here.
+    var email: String?
+    var phone: String?
+    var addressStreet: String?
+    var addressZip: String?
+    var addressCity: String?
+    var lender: Bool = false
+    /// `"none"`, `"pending"` or `"approved"`. Only `"approved"` opens the
+    /// lender's side — and the platform says so, the app does not work it out.
+    var lenderStatus: String = "none"
+    var profileComplete: Bool = false
+    var missingFields: [String] = []
+
+    enum CodingKeys: String, CodingKey {
+        case name, email, phone, addressStreet, addressZip, addressCity
+        case lender, lenderStatus, profileComplete, missingFields
+    }
+
+    init(name: String? = nil, email: String? = nil, phone: String? = nil,
+         addressStreet: String? = nil, addressZip: String? = nil, addressCity: String? = nil,
+         lender: Bool = false, lenderStatus: String = "none",
+         profileComplete: Bool = false, missingFields: [String] = []) {
+        self.name = name; self.email = email; self.phone = phone
+        self.addressStreet = addressStreet; self.addressZip = addressZip
+        self.addressCity = addressCity; self.lender = lender
+        self.lenderStatus = lenderStatus; self.profileComplete = profileComplete
+        self.missingFields = missingFields
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        name = c.wertOptional(.name)
+        email = c.wertOptional(.email)
+        phone = c.wertOptional(.phone)
+        addressStreet = c.wertOptional(.addressStreet)
+        addressZip = c.wertOptional(.addressZip)
+        addressCity = c.wertOptional(.addressCity)
+        lender = c.wert(.lender, false)
+        lenderStatus = c.wert(.lenderStatus, "none")
+        profileComplete = c.wert(.profileComplete, false)
+        missingFields = c.wert(.missingFields, [])
+    }
+}
+
+nonisolated struct RentalProfileEnvelopeDto: Codable, Sendable {
+    var profile: RentalProfileDto = RentalProfileDto()
+
+    enum CodingKeys: String, CodingKey { case profile }
+
+    init(profile: RentalProfileDto = RentalProfileDto()) { self.profile = profile }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        profile = c.wert(.profile, RentalProfileDto())
+    }
+}
+
+/// Route 8. Only the fields that are sent change, so every one of them is
+/// optional and `nil` ones are left out of the body entirely.
+nonisolated struct RentalProfilePatchDto: Encodable, Sendable {
+    var name: String?
+    var phone: String?
+    var addressStreet: String?
+    var addressZip: String?
+    var addressCity: String?
+
+    // No `email`: it comes from the Rössing-ID and is the link to the
+    // account. The platform ignores it; we do not even send it.
+    enum CodingKeys: String, CodingKey { case name, phone, addressStreet, addressZip, addressCity }
+}
+
+/// Route 9: the receipt for „please let me lend things out", not the
+/// permission itself.
+nonisolated struct RentalLenderRequestDto: Codable, Sendable {
+    var lenderStatus: String = "pending"
+    /// German and meant for the screen.
+    var message: String = ""
+
+    enum CodingKeys: String, CodingKey { case lenderStatus, message }
+
+    init(lenderStatus: String = "pending", message: String = "") {
+        self.lenderStatus = lenderStatus; self.message = message
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        lenderStatus = c.wert(.lenderStatus, "pending")
+        message = c.wert(.message, "")
+    }
+}
+
+// MARK: - Bookings
+
+/// Route 10: where to pick the thing up. **The only place in this interface
+/// carrying another person's address and telephone number**, and only after
+/// they confirmed the booking. Not to be cached, not to be shown elsewhere.
+nonisolated struct RentalPickupDto: Codable, Hashable, Sendable {
+    var address: String?
+    var phone: String?
+
+    enum CodingKeys: String, CodingKey { case address, phone }
+
+    init(address: String? = nil, phone: String? = nil) {
+        self.address = address; self.phone = phone
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        address = c.wertOptional(.address)
+        phone = c.wertOptional(.phone)
+    }
+}
+
+/// Routes 10 and 11: a booking seen by the person who made it.
+nonisolated struct RentalBookingDto: Codable, Hashable, Sendable {
+    var id: String = ""
+    var deviceId: String?
+    var setId: String?
+    /// With a set booking this is the set's name.
+    var deviceName: String = ""
+    var startDate: String = ""
+    var endDate: String = ""
+    /// `"pending"`, `"approved"`, `"rejected"` or `"cancelled"`.
+    var status: String = ""
+    var notes: String?
+    /// Whether route 12 has any prospect right now. **The button follows
+    /// this**, not a status check of our own.
+    var canCancel: Bool = false
+    var pickup: RentalPickupDto?
+
+    enum CodingKeys: String, CodingKey {
+        case id, deviceId, setId, deviceName, startDate, endDate, status, notes, canCancel, pickup
+    }
+
+    init(id: String = "", deviceId: String? = nil, setId: String? = nil,
+         deviceName: String = "", startDate: String = "", endDate: String = "",
+         status: String = "", notes: String? = nil, canCancel: Bool = false,
+         pickup: RentalPickupDto? = nil) {
+        self.id = id; self.deviceId = deviceId; self.setId = setId
+        self.deviceName = deviceName; self.startDate = startDate; self.endDate = endDate
+        self.status = status; self.notes = notes; self.canCancel = canCancel
+        self.pickup = pickup
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = c.wert(.id, "")
+        deviceId = c.wertOptional(.deviceId)
+        setId = c.wertOptional(.setId)
+        deviceName = c.wert(.deviceName, "")
+        startDate = c.wert(.startDate, "")
+        endDate = c.wert(.endDate, "")
+        status = c.wert(.status, "")
+        notes = c.wertOptional(.notes)
+        canCancel = c.wert(.canCancel, false)
+        pickup = c.wertOptional(.pickup)
+    }
+}
+
+nonisolated struct RentalBookingsDto: Codable, Sendable {
+    var bookings: [RentalBookingDto] = []
+
+    enum CodingKeys: String, CodingKey { case bookings }
+
+    init(bookings: [RentalBookingDto] = []) { self.bookings = bookings }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        bookings = c.wert(.bookings, [])
+    }
+}
+
+nonisolated struct RentalBookingEnvelopeDto: Codable, Sendable {
+    var booking: RentalBookingDto = RentalBookingDto()
+
+    enum CodingKeys: String, CodingKey { case booking }
+
+    init(booking: RentalBookingDto = RentalBookingDto()) { self.booking = booking }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        booking = c.wert(.booking, RentalBookingDto())
+    }
+}
+
+/// Route 11. Leaving the three personal fields out is the ordinary way for
+/// the app: it has the profile from route 7, so nobody has to type their own
+/// name again. If they are missing here **and** in the profile, the platform
+/// answers `profile_incomplete` and the app leads to route 8.
+nonisolated struct RentalBookingRequestDto: Encodable, Sendable {
+    var deviceId: String?
+    var setId: String?
+    var startDate: String
+    var endDate: String
+    var firstName: String?
+    var lastName: String?
+    var phone: String?
+    var notes: String?
+
+    enum CodingKeys: String, CodingKey {
+        case deviceId, setId, startDate, endDate, firstName, lastName, phone, notes
+    }
+}
+
+/// Routes 12, 14 and 15: `{"status": "cancelled"}` and friends.
+nonisolated struct RentalStatusDto: Codable, Sendable {
+    var status: String = ""
+
+    enum CodingKeys: String, CodingKey { case status }
+
+    init(status: String = "") { self.status = status }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        status = c.wert(.status, "")
+    }
+}
+
+// MARK: - The lender's side
+
+/// Route 13: a booking seen by the person the device belongs to.
+///
+/// `renterName` and `renterPhone` are here because the handover has to be
+/// arranged. They belong in **no** other view and in no store that outlives
+/// the screen.
+nonisolated struct RentalOwnerBookingDto: Codable, Hashable, Sendable {
+    var id: String = ""
+    var deviceId: String?
+    var deviceName: String = ""
+    var startDate: String = ""
+    var endDate: String = ""
+    var status: String = ""
+    var renterName: String?
+    var renterPhone: String?
+    var notes: String?
+    /// Whether routes 14 and 15 work right now. The buttons follow this.
+    var canDecide: Bool = false
+    var canCancel: Bool = false
+
+    enum CodingKeys: String, CodingKey {
+        case id, deviceId, deviceName, startDate, endDate, status
+        case renterName, renterPhone, notes, canDecide, canCancel
+    }
+
+    init(id: String = "", deviceId: String? = nil, deviceName: String = "",
+         startDate: String = "", endDate: String = "", status: String = "",
+         renterName: String? = nil, renterPhone: String? = nil, notes: String? = nil,
+         canDecide: Bool = false, canCancel: Bool = false) {
+        self.id = id; self.deviceId = deviceId; self.deviceName = deviceName
+        self.startDate = startDate; self.endDate = endDate; self.status = status
+        self.renterName = renterName; self.renterPhone = renterPhone; self.notes = notes
+        self.canDecide = canDecide; self.canCancel = canCancel
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = c.wert(.id, "")
+        deviceId = c.wertOptional(.deviceId)
+        deviceName = c.wert(.deviceName, "")
+        startDate = c.wert(.startDate, "")
+        endDate = c.wert(.endDate, "")
+        status = c.wert(.status, "")
+        renterName = c.wertOptional(.renterName)
+        renterPhone = c.wertOptional(.renterPhone)
+        notes = c.wertOptional(.notes)
+        canDecide = c.wert(.canDecide, false)
+        canCancel = c.wert(.canCancel, false)
+    }
+}
+
+nonisolated struct RentalOwnerBookingsDto: Codable, Sendable {
+    var bookings: [RentalOwnerBookingDto] = []
+
+    enum CodingKeys: String, CodingKey { case bookings }
+
+    init(bookings: [RentalOwnerBookingDto] = []) { self.bookings = bookings }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        bookings = c.wert(.bookings, [])
+    }
+}
+
+/// Routes 17 and 18: a stretch the lender keeps for themselves. To everybody
+/// else it looks like any other taken period — no reason, no name.
+nonisolated struct RentalBlockDto: Codable, Hashable, Sendable {
+    var id: String = ""
+    var deviceId: String = ""
+    var deviceName: String = ""
+    var startDate: String = ""
+    var endDate: String = ""
+    var reason: String?
+
+    enum CodingKeys: String, CodingKey { case id, deviceId, deviceName, startDate, endDate, reason }
+
+    init(id: String = "", deviceId: String = "", deviceName: String = "",
+         startDate: String = "", endDate: String = "", reason: String? = nil) {
+        self.id = id; self.deviceId = deviceId; self.deviceName = deviceName
+        self.startDate = startDate; self.endDate = endDate; self.reason = reason
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = c.wert(.id, "")
+        deviceId = c.wert(.deviceId, "")
+        deviceName = c.wert(.deviceName, "")
+        startDate = c.wert(.startDate, "")
+        endDate = c.wert(.endDate, "")
+        reason = c.wertOptional(.reason)
+    }
+}
+
+nonisolated struct RentalBlocksDto: Codable, Sendable {
+    var blocks: [RentalBlockDto] = []
+
+    enum CodingKeys: String, CodingKey { case blocks }
+
+    init(blocks: [RentalBlockDto] = []) { self.blocks = blocks }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        blocks = c.wert(.blocks, [])
+    }
+}
+
+nonisolated struct RentalBlockEnvelopeDto: Codable, Sendable {
+    var block: RentalBlockDto = RentalBlockDto()
+
+    enum CodingKeys: String, CodingKey { case block }
+
+    init(block: RentalBlockDto = RentalBlockDto()) { self.block = block }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        block = c.wert(.block, RentalBlockDto())
+    }
+}
+
+/// Route 18. Sets cannot be blocked, only single devices.
+nonisolated struct RentalBlockRequestDto: Encodable, Sendable {
+    var deviceId: String
+    var startDate: String
+    var endDate: String
+    var reason: String?
+
+    enum CodingKeys: String, CodingKey { case deviceId, startDate, endDate, reason }
+}
+
+// MARK: - Errors
+
+/// Every refusal of the platform has this shape.
+///
+/// `code` is stable and machine-readable, `message` is German and may be
+/// shown. **The app branches on `code`, never on `message`**
+/// (`docs/mieten-api.md`, „Fehler").
+nonisolated struct RentalErrorDto: Decodable, Sendable {
+    var code: String = ""
+    var message: String = ""
+    /// Only with `profile_incomplete`: which fields the platform is missing.
+    var missingFields: [String] = []
+
+    enum Hull: String, CodingKey { case error }
+    enum CodingKeys: String, CodingKey { case code, message, missingFields }
+
+    init(code: String = "", message: String = "", missingFields: [String] = []) {
+        self.code = code; self.message = message; self.missingFields = missingFields
+    }
+
+    init(from decoder: Decoder) throws {
+        let hull = try decoder.container(keyedBy: Hull.self)
+        let c = try hull.nestedContainer(keyedBy: CodingKeys.self, forKey: .error)
+        code = c.wert(.code, "")
+        message = c.wert(.message, "")
+        // The document puts `missingFields` next to `code` and `message`
+        // inside `error`; reading it defensively costs nothing.
+        missingFields = c.wert(.missingFields, [])
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalDeviceModel.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalDeviceModel.swift
@@ -1,0 +1,184 @@
+import Combine
+import Foundation
+
+/// One device, its taken periods, and the way to book it.
+///
+/// The important part of this model is what it does **not** do: it never
+/// decides whether a stretch of days can be booked. It asks the platform
+/// (route 5) and shows the answer; the button follows it. Whoever puts that
+/// condition into the app has it twice, and web and app start disagreeing
+/// exactly where it hurts (`docs/mieten-api.md`, „Was die App nicht
+/// entscheidet").
+///
+/// The second thing it watches: an answer belongs to the stretch of days it
+/// was given for. Changing a date drops it. Otherwise somebody asks for the
+/// free weekend, moves the dates onto a taken one and books it on the
+/// strength of a „yes" that was about something else.
+///
+/// The dates on screen are the days somebody **has** the thing — first and
+/// last. The platform wants the day it comes back, which is one day later
+/// (`docs/mieten-api.md`, „Zeiträume"). That conversion happens here, in one
+/// place, and nowhere else.
+final class RentalDeviceModel: ObservableObject {
+    /// What the list already knew — shown immediately, so the page is never
+    /// blank while the detail is being fetched.
+    @Published private(set) var device: RentalDevice
+    @Published private(set) var occupied: [RentalPeriod] = []
+    @Published private(set) var loading = false
+
+    /// First and last day of the loan, as a person picks them.
+    @Published private(set) var firstDay: Date
+    @Published private(set) var lastDay: Date
+    @Published var notes = ""
+
+    /// The platform's answer for exactly the stretch above — `nil` as soon as
+    /// a date moves.
+    @Published private(set) var availability: RentalAvailability?
+    @Published private(set) var checking = false
+    @Published private(set) var booking = false
+    @Published private(set) var trouble: RentalTrouble?
+    /// The booking that just went through. Stays on screen until the page is
+    /// left — it carries what happens next.
+    @Published private(set) var confirmed: RentalBooking?
+    /// The platform is missing something in the profile before it takes a
+    /// booking. Its list, in German — the screen leads on to the profile.
+    @Published private(set) var missingProfileFields: [String] = []
+
+    private let source: RentalSource
+    private let now: () -> Date
+
+    init(device: RentalDevice, source: RentalSource, now: @escaping () -> Date = Date.init) {
+        self.device = device
+        self.source = source
+        self.now = now
+        let today = RentalDay.calendar().startOfDay(for: now())
+        firstDay = today
+        lastDay = today
+    }
+
+    /// What goes out as `startDate`.
+    var startDate: String { RentalDay.api(firstDay) }
+    /// What goes out as `endDate` — the return day, one after the last day of
+    /// the loan.
+    var endDate: String { RentalDay.api(RentalDay.nextDay(lastDay)) }
+
+    /// Whether the booking button is live. Everything in here comes from the
+    /// platform except „a request is already on its way".
+    var canBook: Bool {
+        guard let answer = availability, !booking, confirmed == nil else { return false }
+        // An answer only counts for the stretch it was given for.
+        return answer.free && answer.startDate == startDate && answer.endDate == endDate
+    }
+
+    /// Whether the answer on screen still belongs to the dates on screen.
+    var answer: RentalAvailability? {
+        guard let availability,
+              availability.startDate == startDate, availability.endDate == endDate
+        else { return nil }
+        return availability
+    }
+
+    func setFirstDay(_ day: Date) {
+        firstDay = RentalDay.calendar().startOfDay(for: day)
+        if lastDay < firstDay { lastDay = firstDay }
+        availability = nil
+    }
+
+    func setLastDay(_ day: Date) {
+        lastDay = RentalDay.calendar().startOfDay(for: day)
+        if lastDay < firstDay { firstDay = lastDay }
+        availability = nil
+    }
+
+    /// Details and taken periods. Called once when the page opens.
+    func load() async {
+        if loading { return }
+        loading = true
+        defer { loading = false }
+        do {
+            let detail = try await source.item(device.id)
+            if let refreshed = detail.asDevice() { device = refreshed }
+            trouble = nil
+        } catch {
+            // The device from the list is still on screen — a note above it
+            // beats an empty page.
+            trouble = RentalTrouble(error)
+        }
+        do {
+            // Route 6 with a device also carries the lender's own blocks, and
+            // it needs no sign-in.
+            occupied = try await source.occupancy(device.id).occupied(
+                deviceId: device.id, now: now()
+            )
+        } catch {
+            if trouble == nil { trouble = RentalTrouble(error) }
+        }
+    }
+
+    /// „Ist es frei?" — asked of the platform, always.
+    func check() async {
+        if checking { return }
+        checking = true
+        defer { checking = false }
+        let wantedStart = startDate
+        let wantedEnd = endDate
+        do {
+            let answer = try await source.availability(device.id, wantedStart, wantedEnd)
+            availability = answer.asAvailability(startDate: wantedStart, endDate: wantedEnd)
+            trouble = nil
+        } catch {
+            availability = nil
+            trouble = RentalTrouble(error)
+        }
+    }
+
+    /// Books the stretch the platform just said yes to.
+    ///
+    /// Name and telephone are deliberately **not** sent: the platform takes
+    /// them from the profile, so nobody types their own name again. Only if
+    /// they are missing there too does it refuse — and then the screen leads
+    /// to the profile instead of guessing.
+    func book() async {
+        guard canBook else { return }
+        booking = true
+        defer { booking = false }
+        missingProfileFields = []
+        do {
+            let created = try await source.book(RentalBookingRequestDto(
+                deviceId: device.id,
+                startDate: startDate,
+                endDate: endDate,
+                notes: notes.trimmingCharacters(in: .whitespacesAndNewlines).rentalNonEmpty
+            ))
+            confirmed = created.asBooking()
+            availability = nil
+            trouble = nil
+        } catch {
+            let bad = RentalTrouble(error)
+            trouble = bad
+            if bad.code == .profileIncomplete {
+                missingProfileFields = RentalFieldNames.labels(bad.missingFields)
+            }
+            if bad.code == .occupied {
+                // Between drawing the calendar and tapping, a minute can pass
+                // and somebody else can be quicker. That is a normal race, not
+                // a crash: the answer is dropped and the calendar refetched.
+                availability = nil
+                await reloadOccupancy()
+            }
+        }
+    }
+
+    /// After a fresh sign-in, or after the profile was completed: forget the
+    /// refusal so the page is usable again.
+    func clearTrouble() {
+        trouble = nil
+        missingProfileFields = []
+    }
+
+    private func reloadOccupancy() async {
+        if let periods = try? await source.occupancy(device.id) {
+            occupied = periods.occupied(deviceId: device.id, now: now())
+        }
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalDeviceView.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalDeviceView.swift
@@ -1,0 +1,274 @@
+import SwiftUI
+
+/// One device: what it is, what it costs, when it is taken — and the way to
+/// book it.
+///
+/// The whole page is built around one sentence: the platform decides. „Ist es
+/// frei?" is a question asked over the wire, and the booking button only wakes
+/// up once the answer says so, for exactly the days on screen.
+struct RentalDeviceView: View {
+    @EnvironmentObject private var umgebung: AppUmgebung
+    let device: RentalDevice
+    @State private var model: RentalDeviceModel?
+
+    var body: some View {
+        Group {
+            if let model {
+                RentalDeviceDetail(model: model)
+            } else {
+                ProgressView().controlSize(.large)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle(device.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            let existing = model ?? RentalDeviceModel(
+                device: device, source: .from(umgebung.rental)
+            )
+            model = existing
+            await existing.load()
+        }
+    }
+}
+
+struct RentalDeviceDetail: View {
+    @EnvironmentObject private var umgebung: AppUmgebung
+    @ObservedObject var model: RentalDeviceModel
+
+    private var signedIn: Bool {
+        if case .angemeldet = umgebung.anmeldung.sitzung { return true }
+        return false
+    }
+
+    var body: some View {
+        List {
+            if let trouble = model.trouble, !trouble.wantsSignIn {
+                Section {
+                    RentalNotice(text: trouble.message) { Task { await model.load() } }
+                }
+            }
+
+            pictureSection
+            factsSection
+            occupiedSection
+            bookingSection
+            linkSection
+        }
+        .accessibilityIdentifier("rental-device")
+    }
+
+    // MARK: Picture and text
+
+    @ViewBuilder private var pictureSection: some View {
+        if !model.device.images.isEmpty {
+            Section {
+                // More than one picture: a strip one can push sideways.
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(model.device.images, id: \.self) { url in
+                            AsyncImage(url: url) { phase in
+                                switch phase {
+                                case .success(let picture):
+                                    picture.resizable().scaledToFill()
+                                case .failure:
+                                    Color.accentColor.opacity(0.10)
+                                default:
+                                    ProgressView()
+                                }
+                            }
+                            .frame(width: 260, height: 195)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 0))
+                .accessibilityHidden(true)
+            }
+        }
+    }
+
+    private var factsSection: some View {
+        Section {
+            if !model.device.blocks.isEmpty {
+                RentalMarkdownText(blocks: model.device.blocks)
+            }
+
+            // Every tariff the platform has, one line each. Deliberately no
+            // sum: which tariff applies to which duration is nowhere written
+            // down, and an invented rule here would be exactly the split
+            // between web and app we avoid.
+            ForEach(model.device.tariffs, id: \.self) { tariff in
+                RentalFact(symbol: "eurosign.circle", text: tariff)
+            }
+            if let deposit = model.device.depositText {
+                RentalFact(symbol: "lock.circle", text: deposit)
+            }
+            if !model.device.tags.isEmpty {
+                RentalFact(symbol: "tag", text: model.device.tags.joined(separator: ", "))
+            }
+        } footer: {
+            if model.device.tariffs.count > 1 {
+                Text("Welcher Tarif für deinen Zeitraum gilt, sagt dir der "
+                    + "Maschinchenring — die App rechnet das nicht aus.")
+            }
+        }
+    }
+
+    @ViewBuilder private var occupiedSection: some View {
+        Section {
+            if model.loading && model.occupied.isEmpty {
+                HStack(spacing: 10) {
+                    ProgressView()
+                    Text("Belegung wird geholt …").foregroundStyle(.secondary)
+                }
+            } else if model.occupied.isEmpty {
+                Text("Für die nächsten Wochen ist nichts eingetragen.")
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("rental-nothing-occupied")
+            } else {
+                ForEach(model.occupied) { period in
+                    HStack(alignment: .firstTextBaseline) {
+                        Label(period.text, systemImage: "calendar")
+                            .font(.subheadline)
+                        Spacer()
+                        Text(period.kind.label)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityIdentifier("rental-occupied-\(period.id)")
+                }
+            }
+        } header: {
+            Text("Schon vergeben")
+        } footer: {
+            Text("Angefragt, vergeben oder gesperrt — belegt ist belegt.")
+        }
+    }
+
+    // MARK: Booking
+
+    @ViewBuilder private var bookingSection: some View {
+        if let booking = model.confirmed {
+            Section("Geschafft") {
+                RentalBookingRow(booking: booking)
+                Text("Die Entscheidung trifft, wem das Gerät gehört. "
+                    + "Unter \u{201E}Meine Buchungen\u{201C} siehst du, wie es weitergeht.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityIdentifier("rental-booked")
+        } else {
+            Section {
+                DatePicker(
+                    "Von",
+                    selection: Binding(get: { model.firstDay }, set: { model.setFirstDay($0) }),
+                    displayedComponents: .date
+                )
+                .accessibilityIdentifier("rental-first-day")
+
+                DatePicker(
+                    "Bis einschließlich",
+                    selection: Binding(get: { model.lastDay }, set: { model.setLastDay($0) }),
+                    in: model.firstDay...,
+                    displayedComponents: .date
+                )
+                .accessibilityIdentifier("rental-last-day")
+
+                Button {
+                    Task { await model.check() }
+                } label: {
+                    HStack {
+                        if model.checking { ProgressView().controlSize(.small) }
+                        Text(model.checking ? "Wird geprüft …" : "Ist es frei?")
+                    }
+                }
+                .disabled(model.checking)
+                .accessibilityIdentifier("rental-check")
+
+                if let answer = model.answer {
+                    Label(answer.message, systemImage: answer.free
+                        ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .font(.subheadline)
+                        .foregroundStyle(answer.free ? Color.green : Color.secondary)
+                        .accessibilityIdentifier("rental-answer")
+                }
+
+                TextField("Notiz für den Verleiher (freiwillig)", text: $model.notes, axis: .vertical)
+                    .lineLimit(1 ... 3)
+                    .accessibilityIdentifier("rental-notes")
+
+                bookingButton
+            } header: {
+                Text("Wann brauchst du es?")
+            } footer: {
+                Text("Der Tag der Rückgabe ist der Tag nach dem letzten Leihtag — "
+                    + "dann kann schon jemand anders anfangen. Ob der Zeitraum frei "
+                    + "ist, sagt der Maschinchenring; gebucht ist erst, wenn der "
+                    + "Verleiher zugestimmt hat.")
+            }
+        }
+    }
+
+    @ViewBuilder private var bookingButton: some View {
+        if !signedIn {
+            // No door in front of the catalogue, but there is one here: a
+            // booking belongs to a person.
+            RentalSignInNotice(trouble: RentalTrouble(RentalError.signInRequired)) {
+                model.clearTrouble()
+            }
+        } else if let trouble = model.trouble, trouble.wantsSignIn {
+            RentalSignInNotice(trouble: trouble) {
+                model.clearTrouble()
+            }
+        } else {
+            if !model.missingProfileFields.isEmpty {
+                // The platform is missing something before it takes a
+                // booking — its list, and the way to fill it in.
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Dem Maschinchenring fehlt noch: "
+                        + model.missingProfileFields.joined(separator: ", ") + ".")
+                        .font(.footnote)
+                    NavigationLink("Profil ausfüllen") {
+                        RentalProfileView()
+                    }
+                    .accessibilityIdentifier("rental-complete-profile")
+                }
+                .accessibilityIdentifier("rental-profile-incomplete")
+            }
+
+            Button {
+                Task { await model.book() }
+            } label: {
+                HStack {
+                    if model.booking { ProgressView().controlSize(.small) }
+                    Text(model.booking ? "Wird angefragt …" : "Verbindlich anfragen")
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!model.canBook)
+            .accessibilityIdentifier("rental-book")
+        }
+    }
+
+    @ViewBuilder private var linkSection: some View {
+        if model.device.webURL != nil || model.device.productURL != nil {
+            Section {
+                if let web = model.device.webURL {
+                    Link(destination: web) {
+                        Label("Im Maschinchenring öffnen", systemImage: "safari")
+                    }
+                    .accessibilityIdentifier("rental-web-link")
+                }
+                if let product = model.device.productURL {
+                    Link(destination: product) {
+                        Label("Seite des Herstellers", systemImage: "link")
+                    }
+                    .accessibilityIdentifier("rental-product-link")
+                }
+            }
+        }
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalOwnerModel.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalOwnerModel.swift
@@ -1,0 +1,150 @@
+import Combine
+import Foundation
+
+/// The lender's side: who asked for my devices, which devices are mine, and
+/// which stretches I keep for myself.
+///
+/// It only exists for somebody the platform has approved (`lenderStatus ==
+/// "approved"`); the app does not work that out, it reads it from route 7.
+/// Everything else is the same habit as in the rest of the area: `canDecide`
+/// and `canCancel` come over the wire, the buttons follow them, and a failed
+/// call never quietly removes a row.
+///
+/// **Adding or changing devices is not here, and not anywhere in the app.**
+/// That happens in the chat and the web version of the platform, and it stays
+/// there (`docs/mieten-api.md`, route 16). The screen says so and offers the
+/// way over.
+final class RentalOwnerModel: ObservableObject {
+    @Published private(set) var bookings: [RentalOwnerBooking] = []
+    @Published private(set) var devices: [RentalDevice] = []
+    @Published private(set) var blocks: [RentalBlock] = []
+    @Published private(set) var loading = false
+    @Published private(set) var trouble: RentalTrouble?
+    /// Which booking is being decided right now.
+    @Published private(set) var deciding: Set<String> = []
+    @Published private(set) var blocking = false
+
+    private var fetched = false
+    private let source: RentalSource
+    private let now: () -> Date
+
+    init(source: RentalSource, now: @escaping () -> Date = Date.init) {
+        self.source = source
+        self.now = now
+    }
+
+    var needsSignIn: Bool { trouble?.wantsSignIn == true }
+
+    var hint: String? {
+        guard let trouble else { return nil }
+        if bookings.isEmpty && devices.isEmpty { return trouble.message }
+        return "Gerade keine Verbindung zum Maschinchenring — die Listen sind "
+            + "möglicherweise nicht mehr aktuell."
+    }
+
+    /// Nothing to decide, nothing lent out — an ordinary state, not an error.
+    var empty: Bool { bookings.isEmpty && devices.isEmpty && !loading && trouble == nil }
+
+    /// How many requests wait for a yes or a no. The number the screen is
+    /// opened for.
+    var waiting: Int { bookings.filter(\.canDecide).count }
+
+    func load() async {
+        if fetched { return }
+        await fetch()
+    }
+
+    func refresh() async {
+        await fetch()
+    }
+
+    private func fetch() async {
+        if loading { return }
+        loading = true
+        defer { loading = false }
+        do {
+            bookings = try await source.ownerBookings().asOwnerBookings(now: now())
+            devices = try await source.ownerItems().asDevices()
+            blocks = try await source.blocks().asBlocks(now: now())
+            fetched = true
+            trouble = nil
+        } catch {
+            trouble = RentalTrouble(error)
+        }
+    }
+
+    /// Confirms a booking. From then on the person who asked sees the pickup
+    /// address — that is why this is a decision and not a toggle.
+    func approve(_ booking: RentalOwnerBooking) async {
+        await decide(booking) { try await self.source.approve(booking.id) }
+    }
+
+    /// Turns a booking down. No reason is recorded; the platform sends the
+    /// cancellation e-mail.
+    func reject(_ booking: RentalOwnerBooking) async {
+        await decide(booking) { try await self.source.reject(booking.id) }
+    }
+
+    /// Withdraws a booking on one's own device — allowed for both sides while
+    /// it is `pending` or `approved`.
+    func cancel(_ booking: RentalOwnerBooking) async {
+        await decide(booking) { try await self.source.cancel(booking.id) }
+    }
+
+    private func decide(_ booking: RentalOwnerBooking,
+                        _ step: @MainActor () async throws -> Void) async {
+        if deciding.contains(booking.id) { return }
+        deciding.insert(booking.id)
+        defer { deciding.remove(booking.id) }
+        do {
+            try await step()
+            trouble = nil
+            // The platform's list is the truth about what just happened.
+            bookings = try await source.ownerBookings().asOwnerBookings(now: now())
+        } catch {
+            trouble = RentalTrouble(error)
+        }
+    }
+
+    /// Blocks a stretch on one's own device. An existing booking is never
+    /// pushed aside — the platform answers `occupied`, and whoever wants the
+    /// days anyway cancels the booking first.
+    ///
+    /// `lastDay` is the last day the device is needed; the platform wants the
+    /// day after, like everywhere in this area.
+    @discardableResult
+    func block(deviceId: String, firstDay: Date, lastDay: Date, reason: String) async -> Bool {
+        if blocking { return false }
+        blocking = true
+        defer { blocking = false }
+        do {
+            _ = try await source.addBlock(RentalBlockRequestDto(
+                deviceId: deviceId,
+                startDate: RentalDay.api(firstDay),
+                endDate: RentalDay.api(RentalDay.nextDay(lastDay)),
+                reason: reason.rentalNonEmpty
+            ))
+            blocks = try await source.blocks().asBlocks(now: now())
+            trouble = nil
+            return true
+        } catch {
+            trouble = RentalTrouble(error)
+            return false
+        }
+    }
+
+    /// Lifts one of one's own blocks.
+    func removeBlock(_ block: RentalBlock) async {
+        do {
+            try await source.removeBlock(block.id)
+            blocks = try await source.blocks().asBlocks(now: now())
+            trouble = nil
+        } catch {
+            trouble = RentalTrouble(error)
+        }
+    }
+
+    func clearTrouble() {
+        trouble = nil
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalOwnerView.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalOwnerView.swift
@@ -1,0 +1,273 @@
+import SwiftUI
+
+/// „Meine Vermietung" — who is asking for my devices, which devices are mine,
+/// and which stretches I keep for myself.
+///
+/// Reachable only from the profile, and only when the platform has approved
+/// somebody as a lender. Adding or changing a device is **not** here: that
+/// happens in the chat and the web version of the Maschinchenring, and it
+/// stays there.
+struct RentalOwnerView: View {
+    @EnvironmentObject private var umgebung: AppUmgebung
+    @State private var model: RentalOwnerModel?
+
+    var body: some View {
+        Group {
+            if let model {
+                RentalOwnerList(model: model)
+            } else {
+                ProgressView().controlSize(.large)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle("Meine Vermietung")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            let existing = model ?? RentalOwnerModel(source: .from(umgebung.rental))
+            model = existing
+            await existing.load()
+        }
+    }
+}
+
+struct RentalOwnerList: View {
+    @ObservedObject var model: RentalOwnerModel
+    /// The device a new block is being drawn for.
+    @State private var blockingDevice: RentalDevice?
+
+    var body: some View {
+        List {
+            if let trouble = model.trouble, trouble.wantsSignIn {
+                Section {
+                    RentalSignInNotice(trouble: trouble) {
+                        model.clearTrouble()
+                        await model.refresh()
+                    }
+                }
+            } else if let hint = model.hint {
+                Section {
+                    RentalNotice(text: hint) { Task { await model.refresh() } }
+                }
+            }
+
+            bookingsSection
+            devicesSection
+            blocksSection
+        }
+        .accessibilityIdentifier("rental-owner")
+        .refreshable { await model.refresh() }
+        .sheet(item: $blockingDevice) { device in
+            RentalBlockSheet(model: model, device: device)
+        }
+    }
+
+    private var bookingsSection: some View {
+        Section {
+            if model.loading && model.bookings.isEmpty {
+                HStack(spacing: 10) {
+                    ProgressView()
+                    Text("Anfragen werden geholt …").foregroundStyle(.secondary)
+                }
+            }
+
+            ForEach(model.bookings) { booking in
+                RentalOwnerBookingRow(model: model, booking: booking)
+            }
+
+            if model.bookings.isEmpty && !model.loading {
+                Text("Für deine Geräte liegt gerade nichts vor.")
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("rental-owner-no-bookings")
+            }
+        } header: {
+            Text(model.waiting > 0 ? "Anfragen (\(model.waiting) offen)" : "Anfragen")
+        } footer: {
+            Text("Sobald du zusagst, bekommt der Mieter deine Abholadresse per "
+                + "E-Mail — vorher nicht.")
+        }
+    }
+
+    private var devicesSection: some View {
+        Section {
+            ForEach(model.devices) { device in
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(device.name).font(.subheadline.weight(.medium))
+                        if device.active == false {
+                            Text("Abgeschaltet — für andere unsichtbar.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    Spacer()
+                    Button("Sperren") { blockingDevice = device }
+                        .buttonStyle(.borderless)
+                        .accessibilityIdentifier("rental-block-\(device.id)")
+                }
+                .accessibilityIdentifier("rental-owner-device-\(device.id)")
+            }
+
+            if model.devices.isEmpty && !model.loading {
+                Text("Du hast noch kein Gerät eingestellt.")
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("rental-owner-no-devices")
+            }
+        } header: {
+            Text("Meine Geräte")
+        } footer: {
+            Text("Geräte anlegen und ändern geht im Maschinchenring selbst — "
+                + "in der App bewusst nicht.")
+        }
+    }
+
+    @ViewBuilder private var blocksSection: some View {
+        Section("Meine Sperren") {
+            ForEach(model.blocks) { block in
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(block.deviceName).font(.subheadline.weight(.medium))
+                    Label(block.periodText, systemImage: "calendar")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    if let reason = block.reason {
+                        Text(reason).font(.footnote).foregroundStyle(.secondary)
+                    }
+                    Button(role: .destructive) {
+                        Task { await model.removeBlock(block) }
+                    } label: {
+                        Text("Sperre aufheben")
+                    }
+                    .buttonStyle(.borderless)
+                    .accessibilityIdentifier("rental-unblock-\(block.id)")
+                }
+                .padding(.vertical, 2)
+            }
+
+            if model.blocks.isEmpty && !model.loading {
+                Text("Keine Sperre eingetragen.")
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("rental-owner-no-blocks")
+            }
+        }
+    }
+}
+
+/// One request on one of my devices — with the two decisions the platform
+/// says are possible right now.
+struct RentalOwnerBookingRow: View {
+    @ObservedObject var model: RentalOwnerModel
+    let booking: RentalOwnerBooking
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(booking.deviceName).font(.headline)
+            Label(booking.periodText, systemImage: "calendar")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            if let back = booking.returnText {
+                Text(back).font(.footnote).foregroundStyle(.secondary)
+            }
+            Label(booking.statusLabel, systemImage: booking.state.symbol)
+                .font(.subheadline.weight(.medium))
+
+            // Name and telephone are here so the handover can be arranged,
+            // and they appear nowhere else in the app.
+            if let name = booking.renterName {
+                Label(name, systemImage: "person").font(.footnote)
+            }
+            if let phone = booking.renterPhone {
+                Label(phone, systemImage: "phone").font(.footnote)
+            }
+            if let note = booking.notes {
+                Text(note).font(.footnote).foregroundStyle(.secondary)
+            }
+
+            // The buttons follow `canDecide` and `canCancel`. Whether a
+            // decision is still open is the platform's answer.
+            HStack(spacing: 16) {
+                if model.deciding.contains(booking.id) {
+                    ProgressView().controlSize(.small)
+                }
+                if booking.canDecide {
+                    Button("Zusagen") { Task { await model.approve(booking) } }
+                        .buttonStyle(.borderless)
+                        .accessibilityIdentifier("rental-approve-\(booking.id)")
+                    Button("Absagen", role: .destructive) {
+                        Task { await model.reject(booking) }
+                    }
+                    .buttonStyle(.borderless)
+                    .accessibilityIdentifier("rental-reject-\(booking.id)")
+                } else if booking.canCancel {
+                    Button("Stornieren", role: .destructive) {
+                        Task { await model.cancel(booking) }
+                    }
+                    .buttonStyle(.borderless)
+                    .accessibilityIdentifier("rental-owner-cancel-\(booking.id)")
+                }
+            }
+            .disabled(model.deciding.contains(booking.id))
+        }
+        .padding(.vertical, 2)
+        .accessibilityIdentifier("rental-owner-booking-\(booking.id)")
+    }
+}
+
+/// „Zeitraum sperren" — the lender keeps a stretch for themselves.
+struct RentalBlockSheet: View {
+    @ObservedObject var model: RentalOwnerModel
+    let device: RentalDevice
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var firstDay = Date()
+    @State private var lastDay = Date()
+    @State private var reason = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    DatePicker("Von", selection: $firstDay, displayedComponents: .date)
+                        .accessibilityIdentifier("rental-block-first-day")
+                    DatePicker("Bis einschließlich", selection: $lastDay,
+                               in: firstDay..., displayedComponents: .date)
+                        .accessibilityIdentifier("rental-block-last-day")
+                    TextField("Grund (freiwillig)", text: $reason)
+                        .accessibilityIdentifier("rental-block-reason")
+                } header: {
+                    Text(device.name)
+                } footer: {
+                    Text("Für andere sieht die Sperre aus wie jeder belegte "
+                        + "Zeitraum — ohne Grund und ohne Namen. Eine bestehende "
+                        + "Buchung verdrängt sie nicht.")
+                }
+
+                if let trouble = model.trouble {
+                    Section {
+                        Text(trouble.message)
+                            .font(.footnote)
+                            .accessibilityIdentifier("rental-block-trouble")
+                    }
+                }
+            }
+            .navigationTitle("Zeitraum sperren")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Abbrechen") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Sperren") {
+                        Task {
+                            let done = await model.block(
+                                deviceId: device.id, firstDay: firstDay,
+                                lastDay: lastDay, reason: reason
+                            )
+                            if done { dismiss() }
+                        }
+                    }
+                    .disabled(model.blocking)
+                    .accessibilityIdentifier("rental-block-save")
+                }
+            }
+        }
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalPresentation.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalPresentation.swift
@@ -1,0 +1,444 @@
+import Foundation
+
+/// Turning the platform's payloads into what the screens show.
+///
+/// Deliberately plain preparation — no network, no SwiftUI. It runs in an
+/// ordinary unit test, which is where the tricky parts belong: days that
+/// arrive as bare dates in a half-open range, tariffs that must not be added
+/// up, and a description written in Markdown.
+///
+/// What is **not** here: any decision. Whether a stretch of days is free,
+/// whether a booking may be withdrawn, who may confirm — all of that arrives
+/// as a flag and is only passed through.
+
+// MARK: - Days
+
+/// Everything that turns the platform's `2026-09-04` into a date and back.
+///
+/// The platform speaks in whole days, not in instants. Reading such a day as
+/// UTC would move it by an hour twice a year, so it is read in the village's
+/// own time zone — the same habit as in the events area.
+///
+/// **The half-open range** (`docs/mieten-api.md`, „Zeiträume") lives here and
+/// nowhere else: `startDate` belongs to a period, `endDate` does not — it is
+/// the day the thing comes back. A booking from the 5th to the 7th occupies
+/// the 5th and the 6th. That is a fact about the calendar, not a rule about
+/// renting: the app needs it to draw and to label, and it still asks the
+/// platform whether anything may be booked.
+nonisolated enum RentalDay {
+    /// The village's own time zone. Spelled out rather than borrowed from
+    /// `Zeitpunkt`: that one belongs to the main actor, and this preparation
+    /// deliberately runs anywhere.
+    static let villageZone = TimeZone(identifier: "Europe/Berlin") ?? .current
+
+    /// Short weekdays, wired down so device and test agree no matter which
+    /// language the phone is set to.
+    static let weekdays = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
+
+    static func calendar(_ zone: TimeZone = villageZone) -> Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = zone
+        c.locale = Locale(identifier: "de_DE")
+        return c
+    }
+
+    /// Reads `2026-09-04` as midnight in the village. Anything unreadable is
+    /// `nil` — one broken entry must not cost the whole list.
+    static func parse(_ text: String, zone: TimeZone = villageZone) -> Date? {
+        let raw = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if raw.isEmpty { return nil }
+        let f = ISO8601DateFormatter()
+        f.timeZone = zone
+        f.formatOptions = [.withFullDate]
+        return f.date(from: raw)
+    }
+
+    /// Back into the platform's spelling — this is what goes out in a query
+    /// or a booking wish.
+    static func api(_ day: Date, zone: TimeZone = villageZone) -> String {
+        let t = calendar(zone).dateComponents([.year, .month, .day], from: day)
+        return String(format: "%04d-%02d-%02d", t.year ?? 0, t.month ?? 0, t.day ?? 0)
+    }
+
+    /// The day after — the app picks the last day somebody wants the thing,
+    /// the platform wants the day it comes back.
+    static func nextDay(_ day: Date, zone: TimeZone = villageZone) -> Date {
+        calendar(zone).date(byAdding: .day, value: 1, to: day) ?? day
+    }
+
+    static func previousDay(_ day: Date, zone: TimeZone = villageZone) -> Date {
+        calendar(zone).date(byAdding: .day, value: -1, to: day) ?? day
+    }
+
+    /// „04.09.2026"
+    static func short(_ day: Date, zone: TimeZone = villageZone) -> String {
+        let t = calendar(zone).dateComponents([.year, .month, .day], from: day)
+        return String(format: "%02d.%02d.%04d", t.day ?? 0, t.month ?? 0, t.year ?? 0)
+    }
+
+    /// „Fr, 04.09.2026"
+    static func withWeekday(_ day: Date, zone: TimeZone = villageZone) -> String {
+        let t = calendar(zone).dateComponents([.weekday], from: day)
+        // `weekday` counts from Sunday = 1; our list starts on Monday.
+        let name = weekdays[(((t.weekday ?? 1) - 2) + 7) % 7]
+        return "\(name), \(short(day, zone: zone))"
+    }
+
+    /// The days a half-open period actually occupies, as a sentence:
+    /// „Fr, 04.09.2026 – Sa, 05.09.2026", and a single day as just itself.
+    ///
+    /// Unreadable ends fall back to whatever the platform sent, so a person
+    /// still sees something rather than a gap.
+    static func occupiedText(startDate: String, endDate: String,
+                             zone: TimeZone = villageZone) -> String {
+        guard let start = parse(startDate, zone: zone) else {
+            return [startDate, endDate].joined(separator: " – ")
+        }
+        guard let end = parse(endDate, zone: zone) else { return withWeekday(start, zone: zone) }
+        let last = previousDay(end, zone: zone)
+        if last <= start { return withWeekday(start, zone: zone) }
+        return withWeekday(start, zone: zone) + " – " + withWeekday(last, zone: zone)
+    }
+
+    /// „Rückgabe: So, 06.09.2026" — the other half of the same fact, spelled
+    /// out rather than left to be worked out from the line above.
+    static func returnText(endDate: String, zone: TimeZone = villageZone) -> String? {
+        guard let end = parse(endDate, zone: zone) else { return nil }
+        return "Rückgabe: " + withWeekday(end, zone: zone)
+    }
+}
+
+/// Money the way it is written in Germany: „25,00 €".
+///
+/// Built from a decimal number plus the sign rather than from
+/// `numberStyle = .currency`: that one's spacing has moved between ICU
+/// versions before, and a price is a thing two people compare across two
+/// phones. The space in front of the sign is a non-breaking one, so „25,00"
+/// and „€" never end up on two lines.
+nonisolated enum RentalMoney {
+    static let euroSign = "\u{00A0}€"
+
+    static func euro(_ amount: Double) -> String {
+        let f = NumberFormatter()
+        f.locale = Locale(identifier: "de_DE")
+        f.numberStyle = .decimal
+        f.minimumFractionDigits = 2
+        f.maximumFractionDigits = 2
+        let number = f.string(from: NSNumber(value: amount))
+            ?? String(format: "%.2f", amount).replacingOccurrences(of: ".", with: ",")
+        return number + euroSign
+    }
+}
+
+// MARK: - Markdown
+
+/// One piece of a device description.
+///
+/// The platform writes descriptions in Markdown (`docs/mieten-api.md`, route
+/// 1). Showing them raw, with asterisks and dashes, is not an option, and
+/// neither is a Markdown library — the app carries none but MapLibre. So the
+/// blocks are cut here and the inline part (`**fett**`, links) is left to
+/// `AttributedString`, which the standard library brings along.
+nonisolated enum RentalTextBlock: Identifiable, Hashable, Sendable {
+    case heading(level: Int, text: AttributedString)
+    case paragraph(AttributedString)
+    case bullet(AttributedString)
+
+    var id: String {
+        switch self {
+        case .heading(let level, let text): return "h\(level)-\(String(text.characters))"
+        case .paragraph(let text): return "p-\(String(text.characters))"
+        case .bullet(let text): return "l-\(String(text.characters))"
+        }
+    }
+}
+
+nonisolated enum RentalMarkdown {
+    /// Cuts a description into blocks. Deliberately small: paragraphs, `- `
+    /// bullets and `##` headings are what the platform's descriptions use.
+    /// Anything else stays a paragraph and is still readable.
+    static func blocks(_ text: String?) -> [RentalTextBlock] {
+        guard let text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return []
+        }
+        var result: [RentalTextBlock] = []
+        var paragraph: [String] = []
+
+        func flush() {
+            let joined = paragraph.joined(separator: " ").trimmingCharacters(in: .whitespaces)
+            paragraph.removeAll()
+            if joined.isEmpty { return }
+            result.append(.paragraph(inline(joined)))
+        }
+
+        for rawLine in text.replacingOccurrences(of: "\r\n", with: "\n").split(
+            separator: "\n", omittingEmptySubsequences: false
+        ) {
+            let line = String(rawLine).trimmingCharacters(in: .whitespaces)
+            if line.isEmpty {
+                flush()
+                continue
+            }
+            if line.hasPrefix("#") {
+                flush()
+                let hashes = line.prefix { $0 == "#" }.count
+                let rest = line.dropFirst(hashes).trimmingCharacters(in: .whitespaces)
+                if !rest.isEmpty { result.append(.heading(level: min(hashes, 4), text: inline(rest))) }
+                continue
+            }
+            if line.hasPrefix("- ") || line.hasPrefix("* ") {
+                flush()
+                let rest = String(line.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+                if !rest.isEmpty { result.append(.bullet(inline(rest))) }
+                continue
+            }
+            paragraph.append(line)
+        }
+        flush()
+        return result
+    }
+
+    /// The inline part — bold, italics, links. Whatever cannot be parsed is
+    /// shown as it stands; a description must never disappear because of a
+    /// stray asterisk.
+    static func inline(_ text: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(text)
+    }
+}
+
+// MARK: - A device
+
+/// One device as the list and the detail page show it.
+nonisolated struct RentalDevice: Identifiable, Hashable, Sendable {
+    let id: String
+    let name: String
+    /// The description, cut into blocks — empty when there is none.
+    let blocks: [RentalTextBlock]
+    /// The first paragraph as plain text, for the row in the list.
+    let summary: String
+    let tags: [String]
+    /// „25,00 € pro Tag", „40,00 € pro Wochenende", … — **one line per tariff
+    /// the platform actually has.** Never added up: which tariff applies to
+    /// which duration is nowhere written down, and an invented rule in the
+    /// app would be exactly the split between web and app we avoid
+    /// (`docs/mieten-api.md`, „Was bewusst fehlt").
+    let tariffs: [String]
+    /// „Kaution 100,00 €", or nothing when there is no deposit.
+    let depositText: String?
+    let thumbnailURL: URL?
+    let images: [URL]
+    /// The manufacturer's page, where the platform knows one.
+    let productURL: URL?
+    /// The same device in the web version — for „im Browser öffnen".
+    let webURL: URL?
+    /// Route 16 only: the lender's own list marks a switched-off device.
+    let active: Bool?
+    /// Everything searchable about this device, folded down once so the
+    /// filter does not rebuild it on every keystroke.
+    let searchIndex: String
+
+    /// Does this device match what somebody typed? Every word has to appear
+    /// somewhere — „rasen walze" finds the Rasenwalze, and so does „walze".
+    ///
+    /// This is the fallback for when the platform's own search cannot be
+    /// reached; it is a filter over text, not a ranking.
+    func matches(_ query: String) -> Bool {
+        let words = query.lowercased()
+            .split(whereSeparator: { $0.isWhitespace })
+            .map(String.init)
+        if words.isEmpty { return true }
+        return words.allSatisfy { searchIndex.contains($0) }
+    }
+}
+
+nonisolated extension RentalItemDto {
+    /// A device, or `nil` when the entry carries no identity at all — a row
+    /// nobody could open is worse than a row that is not there.
+    func asDevice() -> RentalDevice? {
+        let id = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        if id.isEmpty { return nil }
+        let title = name.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var tariffs: [String] = []
+        if let day = pricePerDay { tariffs.append("\(RentalMoney.euro(day)) pro Tag") }
+        if let weekend = pricePerWeekend {
+            tariffs.append("\(RentalMoney.euro(weekend)) pro Wochenende")
+        }
+        if let week = pricePerWeek { tariffs.append("\(RentalMoney.euro(week)) pro Woche") }
+
+        let blocks = RentalMarkdown.blocks(description)
+        let summary = blocks.compactMap { block -> String? in
+            if case .paragraph(let text) = block { return String(text.characters) }
+            return nil
+        }.first ?? ""
+
+        // The thumbnail belongs in front of the gallery, and it is often the
+        // first of `images` again — showing it twice looks like a bug.
+        var pictures: [String] = []
+        for candidate in (thumbnailUrl.map { [$0] } ?? []) + images.map(\.url)
+        where !candidate.isEmpty && !pictures.contains(candidate) {
+            pictures.append(candidate)
+        }
+
+        let haystack = ([title, summary, description ?? ""] + tags)
+            .joined(separator: " ")
+            .lowercased()
+
+        return RentalDevice(
+            id: id,
+            name: title.isEmpty ? id : title,
+            blocks: blocks,
+            summary: summary,
+            tags: tags,
+            tariffs: tariffs,
+            depositText: deposit.map { "Kaution \(RentalMoney.euro($0))" },
+            thumbnailURL: pictures.first.flatMap(URL.init(string:)),
+            images: pictures.compactMap(URL.init(string:)),
+            productURL: productUrl.flatMap(URL.init(string:)),
+            webURL: webUrl.flatMap(URL.init(string:)),
+            active: active,
+            searchIndex: haystack
+        )
+    }
+}
+
+nonisolated extension Collection where Element == RentalItemDto {
+    /// The catalogue as it is shown: readable entries only, in the order the
+    /// platform sent them. Route 1 sorts by name over there, and route 3
+    /// sorts by how well something matched — **re-sorting here would throw
+    /// the search away** (`docs/mieten-api.md`, route 3).
+    func asDevices() -> [RentalDevice] {
+        compactMap { $0.asDevice() }
+    }
+}
+
+// MARK: - Sets
+
+/// A set: several devices at one price of its own.
+nonisolated struct RentalSet: Identifiable, Hashable, Sendable {
+    let id: String
+    let name: String
+    /// Plain text here, not Markdown.
+    let description: String?
+    let tariffs: [String]
+    let depositText: String?
+    let itemIds: [String]
+}
+
+nonisolated extension RentalSetDto {
+    func asSet() -> RentalSet? {
+        let id = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        if id.isEmpty { return nil }
+        var tariffs: [String] = []
+        if let day = pricePerDay { tariffs.append("\(RentalMoney.euro(day)) pro Tag") }
+        let text = description?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return RentalSet(
+            id: id,
+            name: name.isEmpty ? id : name,
+            description: (text?.isEmpty ?? true) ? nil : text,
+            tariffs: tariffs,
+            depositText: deposit.map { "Kaution \(RentalMoney.euro($0))" },
+            itemIds: itemIds
+        )
+    }
+}
+
+nonisolated extension Collection where Element == RentalSetDto {
+    func asSets() -> [RentalSet] { compactMap { $0.asSet() } }
+}
+
+// MARK: - Occupied periods
+
+/// Why a stretch of days is taken. For the drawing only — **all three mean
+/// taken**, and „angefragt" is not something still to be had.
+nonisolated enum RentalOccupancyKind: String, Hashable, Sendable {
+    case pending
+    case approved
+    case blocked
+    case unknown
+
+    init(raw: String) {
+        self = RentalOccupancyKind(rawValue: raw.lowercased()) ?? .unknown
+    }
+
+    var label: String {
+        switch self {
+        case .pending: return "angefragt"
+        case .approved: return "vergeben"
+        case .blocked: return "gesperrt"
+        case .unknown: return "belegt"
+        }
+    }
+}
+
+/// A stretch of days that is taken already — shown under a device so one can
+/// see at a glance whether the weekend is free.
+nonisolated struct RentalPeriod: Identifiable, Hashable, Sendable {
+    let id: String
+    let text: String
+    let kind: RentalOccupancyKind
+    let start: Date?
+    /// The day it comes back — the first day somebody else could start.
+    let end: Date?
+}
+
+nonisolated extension Collection where Element == RentalPeriodDto {
+    /// The taken periods of one device, upcoming ones first, past ones gone.
+    ///
+    /// Purely informational: whether a wish fits is answered by route 5,
+    /// never by this list.
+    func occupied(deviceId: String? = nil, now: Date,
+                  zone: TimeZone = RentalDay.villageZone) -> [RentalPeriod] {
+        let today = RentalDay.calendar(zone).startOfDay(for: now)
+        return enumerated().compactMap { position, period -> RentalPeriod? in
+            if let deviceId, period.deviceId != deviceId { return nil }
+            let start = RentalDay.parse(period.startDate, zone: zone)
+            let end = RentalDay.parse(period.endDate, zone: zone)
+            // `endDate` is the return day: a period is over once that day has
+            // come, not a day later.
+            if let end, end <= today { return nil }
+            return RentalPeriod(
+                id: "\(period.deviceId ?? period.setId ?? "")-\(position)-\(period.startDate)",
+                text: RentalDay.occupiedText(
+                    startDate: period.startDate, endDate: period.endDate, zone: zone
+                ),
+                kind: RentalOccupancyKind(raw: period.status),
+                start: start,
+                end: end
+            )
+        }
+        .sorted { ($0.start ?? .distantFuture) < ($1.start ?? .distantFuture) }
+    }
+}
+
+// MARK: - Availability
+
+/// The platform's answer to „ist es frei?".
+nonisolated struct RentalAvailability: Hashable, Sendable {
+    /// Exactly the stretch this answer was given for. An answer that no
+    /// longer belongs to what is on screen is worthless — and dangerous.
+    let startDate: String
+    let endDate: String
+    let free: Bool
+    /// What is shown above the button.
+    let message: String
+}
+
+nonisolated extension RentalAvailabilityDto {
+    func asAvailability(startDate: String, endDate: String) -> RentalAvailability {
+        RentalAvailability(
+            startDate: startDate,
+            endDate: endDate,
+            free: available,
+            // The platform says `occupied` or nothing at all — deliberately
+            // not who or why. So the sentence is ours, and it stays as
+            // uninformative as the answer is.
+            message: available
+                ? "Der Zeitraum ist frei."
+                : "Der Zeitraum ist schon vergeben. Such dir einen anderen aus."
+        )
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalProfileModel.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalProfileModel.swift
@@ -1,0 +1,130 @@
+import Combine
+import Foundation
+
+/// The profile in the rental platform: telephone and address, and the way to
+/// ask for permission to lend things out.
+///
+/// Two things are worth knowing about it. First, the platform creates the
+/// account by itself on the first call with a Rössing-ID — the app does
+/// nothing for that (`docs/mieten-api.md`, route 7). Second, the profile is
+/// **not** a copy of the village profile: it lives over there, it is what the
+/// lender sees when the device is handed over, and the platform decides when
+/// it is complete enough (`profileComplete`, `missingFields`).
+///
+/// Nothing here works out who may lend: `lenderStatus` arrives from the
+/// platform, and the lender's side appears only when it says `approved`.
+final class RentalProfileModel: ObservableObject {
+    @Published private(set) var profile: RentalProfile?
+    @Published private(set) var loading = false
+    @Published private(set) var saving = false
+    @Published private(set) var trouble: RentalTrouble?
+    /// What the platform said after „ich möchte verleihen" — its own
+    /// sentence, shown as it stands.
+    @Published private(set) var lenderMessage: String?
+    @Published private(set) var askingToLend = false
+
+    // The form. Filled from the profile once it arrives, then owned by the
+    // person typing.
+    @Published var name = ""
+    @Published var phone = ""
+    @Published var addressStreet = ""
+    @Published var addressZip = ""
+    @Published var addressCity = ""
+
+    private var fetched = false
+    private let source: RentalSource
+
+    init(source: RentalSource) {
+        self.source = source
+    }
+
+    var needsSignIn: Bool { trouble?.wantsSignIn == true }
+
+    /// The note above the form.
+    var hint: String? { trouble?.message }
+
+    /// What the platform is still missing — its list, in German.
+    var missingLabels: [String] { profile?.missingLabels ?? [] }
+
+    func load() async {
+        if fetched { return }
+        await fetch()
+    }
+
+    func refresh() async {
+        await fetch()
+    }
+
+    private func fetch() async {
+        if loading { return }
+        loading = true
+        defer { loading = false }
+        do {
+            let answer = try await source.profile()
+            apply(answer.asProfile())
+            fetched = true
+            trouble = nil
+        } catch {
+            trouble = RentalTrouble(error)
+        }
+    }
+
+    private func apply(_ fresh: RentalProfile) {
+        profile = fresh
+        name = fresh.name
+        phone = fresh.phone
+        addressStreet = fresh.addressStreet
+        addressZip = fresh.addressZip
+        addressCity = fresh.addressCity
+    }
+
+    /// Sends what is in the form. Only fields that carry something go out —
+    /// the platform changes exactly what it is given, and an empty value in a
+    /// sent field is a `bad_request`, not a way to clear it.
+    @discardableResult
+    func save() async -> Bool {
+        if saving { return false }
+        saving = true
+        defer { saving = false }
+        let patch = RentalProfilePatchDto(
+            name: name.rentalNonEmpty,
+            phone: phone.rentalNonEmpty,
+            addressStreet: addressStreet.rentalNonEmpty,
+            addressZip: addressZip.rentalNonEmpty,
+            addressCity: addressCity.rentalNonEmpty
+        )
+        do {
+            let answer = try await source.updateProfile(patch)
+            apply(answer.asProfile())
+            trouble = nil
+            return true
+        } catch {
+            // What was typed stays where it is; nobody fills in an address
+            // twice because the network hiccuped.
+            trouble = RentalTrouble(error)
+            return false
+        }
+    }
+
+    /// Asks to become a lender. The answer is a receipt, not a permission —
+    /// somebody decides that by hand, in the web version.
+    func askToLend() async {
+        if askingToLend { return }
+        askingToLend = true
+        defer { askingToLend = false }
+        do {
+            let answer = try await source.requestLender()
+            lenderMessage = answer.message.rentalNonEmpty
+            trouble = nil
+            // The status moved; the platform's own answer is what counts, so
+            // it is fetched rather than patched together here.
+            if let fresh = try? await source.profile() { apply(fresh.asProfile()) }
+        } catch {
+            trouble = RentalTrouble(error)
+        }
+    }
+
+    func clearTrouble() {
+        trouble = nil
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalProfileView.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalProfileView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+/// „Mein Profil im Maschinchenring" — telephone and address, so a handover
+/// can be arranged, plus the way to ask for permission to lend things out.
+///
+/// The profile lives over there, not in the village backend: it is the one
+/// the lender sees. Whether it is complete enough is the platform's answer
+/// (`profileComplete`, `missingFields`), not a check of ours.
+struct RentalProfileView: View {
+    @EnvironmentObject private var umgebung: AppUmgebung
+    @State private var model: RentalProfileModel?
+
+    var body: some View {
+        Group {
+            if let model {
+                RentalProfileForm(model: model)
+            } else {
+                ProgressView().controlSize(.large)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle("Mein Profil")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            let existing = model ?? RentalProfileModel(source: .from(umgebung.rental))
+            model = existing
+            await existing.load()
+        }
+    }
+}
+
+struct RentalProfileForm: View {
+    @ObservedObject var model: RentalProfileModel
+    @State private var saved = false
+
+    var body: some View {
+        List {
+            if let trouble = model.trouble, trouble.wantsSignIn {
+                Section {
+                    RentalSignInNotice(trouble: trouble) {
+                        model.clearTrouble()
+                        await model.refresh()
+                    }
+                }
+            } else if let hint = model.hint {
+                Section {
+                    RentalNotice(text: hint) { Task { await model.refresh() } }
+                }
+            }
+
+            if model.loading && model.profile == nil {
+                Section {
+                    HStack(spacing: 10) {
+                        ProgressView()
+                        Text("Profil wird geholt …").foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            if model.profile != nil {
+                formSection
+                lenderSection
+            }
+        }
+        .accessibilityIdentifier("rental-profile-form")
+        .refreshable { await model.refresh() }
+    }
+
+    private var formSection: some View {
+        Section {
+            TextField("Name", text: $model.name)
+                .textContentType(.name)
+                .accessibilityIdentifier("rental-profile-name")
+            TextField("Telefonnummer", text: $model.phone)
+                .textContentType(.telephoneNumber)
+                .keyboardType(.phonePad)
+                .accessibilityIdentifier("rental-profile-phone")
+            TextField("Straße und Hausnummer", text: $model.addressStreet)
+                .textContentType(.fullStreetAddress)
+                .accessibilityIdentifier("rental-profile-street")
+            TextField("Postleitzahl", text: $model.addressZip)
+                .textContentType(.postalCode)
+                .keyboardType(.numbersAndPunctuation)
+                .accessibilityIdentifier("rental-profile-zip")
+            TextField("Ort", text: $model.addressCity)
+                .textContentType(.addressCity)
+                .accessibilityIdentifier("rental-profile-city")
+
+            Button {
+                Task { saved = await model.save() }
+            } label: {
+                HStack {
+                    if model.saving { ProgressView().controlSize(.small) }
+                    Text(model.saving ? "Wird gespeichert …" : "Speichern")
+                }
+            }
+            .disabled(model.saving)
+            .accessibilityIdentifier("rental-profile-save")
+
+            if saved && model.trouble == nil {
+                Label("Gespeichert.", systemImage: "checkmark.circle.fill")
+                    .font(.footnote)
+                    .foregroundStyle(.green)
+                    .accessibilityIdentifier("rental-profile-saved")
+            }
+        } header: {
+            Text("Deine Angaben")
+        } footer: {
+            if !model.missingLabels.isEmpty {
+                Text("Zum Buchen fehlt dem Maschinchenring noch: "
+                    + model.missingLabels.joined(separator: ", ") + ".")
+                    .accessibilityIdentifier("rental-profile-missing")
+            } else {
+                Text("Deine E-Mail-Adresse kommt aus der Rössing-ID und lässt "
+                    + "sich hier nicht ändern. Telefon und Adresse braucht der "
+                    + "Verleiher für die Übergabe.")
+            }
+        }
+    }
+
+    @ViewBuilder private var lenderSection: some View {
+        if let profile = model.profile {
+            Section {
+                Text(profile.lenderStatus.label)
+                    .font(.subheadline)
+                    .accessibilityIdentifier("rental-lender-status")
+
+                if let message = model.lenderMessage {
+                    // The platform's own sentence, shown as it stands.
+                    Text(message)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("rental-lender-message")
+                }
+
+                if profile.canAskToLend {
+                    Button {
+                        Task { await model.askToLend() }
+                    } label: {
+                        HStack {
+                            if model.askingToLend { ProgressView().controlSize(.small) }
+                            Text("Ich möchte auch verleihen")
+                        }
+                    }
+                    .disabled(model.askingToLend)
+                    .accessibilityIdentifier("rental-ask-to-lend")
+                }
+
+                // The lender's side appears because the platform said
+                // „approved" — never because the app worked it out.
+                if profile.showsLenderArea {
+                    NavigationLink {
+                        RentalOwnerView()
+                    } label: {
+                        Label("Meine Vermietung", systemImage: "shippingbox")
+                    }
+                    .accessibilityIdentifier("rental-owner-area")
+                }
+            } header: {
+                Text("Verleihen")
+            } footer: {
+                Text("Über die Freischaltung entscheidet die Verwaltung des "
+                    + "Maschinchenrings von Hand. Du bekommst eine E-Mail, "
+                    + "sobald es so weit ist.")
+            }
+        }
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalShared.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalShared.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+/// The pieces every screen of this area uses: the note above a list, the way
+/// back into a sign-in, a thumbnail, a line of facts, and a Markdown text.
+
+/// The note above a list — with the way back, not just the bad news.
+struct RentalNotice: View {
+    let text: String
+    var actionTitle: String = "Erneut versuchen"
+    let action: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(text, systemImage: "exclamationmark.triangle.fill")
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+            Button(actionTitle, action: action)
+                .buttonStyle(.borderless)
+                .accessibilityIdentifier("rental-notice-action")
+        }
+        .padding(.vertical, 4)
+        .accessibilityIdentifier("rental-notice")
+    }
+}
+
+/// The note when a sign-in is what is missing.
+///
+/// Two cases, one box. „Nobody is signed in" leads to the ordinary sign-in;
+/// „this device's token predates the Maschinchenring" leads to the same
+/// screen but for a different reason, and saying which one it is beats an
+/// empty list and a shrug (`docs/mieten-api.md`, `token_audience`).
+struct RentalSignInNotice: View {
+    @EnvironmentObject private var umgebung: AppUmgebung
+    let trouble: RentalTrouble
+    /// Run after a successful sign-in — usually „fetch it again".
+    let afterwards: () async -> Void
+    @State private var running = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(trouble.message, systemImage: trouble.needsFreshSignIn
+                ? "person.badge.key" : "person.crop.circle.badge.questionmark")
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+            Button(trouble.needsFreshSignIn ? "Neu anmelden" : "Mit Rössing-ID anmelden") {
+                Task { await signIn() }
+            }
+            .buttonStyle(.borderless)
+            .disabled(running)
+            .accessibilityIdentifier("rental-sign-in")
+        }
+        .padding(.vertical, 4)
+        .accessibilityIdentifier(trouble.needsFreshSignIn
+            ? "rental-sign-in-outdated" : "rental-sign-in-required")
+    }
+
+    private func signIn() async {
+        running = true
+        defer { running = false }
+        // A full sign-in, not a refresh: Zitadel only puts the rental
+        // platform into the token's audience when the authorization request
+        // asks for it, and a refreshed token keeps the audiences it was
+        // issued with. That is the whole reason this button exists.
+        if await umgebung.anmeldung.anmelden() == .erfolg {
+            await umgebung.ichLaden()
+            await afterwards()
+        }
+    }
+}
+
+/// The little picture in front of a row. A device without one keeps its place
+/// in the column, so the names stay aligned.
+struct RentalThumbnail: View {
+    let url: URL?
+
+    var body: some View {
+        Group {
+            if let url {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let bild):
+                        bild.resizable().scaledToFill()
+                    default:
+                        placeholder
+                    }
+                }
+            } else {
+                placeholder
+            }
+        }
+        .frame(width: 56, height: 56)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .accessibilityHidden(true)
+    }
+
+    private var placeholder: some View {
+        ZStack {
+            Color.accentColor.opacity(0.10)
+            Image(systemName: "wrench.and.screwdriver")
+                .font(.title3)
+                .foregroundStyle(.tint)
+        }
+    }
+}
+
+/// One line of facts — the same arrangement for tariff, deposit and address,
+/// so a block does not look like four different things.
+struct RentalFact: View {
+    let symbol: String
+    let text: String
+
+    var body: some View {
+        Label {
+            Text(text).font(.subheadline)
+        } icon: {
+            Image(systemName: symbol).foregroundStyle(.tint)
+        }
+    }
+}
+
+/// A device description, as the platform writes it: Markdown.
+///
+/// Paragraphs, bullets and headings are laid out here; bold, italics and
+/// links come from `AttributedString`. Showing the raw text with its
+/// asterisks would be the one thing that is not an option.
+struct RentalMarkdownText: View {
+    let blocks: [RentalTextBlock]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(blocks) { block in
+                switch block {
+                case .heading(let level, let text):
+                    Text(text)
+                        .font(level <= 2 ? .headline : .subheadline.weight(.semibold))
+                        .padding(.top, 2)
+                        .fixedSize(horizontal: false, vertical: true)
+                case .paragraph(let text):
+                    Text(text)
+                        .font(.body)
+                        .fixedSize(horizontal: false, vertical: true)
+                case .bullet(let text):
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text("•").font(.body).foregroundStyle(.secondary)
+                        Text(text)
+                            .font(.body)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/ios/Dorf/Bereiche/Rental/RentalSource.swift
+++ b/ios/Dorf/Bereiche/Rental/RentalSource.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Where the rental area gets its data from.
+///
+/// A bundle of closures instead of a protocol — the same shape as
+/// `VergabeQuelle`: the area needs a handful of calls, and a test fills them
+/// in itself. That is what keeps every test in this area away from the
+/// network without a single mock framework.
+nonisolated struct RentalSource {
+    // Public, no token (routes 1 to 6).
+    var items: @MainActor () async throws -> [RentalItemDto]
+    var item: @MainActor (String) async throws -> RentalItemDto
+    var search: @MainActor (String) async throws -> [RentalItemDto]
+    var sets: @MainActor () async throws -> [RentalSetDto]
+    var availability: @MainActor (_ deviceId: String, _ startDate: String, _ endDate: String)
+        async throws -> RentalAvailabilityDto
+    var occupancy: @MainActor (_ deviceId: String?) async throws -> [RentalPeriodDto]
+
+    // With a token (routes 7 to 12).
+    var profile: @MainActor () async throws -> RentalProfileDto
+    var updateProfile: @MainActor (RentalProfilePatchDto) async throws -> RentalProfileDto
+    var requestLender: @MainActor () async throws -> RentalLenderRequestDto
+    var myBookings: @MainActor () async throws -> [RentalBookingDto]
+    var book: @MainActor (RentalBookingRequestDto) async throws -> RentalBookingDto
+    var cancel: @MainActor (String) async throws -> Void
+
+    // The lender's side (routes 13 to 19).
+    var ownerBookings: @MainActor () async throws -> [RentalOwnerBookingDto]
+    var approve: @MainActor (String) async throws -> Void
+    var reject: @MainActor (String) async throws -> Void
+    var ownerItems: @MainActor () async throws -> [RentalItemDto]
+    var blocks: @MainActor () async throws -> [RentalBlockDto]
+    var addBlock: @MainActor (RentalBlockRequestDto) async throws -> RentalBlockDto
+    var removeBlock: @MainActor (String) async throws -> Void
+
+    /// The one place that ties the models to the actual platform.
+    static func from(_ client: RentalClient) -> RentalSource {
+        RentalSource(
+            items: { try await client.items() },
+            item: { try await client.item(id: $0) },
+            search: { try await client.search($0, limit: 20) },
+            sets: { try await client.sets() },
+            availability: {
+                try await client.availability(deviceId: $0, startDate: $1, endDate: $2)
+            },
+            occupancy: { try await client.occupancy(deviceId: $0) },
+            profile: { try await client.profile() },
+            updateProfile: { try await client.updateProfile($0) },
+            requestLender: { try await client.requestLender() },
+            myBookings: { try await client.myBookings() },
+            book: { try await client.book($0) },
+            cancel: { try await client.cancel(bookingId: $0) },
+            ownerBookings: { try await client.ownerBookings() },
+            approve: { try await client.approve(bookingId: $0) },
+            reject: { try await client.reject(bookingId: $0) },
+            ownerItems: { try await client.ownerItems() },
+            blocks: { try await client.blocks() },
+            addBlock: { try await client.addBlock($0) },
+            removeBlock: { try await client.removeBlock(id: $0) }
+        )
+    }
+}
+
+/// How the screens of this area report trouble.
+///
+/// One type for every model, because they all answer the same questions: what
+/// does the person read, does the list stay standing, and is this one of the
+/// two cases where a sign-in — a fresh one or an ordinary one — is the way
+/// out rather than „try again".
+nonisolated struct RentalTrouble: Equatable, Sendable {
+    let message: String
+    /// The token was refused although it was sent: the audience from
+    /// `ANMELDE_SCOPES` is missing on this device, because it was already
+    /// signed in when that scope arrived. Only a fresh sign-in helps, and the
+    /// screen offers exactly that (`docs/mieten-api.md`, `token_audience`).
+    let needsFreshSignIn: Bool
+    /// Nobody is signed in; the screen offers the ordinary sign-in.
+    let needsSignIn: Bool
+    /// The platform's error code, where it sent one — for the screens that
+    /// react to a particular one (`profile_incomplete`, `occupied`).
+    let code: RentalErrorCode?
+    /// Only with `profile_incomplete`: what the platform is still missing.
+    let missingFields: [String]
+
+    init(_ error: Error) {
+        let rental = error as? RentalError ?? .network(error.localizedDescription)
+        message = rental.message
+        needsFreshSignIn = rental.needsFreshSignIn
+        needsSignIn = rental.needsSignIn
+        code = rental.code
+        missingFields = rental.missingFields
+    }
+
+    /// Whether a sign-in of some kind is what this needs.
+    var wantsSignIn: Bool { needsSignIn || needsFreshSignIn }
+}

--- a/ios/Dorf/Info.plist
+++ b/ios/Dorf/Info.plist
@@ -79,6 +79,10 @@
 	<string>$(OIDC_LOGOUT_REDIRECT_URI)</string>
 	<key>DorfMapStyleUrl</key>
 	<string>$(MAP_STYLE_URL)</string>
+	<key>DorfRentalBaseUrl</key>
+	<string>$(RENTAL_BASE_URL)</string>
+	<key>DorfRentalProjectId</key>
+	<string>$(RENTAL_PROJECT_ID)</string>
 	<key>DorfDevAuth</key>
 	<string>$(DEV_AUTH)</string>
 </dict>

--- a/ios/Dorf/Konfiguration.swift
+++ b/ios/Dorf/Konfiguration.swift
@@ -22,6 +22,16 @@ nonisolated enum Konfiguration {
     static let oidcAbmeldeRuecksprung = text("DorfOidcLogoutRedirectUri", vorgabe: "de.roessing.app:/logout")
     static let kartenstil = url("DorfMapStyleUrl", vorgabe: "https://tiles.openfreemap.org/styles/liberty")
 
+    /// The rental platform („Maschinchenring"). A service of its own next to
+    /// the backend: the app talks to it directly, the Go backend knows
+    /// nothing about it (`docs/mietplattform-in-den-apps.md`, AP 4).
+    static let rentalBaseUrl = url("DorfRentalBaseUrl", vorgabe: "https://mieten.xn--rssing-wxa.de")
+
+    /// The rental platform's Zitadel project. It has to appear as an audience
+    /// in our access token, otherwise every call is answered with 401 — see
+    /// `rentalAudienceScope` in `Anmeldung.swift`.
+    static let rentalProjectId = text("DorfRentalProjectId", vorgabe: "377276525071827047")
+
     /// Der Entwickler-Login (ohne Rössing-ID) — nur im Debug-Build und nur,
     /// wenn er ausdrücklich eingeschaltet wurde. In einer ausgelieferten App
     /// gibt es ihn nicht, auch nicht versehentlich.

--- a/ios/Dorf/Navigation/StartView.swift
+++ b/ios/Dorf/Navigation/StartView.swift
@@ -58,6 +58,11 @@ struct StartView: View {
                         untertitel: "Termine aus dem Dorf."
                     )
                     Bereichskachel(
+                        ziel: .rental, symbol: "wrench.and.screwdriver.fill",
+                        titel: "Maschinchenring",
+                        untertitel: "Geräte aus dem Dorf leihen."
+                    )
+                    Bereichskachel(
                         ziel: .rangliste, symbol: "trophy.fill", titel: "Rangliste",
                         untertitel: "Wer wie viel geschafft hat."
                     )

--- a/ios/Dorf/Navigation/Ziel.swift
+++ b/ios/Dorf/Navigation/Ziel.swift
@@ -9,6 +9,7 @@ enum Ziel: Hashable {
     case profil
     case dorfbewohner
     case veranstaltungen
+    case rental
     case ideen
     case anfragen
     case einstellungen
@@ -26,6 +27,7 @@ extension View {
             case .profil: ProfilView()
             case .dorfbewohner: DorfbewohnerView()
             case .veranstaltungen: VeranstaltungenView()
+            case .rental: RentalCatalogView()
             case .ideen: IdeenView()
             case .anfragen: VergabeView()
             case .einstellungen: EinstellungenView()

--- a/ios/Dorf/Umgebung.swift
+++ b/ios/Dorf/Umgebung.swift
@@ -14,6 +14,13 @@ final class AppUmgebung: ObservableObject {
     let anmeldung: Anmeldung
     let api: DorfApi
 
+    /// Der Weg zum Verleih („Maschinchenring") — ein **zweiter** Dienst neben
+    /// dem Backend, mit eigener Adresse und eigenem Client. Das Go-Backend
+    /// ist kein Weiterleiter und weiß von der Mietplattform nichts; die Regel
+    /// „genau ein Weg zum Backend" meint `mieten.…` deshalb nicht
+    /// (`docs/mietplattform-in-den-apps.md`, AP 4).
+    let rental: RentalClient
+
     /// Die Orte des Dorfes — **ein** Modell für alle, die sie brauchen.
     ///
     /// Die Startseite zeigt daraus nur eine Zahl („3 Orte warten auf dich")
@@ -45,6 +52,12 @@ final class AppUmgebung: ObservableObject {
         })
         self.anmeldung = anmeldung
         self.api = api
+        // Derselbe Tokengeber, ein anderer Dienst: Das Token gilt für den
+        // Verleih nur, wenn sein Zitadel-Projekt in der `aud` steht — siehe
+        // `ANMELDE_SCOPES`.
+        self.rental = RentalClient(tokenProvider: { [anmeldung] in
+            await anmeldung.frischesToken()
+        })
         self.orte = OrteModell(api: api)
         // Die Benachrichtigungen brauchen denselben Zugang: Sie melden die
         // Gerätekennung an und beim Abmelden wieder ab. Gefragt wird damit
@@ -54,9 +67,13 @@ final class AppUmgebung: ObservableObject {
     }
 
     /// Für Vorschauen und Tests: eine Umgebung, die nichts abruft.
-    init(anmeldung: Anmeldung, api: DorfApi, ich: Ich?, orte: OrteModell? = nil) {
+    init(anmeldung: Anmeldung, api: DorfApi, ich: Ich?, orte: OrteModell? = nil,
+         rental: RentalClient? = nil) {
         self.anmeldung = anmeldung
         self.api = api
+        self.rental = rental ?? RentalClient(tokenProvider: { [anmeldung] in
+            await anmeldung.frischesToken()
+        })
         self.orte = orte ?? OrteModell(api: api)
         self.ich = ich
         kinderWeiterreichen()

--- a/ios/DorfTests/RentalTests.swift
+++ b/ios/DorfTests/RentalTests.swift
@@ -1,0 +1,1125 @@
+import Foundation
+import Testing
+
+@testable import Dorf
+
+/// Der Vertrag mit der Mietplattform („Maschinchenring"): So sieht ihre
+/// Antwort aus, und so wird sie gelesen.
+///
+/// Die Beispiele stammen wörtlich aus `docs/mieten-api.md` — der einzigen
+/// Quelle für diesen Bereich. Ändert sich die Form dort, muss dieser Test
+/// auffallen und nicht erst eine leere Liste auf dem Telefon.
+///
+/// Kein Test geht ins Netz: Geprüft wird die Aufbereitung, und wo ein Client
+/// gebraucht wird, bekommt er eine eigene Basis und eine örtliche Ablage
+/// untergeschoben.
+struct RentalTests {
+    // MARK: Beispiele aus dem Vertrag
+
+    static let itemsJson = """
+    {
+      "items": [
+        {
+          "id": "as-585-km-kreiselmaeher",
+          "name": "AS 585 KM Kreiselmäher",
+          "description": "Kreiselmäher für hohes Gras und Böschungen.\\n\\n- Arbeitsbreite 85 cm\\n- Benzin, Radantrieb",
+          "pricePerDay": 25,
+          "pricePerWeekend": 40,
+          "pricePerWeek": 120,
+          "deposit": 100,
+          "tags": ["garten", "motorgeraet"],
+          "thumbnailUrl": "https://cdn.example.invalid/front.jpg",
+          "productUrl": "https://www.example.invalid/as-585",
+          "webUrl": "https://example.invalid/geraete/as-585-km-kreiselmaeher/"
+        },
+        {
+          "id": "018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11",
+          "name": "Rasenwalze",
+          "description": null,
+          "pricePerDay": 8,
+          "pricePerWeekend": null,
+          "pricePerWeek": null,
+          "deposit": null,
+          "tags": ["garten"],
+          "thumbnailUrl": null,
+          "productUrl": null,
+          "webUrl": "https://example.invalid/geraete/018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11/"
+        }
+      ]
+    }
+    """
+
+    static let occupancyJson = """
+    {
+      "periods": [
+        {
+          "deviceId": "as-585-km-kreiselmaeher",
+          "setId": null,
+          "startDate": "2026-09-05",
+          "endDate": "2026-09-07",
+          "status": "approved"
+        },
+        {
+          "deviceId": "as-585-km-kreiselmaeher",
+          "setId": null,
+          "startDate": "2026-09-12",
+          "endDate": "2026-09-14",
+          "status": "pending"
+        },
+        {
+          "deviceId": "as-585-km-kreiselmaeher",
+          "setId": null,
+          "startDate": "2026-10-01",
+          "endDate": "2026-10-08",
+          "status": "blocked"
+        },
+        {
+          "deviceId": "rasenwalze",
+          "setId": null,
+          "startDate": "2026-09-05",
+          "endDate": "2026-09-06",
+          "status": "approved"
+        }
+      ]
+    }
+    """
+
+    static let myBookingsJson = """
+    {
+      "bookings": [
+        {
+          "id": "8f14c2b0-91ae-4c77-b1b2-0a3d5e7c9f01",
+          "deviceId": "as-585-km-kreiselmaeher",
+          "setId": null,
+          "deviceName": "AS 585 KM Kreiselmäher",
+          "startDate": "2026-09-05",
+          "endDate": "2026-09-07",
+          "status": "approved",
+          "notes": "Hole ich Samstag früh ab.",
+          "canCancel": true,
+          "pickup": {
+            "address": "Hauptstraße 1, 31171 Nordstemmen",
+            "phone": "+49 5069 123456"
+          }
+        },
+        {
+          "id": "1c9e77a3-1234-4bb8-9a0e-77ce31d2a456",
+          "deviceId": "018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11",
+          "setId": null,
+          "deviceName": "Rasenwalze",
+          "startDate": "2026-10-01",
+          "endDate": "2026-10-03",
+          "status": "pending",
+          "notes": null,
+          "canCancel": true,
+          "pickup": null
+        }
+      ]
+    }
+    """
+
+    static let profileJson = """
+    {
+      "profile": {
+        "name": "Erika Musterfrau",
+        "email": "erika@example.de",
+        "phone": "+49 5069 123456",
+        "addressStreet": "Hauptstraße 1",
+        "addressZip": "31171",
+        "addressCity": null,
+        "lender": false,
+        "lenderStatus": "none",
+        "profileComplete": false,
+        "missingFields": ["addressCity"]
+      }
+    }
+    """
+
+    static func decode<T: Decodable>(_ text: String) throws -> T {
+        try JSONDecoder().decode(T.self, from: Data(text.utf8))
+    }
+
+    static func day(_ text: String) throws -> Date {
+        try #require(RentalDay.parse(text))
+    }
+
+    // MARK: Die Antworten der Mietplattform
+
+    @Test func dieGeraetelisteWirdVollstaendigGelesen() throws {
+        let dto: RentalItemsDto = try Self.decode(Self.itemsJson)
+        #expect(dto.items.count == 2)
+
+        let devices = dto.items.asDevices()
+        // Die Reihenfolge der Plattform bleibt — sie sortiert nach Namen,
+        // die Suche nach Passung. Ein zweites Sortieren hier würfe das weg.
+        #expect(devices.map(\.id) == [
+            "as-585-km-kreiselmaeher",
+            "018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11",
+        ])
+
+        let maeher = try #require(devices.first)
+        #expect(maeher.name == "AS 585 KM Kreiselmäher")
+        #expect(maeher.tags == ["garten", "motorgeraet"])
+        #expect(maeher.thumbnailURL?.absoluteString == "https://cdn.example.invalid/front.jpg")
+        #expect(maeher.webURL != nil)
+        #expect(maeher.productURL != nil)
+
+        // Jeder Tarif eine Zeile — und keine Summe. Welcher Tarif für welche
+        // Dauer gilt, steht nirgends; eine erfundene Regel wäre der Bruch
+        // zwischen Web und App. (`\u{00A0}` ist das geschützte Leerzeichen
+        // vor dem Eurozeichen, damit der Preis nicht umbricht.)
+        #expect(maeher.tariffs == [
+            "25,00\u{00A0}€ pro Tag", "40,00\u{00A0}€ pro Wochenende", "120,00\u{00A0}€ pro Woche",
+        ])
+        #expect(maeher.depositText == "Kaution 100,00\u{00A0}€")
+
+        // Fehlende Tarife sind nicht null-gleich-0: Sie kommen gar nicht vor.
+        let walze = devices[1]
+        #expect(walze.tariffs == ["8,00\u{00A0}€ pro Tag"])
+        #expect(walze.depositText == nil)
+        #expect(walze.thumbnailURL == nil)
+        #expect(walze.blocks.isEmpty)
+    }
+
+    @Test func einFehlendesFeldKostetNichtDieGanzeListe() throws {
+        // Die Plattform darf etwas ergänzen oder weglassen, ohne dass eine
+        // ältere App-Fassung leer dasteht.
+        let dto: RentalItemsDto = try Self.decode("""
+        {"items": [{"id": "x", "name": "Bohrhammer", "somethingNew": 7}]}
+        """)
+        let devices = dto.items.asDevices()
+        #expect(devices.count == 1)
+        #expect(devices[0].tariffs.isEmpty)
+
+        // Ein Eintrag ohne Kennung wäre eine Zeile, die niemand öffnen kann.
+        let ohneId: RentalItemsDto = try Self.decode("""
+        {"items": [{"name": "Namenlos"}]}
+        """)
+        #expect(ohneId.items.asDevices().isEmpty)
+    }
+
+    @Test func dasGeraetImDetailBringtSeineBilder() throws {
+        let dto: RentalItemEnvelopeDto = try Self.decode("""
+        {"item": {"id": "a", "name": "Kreiselmäher", "thumbnailUrl": "https://cdn.example.invalid/front.jpg",
+          "images": [
+            {"id": "img-7f3a", "url": "https://cdn.example.invalid/front.jpg", "isThumbnail": true},
+            {"id": "img-9b21", "url": "https://cdn.example.invalid/seite.jpg", "isThumbnail": false}
+          ]}}
+        """)
+        let device = try #require(dto.item.asDevice())
+        // Das Titelbild steht vorn und nicht zweimal.
+        #expect(device.images.map(\.absoluteString) == [
+            "https://cdn.example.invalid/front.jpg",
+            "https://cdn.example.invalid/seite.jpg",
+        ])
+    }
+
+    @Test func setsHabenKlartextUndKeinBild() throws {
+        let dto: RentalSetsDto = try Self.decode("""
+        {"sets": [{"id": "gartenset", "name": "Gartenset",
+          "description": "Vertikutierer, Rasenwalze und Streuwagen zusammen.",
+          "pricePerDay": 30, "deposit": 150,
+          "itemIds": ["a", "vertikutierer", "streuwagen"]}]}
+        """)
+        let sets = dto.sets.asSets()
+        #expect(sets.count == 1)
+        #expect(sets[0].tariffs == ["30,00\u{00A0}€ pro Tag"])
+        #expect(sets[0].depositText == "Kaution 150,00\u{00A0}€")
+        #expect(sets[0].itemIds.count == 3)
+    }
+
+    // MARK: Zeiträume sind halboffen
+
+    @Test func derRueckgabetagGehoertNichtMehrDazu() throws {
+        // „Eine Buchung vom 05. bis 07. belegt den 5. und den 6."
+        #expect(RentalDay.occupiedText(startDate: "2026-09-05", endDate: "2026-09-07")
+            == "Sa, 05.09.2026 – So, 06.09.2026")
+        // Ein einziger Tag bleibt ein einziger Tag.
+        #expect(RentalDay.occupiedText(startDate: "2026-09-05", endDate: "2026-09-06")
+            == "Sa, 05.09.2026")
+        #expect(RentalDay.returnText(endDate: "2026-09-07") == "Rückgabe: Mo, 07.09.2026")
+    }
+
+    @Test func ausDemLetztenLeihtagWirdDerRueckgabetag() throws {
+        let letzter = try Self.day("2026-09-06")
+        #expect(RentalDay.api(RentalDay.nextDay(letzter)) == "2026-09-07")
+        // Und die Datumsangabe bleibt, was die Plattform schreibt.
+        #expect(RentalDay.api(try Self.day("2026-09-05")) == "2026-09-05")
+    }
+
+    @Test func unlesbareTageKostenNichtDieAnzeige() {
+        #expect(RentalDay.parse("") == nil)
+        #expect(RentalDay.parse("übermorgen") == nil)
+        // Statt einer Lücke steht da, was die Plattform geschickt hat.
+        #expect(RentalDay.occupiedText(startDate: "kaputt", endDate: "auch") == "kaputt – auch")
+    }
+
+    @Test func belegtIstBelegt() throws {
+        let dto: RentalOccupancyDto = try Self.decode(Self.occupancyJson)
+        let periods = dto.periods.occupied(
+            deviceId: "as-585-km-kreiselmaeher", now: try Self.day("2026-09-01")
+        )
+        #expect(periods.count == 3)
+        // Angefragt, vergeben, gesperrt: drei Wörter, eine Bedeutung.
+        #expect(periods.map(\.kind) == [.approved, .pending, .blocked])
+        #expect(periods[0].text == "Sa, 05.09.2026 – So, 06.09.2026")
+
+        // Ein fremdes Gerät gehört nicht in diese Liste.
+        #expect(!periods.contains { $0.id.contains("rasenwalze") })
+    }
+
+    @Test func vergangeneZeitraeumeVerschwinden() throws {
+        let dto: RentalOccupancyDto = try Self.decode(Self.occupancyJson)
+        // Am Rückgabetag ist der Zeitraum vorbei: Wer will, fängt heute an.
+        let periods = dto.periods.occupied(
+            deviceId: "as-585-km-kreiselmaeher", now: try Self.day("2026-09-07")
+        )
+        #expect(periods.count == 2)
+        #expect(periods.first?.kind == .pending)
+    }
+
+    // MARK: Markdown
+
+    @Test func dieBeschreibungWirdNichtRohMitSternchenGezeigt() {
+        let blocks = RentalMarkdown.blocks("""
+        Kreiselmäher für hohes Gras und Böschungen.
+
+        ## Technisches
+        - Arbeitsbreite 85 cm
+        - **Benzin**, Radantrieb
+        """)
+        #expect(blocks.count == 4)
+        guard case .paragraph(let ersterAbsatz) = blocks[0] else {
+            Issue.record("Der erste Block ist kein Absatz")
+            return
+        }
+        #expect(String(ersterAbsatz.characters) == "Kreiselmäher für hohes Gras und Böschungen.")
+
+        guard case .heading(let level, let ueberschrift) = blocks[1] else {
+            Issue.record("Der zweite Block ist keine Überschrift")
+            return
+        }
+        #expect(level == 2)
+        #expect(String(ueberschrift.characters) == "Technisches")
+
+        guard case .bullet(let ersterPunkt) = blocks[2] else {
+            Issue.record("Der dritte Block ist kein Aufzählungspunkt")
+            return
+        }
+        #expect(String(ersterPunkt.characters) == "Arbeitsbreite 85 cm")
+
+        guard case .bullet(let zweiterPunkt) = blocks[3] else {
+            Issue.record("Der vierte Block ist kein Aufzählungspunkt")
+            return
+        }
+        // Die Sternchen sind weg, das Wort steht noch da.
+        #expect(String(zweiterPunkt.characters) == "Benzin, Radantrieb")
+    }
+
+    @Test func ohneBeschreibungGibtEsKeinenBlock() {
+        #expect(RentalMarkdown.blocks(nil).isEmpty)
+        #expect(RentalMarkdown.blocks("   \n  ").isEmpty)
+    }
+
+    // MARK: Meine Buchungen
+
+    @Test func meineBuchungenStehenInDerReihenfolgeDieZaehlt() throws {
+        let dto: RentalBookingsDto = try Self.decode(Self.myBookingsJson)
+        let bookings = dto.bookings.asBookings(now: try Self.day("2026-09-01"))
+        #expect(bookings.map(\.deviceName) == ["AS 585 KM Kreiselmäher", "Rasenwalze"])
+
+        let erste = try #require(bookings.first)
+        #expect(erste.state == .approved)
+        #expect(erste.periodText == "Sa, 05.09.2026 – So, 06.09.2026")
+        #expect(erste.returnText == "Rückgabe: Mo, 07.09.2026")
+        #expect(erste.canCancel)
+        // Die Abholadresse steht erst nach der Zusage da — und sonst nirgends.
+        #expect(erste.pickupAddress == "Hauptstraße 1, 31171 Nordstemmen")
+        #expect(erste.pickupPhone == "+49 5069 123456")
+        #expect(bookings[1].pickupAddress == nil)
+    }
+
+    @Test func abgelaufeneBuchungenRutschenNachHinten() throws {
+        let dto: RentalBookingsDto = try Self.decode(Self.myBookingsJson)
+        let bookings = dto.bookings.asBookings(now: try Self.day("2026-09-20"))
+        // Die vergangene Buchung steht hinten, die kommende vorn.
+        #expect(bookings.map(\.deviceName) == ["Rasenwalze", "AS 585 KM Kreiselmäher"])
+    }
+
+    @Test func einUnbekannterZustandBehaeltSeinWort() {
+        #expect(RentalBookingState(raw: "pending") == .pending)
+        #expect(RentalBookingState(raw: "cancelled") == .cancelled)
+        // Nichts wird stillschweigend in einen unserer Zustände gepresst.
+        #expect(RentalBookingState(raw: "expired") == .other("expired"))
+        #expect(RentalBookingState(raw: "expired").label == "expired")
+    }
+
+    // MARK: Profil
+
+    @Test func dasProfilSagtSelbstWasIhmFehlt() throws {
+        let dto: RentalProfileEnvelopeDto = try Self.decode(Self.profileJson)
+        let profile = dto.profile.asProfile()
+        #expect(profile.name == "Erika Musterfrau")
+        #expect(profile.addressCity.isEmpty)
+        #expect(!profile.complete)
+        // Die Plattform nennt ihre Felder englisch, gelesen wird deutsch.
+        #expect(profile.missingLabels == ["Ort"])
+        // Die Vermieteransicht hängt an der Antwort der Plattform, nicht an
+        // einer Bedingung in der App.
+        #expect(!profile.showsLenderArea)
+        #expect(profile.canAskToLend)
+    }
+
+    @Test func nurEinFreigeschalteterVermieterSiehtDieVermieteransicht() {
+        let freigeschaltet = RentalProfileDto(lender: true, lenderStatus: "approved").asProfile()
+        #expect(freigeschaltet.showsLenderArea)
+        #expect(!freigeschaltet.canAskToLend)
+
+        let beantragt = RentalProfileDto(lenderStatus: "pending").asProfile()
+        #expect(!beantragt.showsLenderArea)
+        #expect(!beantragt.canAskToLend)
+    }
+
+    @Test func unbekannteFeldnamenVerschwindenNicht() {
+        #expect(RentalFieldNames.labels(["phone", "addressZip"]) == ["Telefonnummer", "Postleitzahl"])
+        #expect(RentalFieldNames.labels(["addressCountry"]) == ["addressCountry"])
+        #expect(RentalFieldNames.sentence([]) == nil)
+    }
+
+    // MARK: Fehler — die App verzweigt auf den Code, nie auf den Text
+
+    @Test func einAbgelaufenesTokenUndEinTokenOhneEmpfaengerSindZweiDinge() {
+        let abgelaufen = RentalClient.error(status: 401, data: Data("""
+        {"error": {"code": "unauthorized", "message": "Kein Token"}}
+        """.utf8))
+        #expect(abgelaufen.needsSignIn)
+        #expect(!abgelaufen.needsFreshSignIn)
+
+        // Der Fall, der dieses Projekt schon einmal getroffen hat: Das Gerät
+        // war vor der Aktualisierung angemeldet und behält seinen Tokensatz.
+        let ohneEmpfaenger = RentalClient.error(status: 401, data: Data("""
+        {"error": {"code": "token_audience", "message": "Token gilt nicht für die Mietplattform"}}
+        """.utf8))
+        #expect(ohneEmpfaenger.needsFreshSignIn)
+        #expect(!ohneEmpfaenger.needsSignIn)
+        // Die Meldung der Plattform gewinnt über unsere Vorgabe.
+        #expect(ohneEmpfaenger.message == "Token gilt nicht für die Mietplattform")
+
+        let lage = RentalTrouble(ohneEmpfaenger)
+        #expect(lage.needsFreshSignIn)
+        #expect(lage.wantsSignIn)
+    }
+
+    @Test func einUnvollstaendigesProfilSagtWasFehlt() {
+        let fehler = RentalClient.error(status: 400, data: Data("""
+        {"error": {"code": "profile_incomplete", "message": "Dein Profil ist unvollständig",
+          "missingFields": ["phone", "addressStreet", "addressZip", "addressCity"]}}
+        """.utf8))
+        #expect(fehler.code == .profileIncomplete)
+        #expect(fehler.missingFields.count == 4)
+        #expect(RentalFieldNames.labels(fehler.missingFields).first == "Telefonnummer")
+    }
+
+    @Test func ohneLesbarenKoerperSpringtDerStatusEin() {
+        // Eine Fehlerseite eines Vorschalters darf nicht wie ein
+        // Empfängerproblem aussehen — sonst schicken wir jemanden ohne Not
+        // durch eine neue Anmeldung.
+        let vorschalter = RentalClient.error(status: 401, data: Data("<html>nope</html>".utf8))
+        #expect(vorschalter.code == .unauthorized)
+        #expect(!vorschalter.needsFreshSignIn)
+
+        let serverfehler = RentalClient.error(status: 502, data: Data())
+        #expect(serverfehler.code == .serverFault)
+    }
+
+    @Test func einNeuerFehlercodeWirdGezeigtUndNichtVerschluckt() {
+        let neu = RentalClient.error(status: 409, data: Data("""
+        {"error": {"code": "seasonal_closure", "message": "Im Winter verleihen wir nicht."}}
+        """.utf8))
+        #expect(neu.code == .unknown)
+        #expect(neu.message == "Im Winter verleihen wir nicht.")
+    }
+
+    @Test func belegtIstEinEigenerFall() {
+        let belegt = RentalClient.error(status: 409, data: Data("""
+        {"error": {"code": "occupied", "message": "Zeitraum ist belegt"}}
+        """.utf8))
+        #expect(belegt.code == .occupied)
+    }
+
+    // MARK: Der Scope, ohne den kein Token gilt
+
+    @Test func derEmpfaengerScopeHatDieFormDieZitadelVerlangt() {
+        #expect(projectAudienceScope("377276525071827047")
+            == "urn:zitadel:iam:org:project:id:377276525071827047:aud")
+        // Und die Anmeldung fordert einen solchen Scope tatsächlich an —
+        // ohne ihn weist die Mietplattform jedes Token ab.
+        #expect(ANMELDE_SCOPES.contains {
+            $0.hasPrefix("urn:zitadel:iam:org:project:id:") && $0.hasSuffix(":aud")
+        })
+    }
+}
+
+// MARK: - Der Weg zur Mietplattform
+
+/// Was tatsächlich hinausginge — Pfad, Verfahren, Körper und vor allem: ob
+/// ein Token mitfährt. Abgefangen wird örtlich, es verlässt nichts das Gerät.
+struct RentalClientTests {
+    static func client(_ token: Tokenlage = .token("abc")) -> RentalClient {
+        let k = URLSessionConfiguration.ephemeral
+        k.protocolClasses = [RentalStub.self]
+        return RentalClient(
+            base: URL(string: "http://127.0.0.1:8099")!,
+            session: URLSession(configuration: k),
+            tokenProvider: { token }
+        )
+    }
+
+    @Test func derKatalogGehtOhneToken() async throws {
+        RentalStub.reset()
+        RentalStub.answer = (200, Data(RentalTests.itemsJson.utf8))
+
+        let items = try await Self.client().items()
+        #expect(items.count == 2)
+
+        let request = try #require(RentalStub.lastRequest)
+        #expect(request.url?.path == "/api/v1/items")
+        // Umsehen geht ohne Anmeldung — und ein Token an eine öffentliche
+        // Route wäre eine unnötige Preisgabe. Vor allem aber bräche der
+        // Katalog sonst genau für die, die schon angemeldet sind.
+        #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+
+    @Test func dieVerfuegbarkeitFragtMitDenParameternDesVertrags() async throws {
+        RentalStub.reset()
+        RentalStub.answer = (200, Data(#"{"available": false, "reason": "occupied"}"#.utf8))
+
+        let answer = try await Self.client().availability(
+            deviceId: "rasenwalze", startDate: "2026-09-05", endDate: "2026-09-07"
+        )
+        #expect(!answer.available)
+        #expect(answer.reason == "occupied")
+
+        let request = try #require(RentalStub.lastRequest)
+        #expect(request.url?.path == "/api/v1/availability")
+        let query = try #require(request.url?.query())
+        #expect(query.contains("deviceId=rasenwalze"))
+        #expect(query.contains("startDate=2026-09-05"))
+        #expect(query.contains("endDate=2026-09-07"))
+        #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+
+    @Test func meineBuchungenNehmenDasTokenMit() async throws {
+        RentalStub.reset()
+        RentalStub.answer = (200, Data(RentalTests.myBookingsJson.utf8))
+
+        _ = try await Self.client().myBookings()
+        let request = try #require(RentalStub.lastRequest)
+        #expect(request.url?.path == "/api/v1/bookings/mine")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer abc")
+    }
+
+    @Test func ohneAnmeldungFragtDieAppGarNichtErstNach() async throws {
+        RentalStub.reset()
+        RentalStub.answer = (200, Data("{}".utf8))
+
+        await #expect(throws: RentalError.self) {
+            _ = try await Self.client(.abgemeldet).myBookings()
+        }
+        // Es ist nichts hinausgegangen: Der Fehler entsteht vor der Anfrage.
+        #expect(RentalStub.lastRequest == nil)
+    }
+
+    @Test func einFunklochIstKeineAbgelaufeneAnmeldung() async throws {
+        RentalStub.reset()
+        RentalStub.answer = (200, Data("{}".utf8))
+
+        do {
+            _ = try await Self.client(.nichtErreichbar).myBookings()
+            Issue.record("Es hätte einen Fehler geben müssen")
+        } catch let fehler as RentalError {
+            // „Ich konnte nicht fragen" darf niemanden abmelden.
+            #expect(!fehler.needsSignIn)
+            #expect(!fehler.needsFreshSignIn)
+        }
+    }
+
+    @Test func eineBuchungSchicktGenauDasWasDerVertragVerlangt() async throws {
+        RentalStub.reset()
+        RentalStub.answer = (201, Data("""
+        {"booking": {"id": "neu", "deviceId": "rasenwalze", "deviceName": "Rasenwalze",
+          "startDate": "2026-09-05", "endDate": "2026-09-07", "status": "pending",
+          "canCancel": true}}
+        """.utf8))
+
+        let booking = try await Self.client().book(RentalBookingRequestDto(
+            deviceId: "rasenwalze", startDate: "2026-09-05", endDate: "2026-09-07",
+            notes: "Hole ich früh ab."
+        ))
+        #expect(booking.id == "neu")
+
+        let request = try #require(RentalStub.lastRequest)
+        #expect(request.httpMethod == "POST")
+        #expect(request.url?.path == "/api/v1/bookings")
+        let body = try #require(RentalStub.lastBody)
+        let gelesen = try #require(
+            try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        #expect(gelesen["deviceId"] as? String == "rasenwalze")
+        #expect(gelesen["endDate"] as? String == "2026-09-07")
+        // Name und Nummer holt der Server aus dem Profil — abtippen lassen
+        // wir niemanden.
+        #expect(!gelesen.keys.contains("firstName"))
+        #expect(!gelesen.keys.contains("phone"))
+        #expect(!gelesen.keys.contains("setId"))
+    }
+
+    @Test func eineFehlerseiteGehtNichtAlsLeereListeDurch() async throws {
+        RentalStub.reset()
+        RentalStub.answer = (200, Data("<html>Wartung</html>".utf8))
+
+        do {
+            _ = try await Self.client().items()
+            Issue.record("Eine Fehlerseite darf nicht als Katalog durchgehen")
+        } catch let fehler as RentalError {
+            #expect(fehler == .unreadable)
+        }
+    }
+
+    @Test func dasProfilAendernSchicktNurWasDasteht() async throws {
+        RentalStub.reset()
+        RentalStub.answer = (200, Data(RentalTests.profileJson.utf8))
+
+        _ = try await Self.client().updateProfile(RentalProfilePatchDto(
+            phone: "+49 5069 123456", addressCity: "Nordstemmen"
+        ))
+        let request = try #require(RentalStub.lastRequest)
+        #expect(request.httpMethod == "PATCH")
+        let body = try #require(RentalStub.lastBody)
+        let gelesen = try #require(
+            try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        #expect(gelesen["phone"] as? String == "+49 5069 123456")
+        #expect(gelesen["addressCity"] as? String == "Nordstemmen")
+        // Was nicht ausgefüllt wurde, wird auch nicht überschrieben.
+        #expect(!gelesen.keys.contains("name"))
+        #expect(!gelesen.keys.contains("addressStreet"))
+        // Die E-Mail-Adresse kommt aus der Rössing-ID und geht gar nicht mit.
+        #expect(!gelesen.keys.contains("email"))
+    }
+
+    @Test func einSperrwunschNenntSeinGeraet() async throws {
+        RentalStub.reset()
+        RentalStub.answer = (201, Data("""
+        {"block": {"id": "b1", "deviceId": "rasenwalze", "deviceName": "Rasenwalze",
+          "startDate": "2026-10-01", "endDate": "2026-10-08", "reason": "Eigener Einsatz"}}
+        """.utf8))
+
+        let block = try await Self.client().addBlock(RentalBlockRequestDto(
+            deviceId: "rasenwalze", startDate: "2026-10-01", endDate: "2026-10-08",
+            reason: "Eigener Einsatz"
+        ))
+        #expect(block.id == "b1")
+        let request = try #require(RentalStub.lastRequest)
+        #expect(request.url?.path == "/api/v1/owner/blocks")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer abc")
+    }
+
+    @Test func eineSperreAufhebenIstEinLoeschen() async throws {
+        RentalStub.reset()
+        RentalStub.answer = (200, Data(#"{"deleted": true}"#.utf8))
+
+        try await Self.client().removeBlock(id: "b1")
+        let request = try #require(RentalStub.lastRequest)
+        #expect(request.httpMethod == "DELETE")
+        #expect(request.url?.path == "/api/v1/owner/blocks/b1")
+    }
+}
+
+// MARK: - Der Zustand der Ansichten
+
+@MainActor
+struct RentalModelTests {
+    /// Eine Quelle, die nichts kann außer dem, was der Test ihr sagt. Alles
+    /// Unbenutzte scheitert laut — ein Modell, das heimlich etwas anderes
+    /// abruft, fällt damit auf.
+    static func source(
+        items: @escaping @MainActor () async throws -> [RentalItemDto] = { [] },
+        item: @escaping @MainActor (String) async throws -> RentalItemDto = { _ in
+            RentalItemDto()
+        },
+        search: @escaping @MainActor (String) async throws -> [RentalItemDto] = { _ in [] },
+        sets: @escaping @MainActor () async throws -> [RentalSetDto] = { [] },
+        availability: @escaping @MainActor (String, String, String) async throws
+            -> RentalAvailabilityDto = { _, _, _ in RentalAvailabilityDto() },
+        occupancy: @escaping @MainActor (String?) async throws -> [RentalPeriodDto] = { _ in [] },
+        profile: @escaping @MainActor () async throws -> RentalProfileDto = {
+            RentalProfileDto()
+        },
+        updateProfile: @escaping @MainActor (RentalProfilePatchDto) async throws
+            -> RentalProfileDto = { _ in RentalProfileDto() },
+        requestLender: @escaping @MainActor () async throws -> RentalLenderRequestDto = {
+            RentalLenderRequestDto()
+        },
+        myBookings: @escaping @MainActor () async throws -> [RentalBookingDto] = { [] },
+        book: @escaping @MainActor (RentalBookingRequestDto) async throws -> RentalBookingDto = {
+            _ in RentalBookingDto()
+        },
+        cancel: @escaping @MainActor (String) async throws -> Void = { _ in },
+        ownerBookings: @escaping @MainActor () async throws -> [RentalOwnerBookingDto] = { [] },
+        approve: @escaping @MainActor (String) async throws -> Void = { _ in },
+        reject: @escaping @MainActor (String) async throws -> Void = { _ in },
+        ownerItems: @escaping @MainActor () async throws -> [RentalItemDto] = { [] },
+        blocks: @escaping @MainActor () async throws -> [RentalBlockDto] = { [] },
+        addBlock: @escaping @MainActor (RentalBlockRequestDto) async throws -> RentalBlockDto = {
+            _ in RentalBlockDto()
+        },
+        removeBlock: @escaping @MainActor (String) async throws -> Void = { _ in }
+    ) -> RentalSource {
+        RentalSource(
+            items: items, item: item, search: search, sets: sets,
+            availability: availability, occupancy: occupancy,
+            profile: profile, updateProfile: updateProfile, requestLender: requestLender,
+            myBookings: myBookings, book: book, cancel: cancel,
+            ownerBookings: ownerBookings, approve: approve, reject: reject,
+            ownerItems: ownerItems, blocks: blocks, addBlock: addBlock, removeBlock: removeBlock
+        )
+    }
+
+    static let geraet = RentalItemDto(id: "rasenwalze", name: "Rasenwalze", pricePerDay: 8)
+    static let maeher = RentalItemDto(id: "maeher", name: "Kreiselmäher", pricePerDay: 25)
+
+    static func fehler(_ code: String, status: Int = 400) -> RentalError {
+        RentalClient.error(
+            status: status,
+            data: Data(#"{"error": {"code": "\#(code)", "message": ""}}"#.utf8)
+        )
+    }
+
+    static func day(_ text: String) throws -> Date {
+        try #require(RentalDay.parse(text))
+    }
+
+    // MARK: Katalog
+
+    @Test func einFehlerIstNichtNichtsDa() async throws {
+        // Erst eine Liste, dann ein Ausfall: Die Liste bleibt stehen, und
+        // darüber steht, dass sie alt sein könnte. Eine leere Seite ohne
+        // Erklärung wäre die schlechteste Antwort.
+        let ausfall = Schalter()
+        let model = RentalCatalogModel(source: Self.source(items: {
+            if await ausfall.an { throw RentalError.network("kaputt") }
+            return [Self.geraet, Self.maeher]
+        }))
+
+        await model.load()
+        #expect(model.devices.count == 2)
+        #expect(model.hint == nil)
+
+        await ausfall.einschalten()
+        await model.refresh()
+
+        #expect(model.devices.count == 2)
+        #expect(model.hint?.contains("nicht mehr aktuell") == true)
+        #expect(!model.empty)
+    }
+
+    @Test func ohneGeraeteUndOhneFehlerIstWirklichNichtsDa() async {
+        let model = RentalCatalogModel(source: Self.source())
+        await model.load()
+        #expect(model.empty)
+        #expect(model.hint == nil)
+    }
+
+    @Test func ohneListeNenntDerHinweisDenGrund() async {
+        let model = RentalCatalogModel(source: Self.source(items: {
+            throw Self.fehler("internal", status: 500)
+        }))
+        await model.load()
+        #expect(model.devices.isEmpty)
+        #expect(model.hint?.isEmpty == false)
+        // „Fehler" heißt nicht „nichts da".
+        #expect(!model.empty)
+    }
+
+    @Test func dieReihenfolgeDerSucheBleibtWieSieKam() async {
+        // Die Plattform sortiert nach Passung; wir sortieren nicht um.
+        let model = RentalCatalogModel(source: Self.source(
+            items: { [Self.geraet, Self.maeher] },
+            search: { _ in [Self.maeher, Self.geraet] }
+        ))
+        await model.load()
+        model.query = "rasen"
+        await model.runSearch()
+
+        #expect(model.visible.map(\.id) == ["maeher", "rasenwalze"])
+        #expect(!model.withoutMatch)
+    }
+
+    @Test func ohneSucheDerPlattformWirdDasDurchsuchtWasSchonDaIst() async {
+        let model = RentalCatalogModel(source: Self.source(
+            items: { [Self.geraet, Self.maeher] },
+            search: { _ in throw RentalError.network("kaputt") }
+        ))
+        await model.load()
+        model.query = "walze"
+        await model.runSearch()
+
+        #expect(model.visible.map(\.id) == ["rasenwalze"])
+        // Und es steht dran, dass hier etwas anderes passiert ist.
+        #expect(model.hint?.contains("Suche des Maschinchenrings") == true)
+    }
+
+    @Test func einLeeresSuchfeldZeigtWiederAlles() async {
+        let model = RentalCatalogModel(source: Self.source(
+            items: { [Self.geraet, Self.maeher] },
+            search: { _ in [Self.maeher] }
+        ))
+        await model.load()
+        model.query = "mäher"
+        await model.runSearch()
+        #expect(model.visible.count == 1)
+
+        model.query = "   "
+        await model.runSearch()
+        #expect(model.visible.count == 2)
+        #expect(!model.withoutMatch)
+    }
+
+    @Test func keinTrefferIstKeinFehler() async {
+        let model = RentalCatalogModel(source: Self.source(
+            items: { [Self.geraet] }, search: { _ in [] }
+        ))
+        await model.load()
+        model.query = "bagger"
+        await model.runSearch()
+        #expect(model.visible.isEmpty)
+        #expect(model.withoutMatch)
+    }
+
+    // MARK: Ein Gerät
+
+    @Test func dieAntwortGiltNurFuerDenZeitraumFuerDenSieKam() async throws {
+        let model = RentalDeviceModel(
+            device: try #require(Self.geraet.asDevice()),
+            source: Self.source(availability: { _, _, _ in
+                RentalAvailabilityDto(available: true)
+            }),
+            now: { try! Self.day("2026-09-05") }
+        )
+        model.setLastDay(try Self.day("2026-09-06"))
+        await model.check()
+
+        #expect(model.answer?.free == true)
+        #expect(model.canBook)
+        // Der Rückgabetag ist der Tag nach dem letzten Leihtag.
+        #expect(model.endDate == "2026-09-07")
+
+        // Wer die Tage verschiebt, hat keine Antwort mehr — sonst bucht
+        // jemand ein freies Wochenende auf einem belegten.
+        model.setLastDay(try Self.day("2026-09-10"))
+        #expect(model.answer == nil)
+        #expect(!model.canBook)
+    }
+
+    @Test func ohneJaDerPlattformBleibtDerKnopfAus() async throws {
+        let model = RentalDeviceModel(
+            device: try #require(Self.geraet.asDevice()),
+            source: Self.source(availability: { _, _, _ in
+                RentalAvailabilityDto(available: false, reason: "occupied")
+            }),
+            now: { try! Self.day("2026-09-05") }
+        )
+        await model.check()
+        #expect(model.answer?.free == false)
+        #expect(!model.canBook)
+        #expect(model.answer?.message.contains("vergeben") == true)
+    }
+
+    @Test func einWettlaufIstKeinAbsturz() async throws {
+        // Zwischen dem Zeichnen des Kalenders und dem Tippen kann eine Minute
+        // liegen. Dann sagt die Plattform „belegt" — und die App holt den
+        // Kalender neu, statt zu behaupten, es habe geklappt.
+        let neuGeholt = Schalter()
+        let model = RentalDeviceModel(
+            device: try #require(Self.geraet.asDevice()),
+            source: Self.source(
+                availability: { _, _, _ in RentalAvailabilityDto(available: true) },
+                occupancy: { _ in
+                    await neuGeholt.einschalten()
+                    return []
+                },
+                book: { _ in throw Self.fehler("occupied", status: 409) }
+            ),
+            now: { try! Self.day("2026-09-05") }
+        )
+        await model.check()
+        #expect(model.canBook)
+
+        await model.book()
+        #expect(model.confirmed == nil)
+        #expect(model.trouble?.code == .occupied)
+        #expect(model.answer == nil)
+        #expect(await neuGeholt.an)
+    }
+
+    @Test func einUnvollstaendigesProfilFuehrtWeiterStattZuSchweigen() async throws {
+        let model = RentalDeviceModel(
+            device: try #require(Self.geraet.asDevice()),
+            source: Self.source(
+                availability: { _, _, _ in RentalAvailabilityDto(available: true) },
+                book: { _ in
+                    throw RentalClient.error(status: 400, data: Data("""
+                    {"error": {"code": "profile_incomplete", "message": "Dein Profil ist unvollständig",
+                      "missingFields": ["phone", "addressCity"]}}
+                    """.utf8))
+                }
+            ),
+            now: { try! Self.day("2026-09-05") }
+        )
+        await model.check()
+        await model.book()
+
+        #expect(model.missingProfileFields == ["Telefonnummer", "Ort"])
+        #expect(model.trouble?.code == .profileIncomplete)
+    }
+
+    @Test func eineGebuchteAnfrageBleibtAufDemSchirm() async throws {
+        let model = RentalDeviceModel(
+            device: try #require(Self.geraet.asDevice()),
+            source: Self.source(
+                availability: { _, _, _ in RentalAvailabilityDto(available: true) },
+                book: { wunsch in
+                    RentalBookingDto(
+                        id: "neu", deviceId: wunsch.deviceId, deviceName: "Rasenwalze",
+                        startDate: wunsch.startDate, endDate: wunsch.endDate,
+                        status: "pending", canCancel: true
+                    )
+                }
+            ),
+            now: { try! Self.day("2026-09-05") }
+        )
+        await model.check()
+        await model.book()
+
+        #expect(model.confirmed?.id == "neu")
+        #expect(model.confirmed?.state == .pending)
+        // Zweimal buchen geht nicht.
+        #expect(!model.canBook)
+    }
+
+    // MARK: Meine Buchungen
+
+    @Test func einAbgelehntesStornoNimmtKeineZeileWeg() async throws {
+        let model = RentalBookingsModel(
+            source: Self.source(
+                myBookings: {
+                    [RentalBookingDto(id: "b1", deviceName: "Rasenwalze",
+                                      startDate: "2026-09-05", endDate: "2026-09-07",
+                                      status: "approved", canCancel: true)]
+                },
+                cancel: { _ in throw Self.fehler("conflict", status: 409) }
+            ),
+            now: { try! Self.day("2026-09-01") }
+        )
+        await model.load()
+        #expect(model.bookings.count == 1)
+
+        await model.cancel(try #require(model.bookings.first))
+        // Eine Zeile, die verschwindet, während die Plattform die Buchung
+        // noch hält, fällt erst auf, wenn das Gerät weg ist.
+        #expect(model.bookings.count == 1)
+        #expect(model.hint?.isEmpty == false)
+    }
+
+    @Test func einTokenOhneEmpfaengerFuehrtZurNeuenAnmeldung() async {
+        let model = RentalBookingsModel(source: Self.source(myBookings: {
+            throw Self.fehler("token_audience", status: 401)
+        }))
+        await model.load()
+
+        #expect(model.bookings.isEmpty)
+        // Keine leere Liste ohne Erklärung: Der Bildschirm bietet die neue
+        // Anmeldung an.
+        #expect(model.needsSignIn)
+        #expect(model.trouble?.needsFreshSignIn == true)
+        #expect(!model.empty)
+    }
+
+    // MARK: Vermieter
+
+    @Test func offeneAnfragenStehenOben() async throws {
+        let model = RentalOwnerModel(
+            source: Self.source(ownerBookings: {
+                [
+                    RentalOwnerBookingDto(id: "alt", deviceName: "Rasenwalze",
+                                          startDate: "2026-09-01", endDate: "2026-09-02",
+                                          status: "approved", canCancel: true),
+                    RentalOwnerBookingDto(id: "offen", deviceName: "Kreiselmäher",
+                                          startDate: "2026-10-01", endDate: "2026-10-03",
+                                          status: "pending", canDecide: true, canCancel: true),
+                ]
+            }),
+            now: { try! Self.day("2026-09-15") }
+        )
+        await model.load()
+        #expect(model.bookings.map(\.id) == ["offen", "alt"])
+        #expect(model.waiting == 1)
+    }
+
+    @Test func nachEinerZusageZaehltWiederDieListeDerPlattform() async throws {
+        let zugesagt = Schalter()
+        let model = RentalOwnerModel(
+            source: Self.source(
+                ownerBookings: {
+                    if await zugesagt.an {
+                        return [RentalOwnerBookingDto(id: "b1", deviceName: "Rasenwalze",
+                                                      startDate: "2026-10-01", endDate: "2026-10-03",
+                                                      status: "approved", canCancel: true)]
+                    }
+                    return [RentalOwnerBookingDto(id: "b1", deviceName: "Rasenwalze",
+                                                  startDate: "2026-10-01", endDate: "2026-10-03",
+                                                  status: "pending", canDecide: true)]
+                },
+                approve: { _ in await zugesagt.einschalten() }
+            ),
+            now: { try! Self.day("2026-09-15") }
+        )
+        await model.load()
+        #expect(model.bookings.first?.canDecide == true)
+
+        await model.approve(try #require(model.bookings.first))
+        #expect(model.bookings.first?.state == .approved)
+        #expect(model.bookings.first?.canDecide == false)
+    }
+
+    @Test func eineSperreNenntDenRueckgabetag() async throws {
+        let gesendet = Merker()
+        let model = RentalOwnerModel(
+            source: Self.source(addBlock: { wunsch in
+                await gesendet.merken(wunsch.endDate)
+                return RentalBlockDto(id: "b1", deviceId: wunsch.deviceId,
+                                      startDate: wunsch.startDate, endDate: wunsch.endDate)
+            }),
+            now: { try! Self.day("2026-09-15") }
+        )
+        let erfolg = await model.block(
+            deviceId: "rasenwalze",
+            firstDay: try Self.day("2026-10-01"),
+            lastDay: try Self.day("2026-10-07"),
+            reason: ""
+        )
+        #expect(erfolg)
+        // Letzter Tag der Sperre ist der 7., zurück gibt es das Gerät am 8.
+        #expect(await gesendet.wert == "2026-10-08")
+    }
+
+    // MARK: Profil
+
+    @Test func dasProfilFuelltDasFormularUndNimmtNurWasDasteht() async {
+        let gesendet = Merker()
+        let model = RentalProfileModel(source: Self.source(
+            profile: {
+                RentalProfileDto(name: "Erika", email: "erika@example.de", phone: nil,
+                                 addressStreet: "Hauptstraße 1", addressZip: "31171",
+                                 addressCity: nil, profileComplete: false,
+                                 missingFields: ["phone", "addressCity"])
+            },
+            updateProfile: { patch in
+                await gesendet.merken(patch.phone ?? "")
+                return RentalProfileDto(name: patch.name, phone: patch.phone,
+                                        profileComplete: true)
+            }
+        ))
+        await model.load()
+        #expect(model.name == "Erika")
+        #expect(model.phone.isEmpty)
+        #expect(model.missingLabels == ["Telefonnummer", "Ort"])
+
+        model.phone = "+49 5069 123456"
+        let gespeichert = await model.save()
+        #expect(gespeichert)
+        #expect(await gesendet.wert == "+49 5069 123456")
+        #expect(model.profile?.complete == true)
+    }
+
+    @Test func nachDerAnfrageAlsVermieterStehtDieAntwortDerPlattformDa() async {
+        let model = RentalProfileModel(source: Self.source(
+            profile: { RentalProfileDto(lenderStatus: "pending") },
+            requestLender: {
+                RentalLenderRequestDto(
+                    lenderStatus: "pending",
+                    message: "Deine Anfrage wurde weitergeleitet."
+                )
+            }
+        ))
+        await model.load()
+        await model.askToLend()
+        // Der Satz der Plattform, unverändert.
+        #expect(model.lenderMessage == "Deine Anfrage wurde weitergeleitet.")
+        #expect(model.profile?.lenderStatus == .pending)
+        #expect(model.profile?.showsLenderArea == false)
+    }
+}
+
+// MARK: - Kleine Helfer für die Tests
+
+/// Ein Schalter, den eine Quelle über Aktorgrenzen hinweg umlegen kann.
+private actor Schalter {
+    private(set) var an = false
+    func einschalten() { an = true }
+}
+
+/// Merkt sich einen Wert, den eine Quelle bekommen hat.
+private actor Merker {
+    private(set) var wert = ""
+    func merken(_ neu: String) { wert = neu }
+}
+
+/// Örtliche Ablage statt Netz: Die Anfrage wird abgefangen und beantwortet,
+/// ohne das Gerät zu verlassen. Kein Test darf nach draußen.
+private nonisolated final class RentalStub: URLProtocol {
+    nonisolated(unsafe) static var answer: (Int, Data) = (200, Data())
+    nonisolated(unsafe) static var lastRequest: URLRequest?
+    nonisolated(unsafe) static var lastBody: Data?
+
+    static func reset() {
+        answer = (200, Data())
+        lastRequest = nil
+        lastBody = nil
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        RentalStub.lastRequest = request
+        // `URLSession` schiebt den Körper in einen Datenstrom um, bevor der
+        // Protokollhandler ihn sieht — deshalb beide Wege.
+        RentalStub.lastBody = request.httpBody ?? request.httpBodyStream.map { strom in
+            strom.open()
+            defer { strom.close() }
+            var gesammelt = Data()
+            var puffer = [UInt8](repeating: 0, count: 4096)
+            while strom.hasBytesAvailable {
+                let gelesen = strom.read(&puffer, maxLength: puffer.count)
+                if gelesen <= 0 { break }
+                gesammelt.append(contentsOf: puffer[0 ..< gelesen])
+            }
+            return gesammelt
+        }
+
+        let (status, daten) = RentalStub.answer
+        let kopf = HTTPURLResponse(
+            url: request.url ?? URL(string: "http://127.0.0.1")!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json; charset=utf-8"]
+        )!
+        client?.urlProtocol(self, didReceive: kopf, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: daten)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/ios/Makefile
+++ b/ios/Makefile
@@ -10,7 +10,8 @@ SCHEME    ?= Dorf
 LOKALE_ADRESSEN = API_BASE_URL=http://127.0.0.1:8099 \
 	WEBSITE_BASE_URL=http://127.0.0.1:8097 \
 	OIDC_ISSUER=http://127.0.0.1:8123 \
-	MAP_STYLE_URL=http://127.0.0.1:8097/map-style.json
+	MAP_STYLE_URL=http://127.0.0.1:8097/map-style.json \
+	RENTAL_BASE_URL=http://127.0.0.1:8098
 
 # Auslieferung nach TestFlight. Dieselben Werte wie in
 # .github/workflows/ios-release.yml — wer es von Hand macht, soll dasselbe tun

--- a/ios/OFFEN.md
+++ b/ios/OFFEN.md
@@ -61,6 +61,34 @@ Adressen, damit niemand vor einer leeren Stelle steht.
   (`xcrun simctl push <geräte-id> de.roessing.app <datei.apns>`) — der Weg
   über Apple braucht ein echtes iPhone.
 
+### Maschinchenring — was der Bereich bewusst nicht kann
+
+Der Verleih ist ein **eigener Dienst** (`mieten.…`) mit eigenem Vertrag
+(`docs/mieten-api.md`). Was dort nicht steht, gibt es hier auch nicht — und
+zwar mit Absicht, nicht aus Vergesslichkeit:
+
+- **Geräte anlegen oder ändern.** Die Schnittstelle kennt es nicht; es läuft
+  über den Chat und die Webfassung des Maschinchenrings und soll dort
+  bleiben. Die Vermieteransicht sagt das und führt hinüber.
+- **Sets buchen.** Sets werden angezeigt, nicht gebucht: Stornieren,
+  Zusagen und Absagen einer Set-Buchung ist serverseitig noch nicht
+  umgesetzt und antwortet mit `409`. Eine Buchungsstrecke, deren Rückweg
+  fehlt, wäre eine Falle.
+- **Eine Preissumme.** Der Server rechnet keine aus, und welcher Tarif bei
+  welcher Dauer gilt, steht nirgends. Die App zeigt deshalb **alle** Tarife
+  untereinander und rechnet nichts. Eine erfundene Regel wäre genau der
+  Bruch zwischen Web und App, den wir vermeiden.
+- **Push für Buchungsanfragen.** Läuft heute ausschließlich über E-Mail; das
+  ist ein eigenes Paket und setzt voraus, dass die Mietplattform weiß, an
+  welches Gerät sie senden soll.
+- **Bilder hochladen.** Es gibt einen Endpunkt drüben, er ist aber nicht Teil
+  des Vertrags.
+- **Vermieter freischalten.** Entscheidet die Verwaltung des
+  Maschinchenrings von Hand in der Webfassung. Die App kann nur fragen
+  (Route 9) und den Stand zeigen.
+- **Eine Karte der Abholorte.** Adressen stehen nur in einer bestätigten
+  eigenen Buchung; sie irgendwo zu sammeln wäre gegen den Sinn dieser Regel.
+
 ## Kleinere Lücken
 
 - **Termine auf der Dorfkarte.** `Termin.koordinate` ist gefüllt, sobald die
@@ -161,6 +189,15 @@ Diese Punkte liegen außerhalb von `ios/` und wurden hier nur aufgeschrieben.
 
 **Noch offen:**
 
+- **Der Maschinchenring auf Android.** Die iOS-Fassung des Bereichs steht;
+  die Android-Fassung baut jemand anderes gegen denselben Vertrag
+  (`docs/mieten-api.md`). Bis sie liegt, sind die beiden Apps **nicht** auf
+  demselben Stand — das ist der ausdrückliche Vorbehalt aus `CLAUDE.md`,
+  „Android und iOS bleiben auf demselben Stand", und kein Versehen.
+  Ausgeliefert werden sollte erst, wenn beide Fassungen da sind; sonst sieht
+  der Nachbar mit dem anderen Telefon etwas anderes.
+- **`README.md`** im Wurzelverzeichnis nennt den Maschinchenring noch nicht
+  als zweiten Dienst neben Backend und Website.
 - **`backend/SICHERHEIT.md`**, Punkt 3 der Liste („Push ist da — und damit
   ist Google beteiligt") beschreibt weiterhin nur den Firebase-Weg. Der
   iOS-Weg steht inzwischen weiter unten in einem eigenen Abschnitt, aber

--- a/ios/README.md
+++ b/ios/README.md
@@ -40,7 +40,7 @@ Wer eine Datei hinzufügt, ruft danach `make projekt` auf.
 
 `make testen` setzt alle vier Adressen auf den eigenen Rechner um — dieselben
 Werte wie `.github/workflows/ios.yml`. Der letzte grüne CI-Lauf meldet
-**154 Tests in 10 Suiten**.
+**228 Tests in 15 Suiten**.
 
 ### Zwei Fallstricke, die Zeit gekostet haben
 
@@ -109,7 +109,8 @@ viele Orte gerade warten, und bei Hitze einen Hinweis.
 |---|---|
 | **Mithelfen** | Orte als Karte oder Liste, Ampel je Aufgabe, Ortsdetail mit Plan, letzter Erledigung und Historie; melden nach Rückfrage, zurücknehmen; „Ich helfe hier mit" trägt als Helfer:in ein |
 | **Dorfkarte** (keine eigene Seite, sondern Teil von „Mithelfen") | MapLibre mit den Orten als Ampel-Nadeln, eigener Standort, Tipp auf eine Nadel öffnet den Ort |
-| **Was ist los in Rössing** | Termine aus `events.json` der Website — der einzige Abruf **ohne** Zugangstoken |
+| **Was ist los in Rössing** | Termine aus `events.json` der Website — ein Abruf **ohne** Zugangstoken |
+| **Maschinchenring** | Der Verleih des Dorfes (`mieten.…`, ein **zweiter** Dienst neben dem Backend): Geräte durchsehen und suchen ohne Anmeldung, Belegung sehen, mit Rössing-ID buchen, eigene Buchungen sehen und zurückziehen, Profil dort pflegen; für Freigeschaltete die Vermieteransicht (zusagen, absagen, Zeiträume sperren). Geräte anlegen bleibt beim Maschinchenring selbst |
 | **Rangliste** | Was das Dorf geschafft hat, wer wie viel, wo man selbst steht; fünf Zeiträume. Ohne Punkte und ohne Abzeichen für Versäumtes |
 | **Anfragen und Hinweise** | Die Vergabe: wer gerade gefragt ist, zusagen und wieder abgeben, Hinweise bestätigen |
 | **Mein Profil** | Eigene Angaben mit Sichtbarkeitsschaltern, die in Worten sagen, wer ein Feld sieht. Telefon, E-Mail und Notiz sind vorbelegt **nicht** öffentlich |
@@ -158,6 +159,21 @@ Angefordert wird beim Login zusätzlich der Scope
 `urn:zitadel:iam:org:projects:roles` („projects", Plural). Ohne ihn stellt
 Zitadel ein Token **ganz ohne Rollen** aus — dann ist niemand Verwaltung.
 
+Dazu kommt der **Empfänger-Scope der Mietplattform**:
+`urn:zitadel:iam:org:project:id:<RENTAL_PROJECT_ID>:aud`. Ein Token gilt nur
+für die Projekte, die in seiner `aud` stehen; ohne diesen Scope antwortet
+`mieten.…` auf jede angemeldete Route mit `401 token_audience`. Die
+Projekt-Kennung steht in `project.yml` (`RENTAL_PROJECT_ID`), nicht im
+Quelltext.
+
+**Der Stolperstein dabei:** Ein Gerät, das schon angemeldet ist, behält
+seinen Tokensatz über die Aktualisierung hinweg — es bekommt also weiter
+Token *ohne* den neuen Empfänger, und eine Erneuerung ändert daran nichts;
+Zitadel legt Empfänger nur bei der Autorisierung fest. Deshalb erkennt der
+Bereich `token_audience` am Code (nicht am Text, nicht am Status) und bietet
+eine **neue Anmeldung** an, statt eine leere Liste zu zeigen. Der Katalog ist
+davon unberührt: Er kommt ohne Token.
+
 `offline_access` hält die Sitzung über den Neustart hinweg; die Tokens liegen
 im Schlüsselbund. Der Entwickler-Login ohne Zitadel gibt es nur im
 Debug-Build und nur mit `DEV_AUTH=1` — in einem Release-Build ist er hart
@@ -176,8 +192,21 @@ jeder Bereich seinen eigenen Transport gebaut, und Fristen, Kopfzeilen und
 Fehlerübersetzung liefen auseinander. Wer einen Endpunkt ergänzt, benutzt
 die Helfer und schreibt das DTO zu den übrigen in `Modelle.swift`.
 
-Einzige Ausnahme ist der Terminfeed: `events.json` der Website ist öffentlich
-und wird ohne Zugangstoken gelesen.
+Ausgenommen sind die **anderen Dienste** — und nur die. „Genau ein Weg zum
+Backend" heißt: zum Dorf-Backend. Was nicht dort wohnt, hat einen eigenen
+kleinen Client, sonst müsste `DorfApi` fremde Fehlerformen und fremde
+Anmeldungen mitschleppen:
+
+| Dienst | Client | Token |
+|---|---|---|
+| Website (`events.json`) | `Bereiche/Veranstaltungen/Veranstaltungen.swift` | nein — die Seite ist öffentlich |
+| Maschinchenring (`mieten.…`) | `Bereiche/Rental/RentalClient.swift` | nur auf den Routen, die eines verlangen |
+
+Beim Maschinchenring ist das keine Sparsamkeit: Katalog, Suche, Sets,
+Verfügbarkeit und Belegung sind dort öffentlich. Ginge das Token überall
+mit, bräche das Umsehen genau für die, die schon angemeldet sind — nämlich
+für jedes Gerät, dessen Token die Mietplattform noch nicht als Empfänger
+kennt (siehe unten).
 
 ## Push-Benachrichtigungen
 

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -44,6 +44,15 @@ settings:
     OIDC_REDIRECT_URI: de.roessing.app:/oauth2redirect
     OIDC_LOGOUT_REDIRECT_URI: de.roessing.app:/logout
     MAP_STYLE_URL: https://tiles.openfreemap.org/styles/liberty
+    # Die Mietplattform („Maschinchenring") ist ein eigener Dienst neben dem
+    # Backend — die App spricht unmittelbar mit ihr (docs/mietplattform-in-den-apps.md,
+    # AP 4). Deshalb eine zweite Adresse, und deshalb steht sie hier und nicht
+    # im Quelltext.
+    RENTAL_BASE_URL: https://mieten.xn--rssing-wxa.de
+    # Zitadel-Projekt „Mietplattform". Es muss als Empfänger im Token stehen,
+    # sonst weist die Mietplattform jedes Token dieser App ab (AP 2). Die
+    # Kennung wird zum Scope urn:zitadel:iam:org:project:id:<id>:aud.
+    RENTAL_PROJECT_ID: "377276525071827047"
     # Entwickler-Login (ohne Zitadel) — nur zusammen mit einem Backend im
     # AUTH_MODE=insecure-dev. In Release-Builds hart aus, siehe Konfiguration.swift.
     DEV_AUTH: "0"


### PR DESCRIPTION
Fixes #72

Der Verleih des Dorfes ist ein Bereich der iOS-App. Der Zweig setzt auf dem WIP-Stand „WIP iOS: Bereich Verleih" auf, ist auf `origin/main` rebased und dann gegen den inzwischen vorliegenden Vertrag (`docs/mieten-api.md`) **neu gebaut**: Der WIP hatte Routen und Feldnamen raten müssen (`/api/v1/items/{id}/availability`, `itemId`, `from`/`to`, `bookable`, `priceText`, `ownerName` …) — davon stimmt fast nichts. Vertrag, Client, Aufbereitung und Modelle sind ersetzt; Zuschnitt und Haltung des WIP (eigener Client, „ein Fehler ist nicht nichts da", Knöpfe folgen dem Server) sind geblieben.

## Was der Bereich kann

**Ohne Anmeldung** — die Routen sind drüben öffentlich, und es geht **kein Token** hinaus:

- Geräte durchsehen (Route 1), Gerät im Detail mit Bilderstreifen (2)
- Suchen über die hybride Suche der Plattform (3), mit 300 ms Ruhe nach dem Tippen. **Die Reihenfolge der Plattform bleibt** — sie sortiert nach Passung. Ist die Suchroute nicht erreichbar, wird die schon geladene Liste gefiltert, und das steht auch dran.
- Sets ansehen (4)
- Belegung eines Geräts sehen (6), einschließlich der Sperren des Vermieters
- Verfügbarkeit erfragen (5)
- Der Anmeldebildschirm bekommt dafür einen zweiten Weg: „Erst einmal umsehen: Maschinchenring". Wer noch keine Rössing-ID hat, soll sich umsehen dürfen.

**Mit Rössing-ID:**

- Buchen (11) — Name und Nummer holt der Server aus dem Profil, abtippen muss niemand
- Eigene Buchungen mit Zustand, Abholadresse nach der Zusage und Notiz (10)
- Buchung zurückziehen, nach Rückfrage (12)
- Profil im Maschinchenring lesen und ändern (7, 8), „ich möchte auch verleihen" (9)

**Für Freigeschaltete** (nur wenn die Plattform `lenderStatus: "approved"` sagt) unter „Mein Profil → Meine Vermietung":

- Anfragen auf den eigenen Geräten, offene zuerst, mit Name und Nummer für die Übergabe (13)
- Zusagen und Absagen (14, 15), stornieren (12)
- Eigene Geräte, abgeschaltete eingeschlossen (16)
- Zeiträume sperren und Sperren aufheben (17, 18, 19)

Alle 19 Routen des Vertrags sind im Client, keine ist erfunden.

## Zwei Dinge, die der Bereich bewusst nicht tut

**Er kennt keine Regel des Verleihs.** `available` (5) entscheidet, ob der Buchen-Knopf wach wird; `canCancel`, `canDecide` und `lenderStatus` entscheiden über die übrigen Knöpfe. Eine Antwort auf „ist es frei?" gilt nur für **den Zeitraum, für den sie kam** — wer die Tage verschiebt, hat keine Antwort mehr. Sonst bucht jemand ein freies Wochenende auf einem belegten.

**Er rechnet keinen Preis aus.** Der Server tut es nicht, und welcher Tarif bei welcher Dauer gilt, steht nirgends. Also stehen alle Tarife untereinander, und unter mehreren steht ein Satz, der sagt, wer es weiß.

## Der Empfänger im Token — und das Gerät, das schon angemeldet ist

`ANMELDE_SCOPES` fordert jetzt zusätzlich `urn:zitadel:iam:org:project:id:<RENTAL_PROJECT_ID>:aud` an; die Projekt-Kennung steht in `project.yml` → `Info.plist` → `Konfiguration.swift`, nicht im Quelltext.

Das genügt aber nur für Geräte, die sich **nach** dieser Fassung anmelden. Ein Gerät, das schon angemeldet ist, behält seinen Tokensatz über die Aktualisierung hinweg, und eine Erneuerung ändert daran nichts — Zitadel legt Empfänger bei der Autorisierung fest, nicht beim Refresh. Solche Geräte bekommen von `mieten.…` weiter ein `401 token_audience`.

Die Antwort darauf besteht aus zwei Teilen:

1. **Der Katalog bricht nicht.** Er geht ohne Token hinaus, also ist Umsehen und Suchen für diese Geräte unverändert möglich. Hätten wir das Token überall mitgeschickt, wäre der Bereich ausgerechnet für die Angemeldeten leer.
2. **Wo ein Token nötig ist, sagt die App, was los ist, und bietet eine neue Anmeldung an** — nicht „erneut versuchen", denn das wäre eine Lüge. Unterschieden wird am **Code** (`token_audience` gegen `unauthorized`), nicht am Text und nicht am Status: Eine Fehlerseite eines Vorschalters mit 401 schickt niemanden ohne Not durch eine neue Anmeldung.

## Wie geprüft wurde

- `xcodegen generate && xcodebuild test …` gegen den Simulator (iPhone 17, vorher `simctl bootstatus -b`): **228 Tests in 15 Suiten, grün** — 52 davon neu in `DorfTests/RentalTests.swift`.
- `python3 .github/scripts/pruefe_lokale_tests.py` und `--selbsttest`: grün. Kein Test fasst einen entfernten Server an; die Client-Tests setzen ihre Basis selbst und fangen ihre Sitzung über `protocolClasses` ab.
- Die JSON-Beispiele der Tests sind aus `docs/mieten-api.md` abgeschrieben, nicht nacherzählt. Geprüft wird unter anderem: der halboffene Zeitraum (05.–07. belegt den 5. und den 6.), dass aus dem letzten Leihtag der Rückgabetag wird, dass `null`-Tarife nicht zu 0 werden, dass eine Fehlerseite nicht als leerer Katalog durchgeht, dass an öffentliche Routen kein Token geht, dass eine Buchung `firstName`/`phone` **nicht** mitschickt, und dass `token_audience` und `unauthorized` zu zwei verschiedenen Angeboten führen.
- **Von Hand im Simulator angesehen** (headless VM, `simctl`, gegen einen örtlichen Ersatzserver): Katalogliste mit Tarifen und Sets, und die Geräteseite — die Markdown-Beschreibung erscheint mit Überschrift, Aufzählung und Fettung statt mit Sternchen, die Tarife stehen einzeln, und die Belegung zeigt „Sa, 05.09.2026 – So, 06.09.2026" für den Zeitraum 05.→07.

## Was offen bleibt

- **Android.** Diese Änderung ist nur die halbe Sache: Die Android-Fassung baut jemand anderes gegen denselben Vertrag. Bis sie liegt, sind die beiden Apps nicht auf demselben Stand — das ist der ausdrückliche Vorbehalt aus `CLAUDE.md` und steht so auch in `ios/OFFEN.md`. **Ausgeliefert werden sollte erst, wenn beide da sind.**
- **Sets werden angezeigt, nicht gebucht.** Stornieren, Zusagen und Absagen einer Set-Buchung ist serverseitig noch nicht umgesetzt und antwortet mit `409`. Eine Buchungsstrecke ohne Rückweg wäre eine Falle.
- **Geräte anlegen und ändern** bleibt beim Chat und der Webfassung des Maschinchenrings. Die Vermieteransicht sagt das.
- **Push** für Buchungsanfragen und -entscheidungen: eigenes Paket, läuft heute über E-Mail.
- **Bilder hochladen:** nicht Teil des Vertrags.
- Die Routen unter `/api/v1/…` sind drüben noch nicht ausgerollt. Der Bereich ist gegen die festgelegte Form gebaut; die ersten echten Antworten kommen, sobald der PR in der Mietplattform zusammengeführt ist.
- Die Wurzel-`README.md` nennt den Maschinchenring noch nicht als zweiten Dienst neben Backend und Website (in `ios/OFFEN.md` vermerkt).

Nicht selbst nach `main` gemergt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFr41QjEr7CGPjtAkUhwz
