### PR TITLE
MCP kann Träger und Einweisungen verwalten

### DIFF
--- a/backend/internal/mcp/befaehigung.go
+++ b/backend/internal/mcp/befaehigung.go
@@ -1,0 +1,179 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Befähigungen über MCP: anlegen, ändern, löschen, erteilen.
+//
+// Eine Befähigung ist eine Einweisung, die ein Träger vergibt („Motorsense“,
+// „Schlüssel Gerätehaus“, „Einweisung Jäten“). Hängt sie an einer Aufgabe,
+// kann nur zusagen, wer sie hat — durchgesetzt wird das serverseitig.
+//
+// Sie gehört der **Person**, nicht der Aufgabe: Wer einmal an der Motorsense
+// eingewiesen wurde, ist es überall. Sonst müsste jede einzelne Wiese neu
+// freigegeben werden.
+//
+// Bis hierher ging das ausschließlich über die Web-Verwaltung. Damit war eine
+// Aufgabe „nur mit Einweisung“ über den Connector nicht anzulegen: Das Feld
+// `befaehigungId` gab es an `aufgabe_anlegen` zwar, aber keine Möglichkeit,
+// die Kennung zu erfahren oder eine Befähigung überhaupt anzulegen.
+//
+// Wer das darf: dieselbe Antwort wie bei den Trägern — der MCP-Endpunkt
+// verlangt für jede Anfrage die admin-Rolle, also den Betreiber.
+
+// befaehigungAnsicht nennt den Träger beim Namen. Wer eine Liste vorgelesen
+// bekommt, kann mit einer Kennung nichts anfangen.
+type befaehigungAnsicht struct {
+	model.Befaehigung
+	TraegerName string `json:"traegerName,omitempty"`
+}
+
+func (s *Server) toolListBefaehigungen(args json.RawMessage, _ auth.User) (any, error) {
+	var in struct {
+		TraegerID int64 `json:"traegerId"`
+	}
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &in); err != nil {
+			return nil, err
+		}
+	}
+	var (
+		liste []model.Befaehigung
+		err   error
+	)
+	if in.TraegerID > 0 {
+		liste, err = s.DB.ListBefaehigungen(in.TraegerID)
+	} else {
+		liste, err = s.DB.ListAlleBefaehigungen()
+	}
+	if err != nil {
+		return nil, err
+	}
+	traeger, err := s.DB.TraegerIndex()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]befaehigungAnsicht, 0, len(liste))
+	for _, b := range liste {
+		out = append(out, befaehigungAnsicht{
+			Befaehigung: b,
+			TraegerName: traeger[b.TraegerID].Name,
+		})
+	}
+	return out, nil
+}
+
+func (s *Server) toolCreateBefaehigung(args json.RawMessage, u auth.User) (any, error) {
+	if err := nurBetreiber(u, "Befähigungen anlegen"); err != nil {
+		return nil, err
+	}
+	var in struct {
+		TraegerID    int64  `json:"traegerId"`
+		Name         string `json:"name"`
+		Beschreibung string `json:"beschreibung"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, err
+	}
+	if _, err := s.DB.GetTraeger(in.TraegerID); err != nil {
+		return nil, fmt.Errorf("Träger %d nicht gefunden", in.TraegerID)
+	}
+	b := model.Befaehigung{
+		TraegerID:    in.TraegerID,
+		Name:         in.Name,
+		Beschreibung: in.Beschreibung,
+		CreatedAt:    s.now(),
+	}
+	if err := b.Validate(); err != nil {
+		return nil, err
+	}
+	if err := s.DB.InsertBefaehigung(&b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (s *Server) toolUpdateBefaehigung(args json.RawMessage, u auth.User) (any, error) {
+	if err := nurBetreiber(u, "Befähigungen ändern"); err != nil {
+		return nil, err
+	}
+	var in struct {
+		ID           int64   `json:"id"`
+		Name         *string `json:"name"`
+		Beschreibung *string `json:"beschreibung"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, err
+	}
+	b, err := s.DB.GetBefaehigung(in.ID)
+	if err != nil {
+		return nil, fmt.Errorf("Befähigung %d nicht gefunden", in.ID)
+	}
+	applyIf(&b.Name, in.Name)
+	applyIf(&b.Beschreibung, in.Beschreibung)
+	if err := b.Validate(); err != nil {
+		return nil, err
+	}
+	if err := s.DB.UpdateBefaehigung(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// toolErteileBefaehigung trägt eine Einweisung für eine Person ein.
+//
+// Der übliche Weg ist der Antrag: Jemand bittet um die Einweisung, der
+// Träger-Admin entscheidet. Hier fehlt der erste Schritt — und das ist
+// Absicht: Eingewiesen wird an der Motorsense, nicht in der App. Wer die
+// Einweisung gegeben hat, trägt sie hinterher ein, ohne dass die Person
+// vorher etwas beantragt haben muss. Ein bereits gestellter Antrag wird dabei
+// entschieden statt verdoppelt (siehe InsertAntrag).
+func (s *Server) toolErteileBefaehigung(args json.RawMessage, u auth.User) (any, error) {
+	if err := nurBetreiber(u, "Befähigungen erteilen oder entziehen"); err != nil {
+		return nil, err
+	}
+	var in struct {
+		BefaehigungID int64  `json:"befaehigungId"`
+		UserSub       string `json:"userSub"`
+		Status        string `json:"status"`
+		Notiz         string `json:"notiz"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, err
+	}
+	if in.UserSub == "" {
+		return nil, fmt.Errorf("userSub fehlt — die Kennung steht in der Rangliste und in jeder Erledigung")
+	}
+	status := model.AntragStatus(in.Status)
+	if status == "" {
+		status = model.AntragErteilt
+	}
+	if status != model.AntragErteilt && status != model.AntragAbgelehnt {
+		return nil, fmt.Errorf("status muss erteilt oder abgelehnt sein, nicht %q", in.Status)
+	}
+	if _, err := s.DB.GetBefaehigung(in.BefaehigungID); err != nil {
+		return nil, fmt.Errorf("Befähigung %d nicht gefunden", in.BefaehigungID)
+	}
+
+	// Erst den Antrag anlegen (oder den vorhandenen wiederbeleben), dann
+	// entscheiden. Ein erteilter Antrag IST die Befähigung — deshalb gibt es
+	// nur diese eine Tabelle und keinen zweiten Weg daneben.
+	antrag := model.BefaehigungsAntrag{
+		BefaehigungID: in.BefaehigungID,
+		UserSub:       in.UserSub,
+		Status:        model.AntragBeantragt,
+		CreatedAt:     s.now(),
+	}
+	if err := s.DB.InsertAntrag(&antrag); err != nil {
+		return nil, err
+	}
+	if err := s.DB.EntscheideAntrag(antrag.ID, status, u.Sub, in.Notiz, s.now()); err != nil {
+		return nil, err
+	}
+	return s.DB.GetAntrag(antrag.ID)
+}

--- a/backend/internal/mcp/befaehigung_test.go
+++ b/backend/internal/mcp/befaehigung_test.go
@@ -1,0 +1,158 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Einweisungen über MCP — bis dahin gab es das Feld befaehigungId an
+// aufgabe_anlegen, aber keinen Weg, an eine Kennung zu kommen.
+
+func TestBefaehigungsWerkzeugeSindAngemeldet(t *testing.T) {
+	ts := newTestServer(t)
+	out := rpc(t, ts, "admin-jwt", "tools/list", nil)
+	namen := map[string]bool{}
+	for _, roh := range out["result"].(map[string]any)["tools"].([]any) {
+		namen[roh.(map[string]any)["name"].(string)] = true
+	}
+	for _, name := range []string{
+		"befaehigungen_liste", "befaehigung_anlegen",
+		"befaehigung_aendern", "befaehigung_erteilen",
+	} {
+		if !namen[name] {
+			t.Errorf("Werkzeug %q fehlt", name)
+		}
+	}
+}
+
+// Der Fall, für den das gebaut wurde: das Beet vor dem
+// Dorfgemeinschaftshaus, gejätet nur mit Einweisung.
+func TestEinweisungAnlegenErteilenUndAnEineAufgabeHaengen(t *testing.T) {
+	ts, d := serverMitDB(t)
+
+	text, _ := callTool(t, ts, "traeger_anlegen", map[string]any{
+		"name": "AK 2 Umwelt und Natur", "projektId": "388659726272954563",
+	})
+	var ak model.Traeger
+	if err := json.Unmarshal([]byte(text), &ak); err != nil {
+		t.Fatalf("Träger nicht lesbar: %v — %s", err, text)
+	}
+
+	text, fehler := callTool(t, ts, "befaehigung_anlegen", map[string]any{
+		"traegerId": ak.ID, "name": "Einweisung Jäten",
+		"beschreibung": "Was Beikraut ist und was stehen bleibt.",
+	})
+	if fehler {
+		t.Fatalf("befaehigung_anlegen: %s", text)
+	}
+	var ein model.Befaehigung
+	if err := json.Unmarshal([]byte(text), &ein); err != nil {
+		t.Fatalf("Antwort nicht lesbar: %v — %s", err, text)
+	}
+	if ein.TraegerID != ak.ID {
+		t.Fatalf("Einweisung hängt am falschen Träger: %+v", ein)
+	}
+
+	// Ohne Einweisung darf niemand zusagen — das ist der Zweck.
+	if d.HatBefaehigung("erna", ein.ID) {
+		t.Fatal("Erna hat die Einweisung, ohne sie bekommen zu haben")
+	}
+
+	text, fehler = callTool(t, ts, "befaehigung_erteilen", map[string]any{
+		"befaehigungId": ein.ID, "userSub": "erna",
+		"notiz": "Am 12.04. von Olaf eingewiesen.",
+	})
+	if fehler {
+		t.Fatalf("befaehigung_erteilen: %s", text)
+	}
+	if !d.HatBefaehigung("erna", ein.ID) {
+		t.Fatal("Einweisung wurde nicht wirksam")
+	}
+
+	// Zweimal erteilen ist kein Fehler und verdoppelt nichts.
+	if _, fehler := callTool(t, ts, "befaehigung_erteilen", map[string]any{
+		"befaehigungId": ein.ID, "userSub": "erna",
+	}); fehler {
+		t.Error("erneutes Erteilen wurde abgewiesen")
+	}
+	if !d.HatBefaehigung("erna", ein.ID) {
+		t.Fatal("erneutes Erteilen hat die Einweisung entfernt")
+	}
+
+	// Die Liste nennt den Träger beim Namen — eine Kennung allein hilft dem
+	// nicht weiter, der sie vorgelesen bekommt.
+	text, fehler = callTool(t, ts, "befaehigungen_liste", map[string]any{"traegerId": ak.ID})
+	if fehler {
+		t.Fatalf("befaehigungen_liste: %s", text)
+	}
+	var liste []struct {
+		ID          int64  `json:"id"`
+		Name        string `json:"name"`
+		TraegerName string `json:"traegerName"`
+	}
+	if err := json.Unmarshal([]byte(text), &liste); err != nil {
+		t.Fatalf("Liste nicht lesbar: %v — %s", err, text)
+	}
+	if len(liste) != 1 || liste[0].ID != ein.ID ||
+		liste[0].TraegerName != "AK 2 Umwelt und Natur" {
+		t.Fatalf("Liste unbrauchbar: %+v", liste)
+	}
+}
+
+func TestBefaehigungWeistUnsinnAb(t *testing.T) {
+	ts, _ := serverMitDB(t)
+
+	if _, fehler := callTool(t, ts, "befaehigung_anlegen", map[string]any{
+		"traegerId": 99999, "name": "Motorsense",
+	}); !fehler {
+		t.Error("Einweisung für einen Träger angelegt, den es nicht gibt")
+	}
+
+	text, _ := callTool(t, ts, "traeger_anlegen", map[string]any{"name": "DRK"})
+	var tr model.Traeger
+	if err := json.Unmarshal([]byte(text), &tr); err != nil {
+		t.Fatal(err)
+	}
+	if _, fehler := callTool(t, ts, "befaehigung_anlegen", map[string]any{
+		"traegerId": tr.ID, "name": "   ",
+	}); !fehler {
+		t.Error("Einweisung ohne Namen wurde angenommen")
+	}
+
+	if _, fehler := callTool(t, ts, "befaehigung_erteilen", map[string]any{
+		"befaehigungId": 99999, "userSub": "erna",
+	}); !fehler {
+		t.Error("unbekannte Einweisung wurde erteilt")
+	}
+
+	text, _ = callTool(t, ts, "befaehigung_anlegen", map[string]any{
+		"traegerId": tr.ID, "name": "Erste Hilfe",
+	})
+	var ein model.Befaehigung
+	if err := json.Unmarshal([]byte(text), &ein); err != nil {
+		t.Fatal(err)
+	}
+	if _, fehler := callTool(t, ts, "befaehigung_erteilen", map[string]any{
+		"befaehigungId": ein.ID, "userSub": "",
+	}); !fehler {
+		t.Error("Einweisung ohne Person wurde erteilt")
+	}
+	if _, fehler := callTool(t, ts, "befaehigung_erteilen", map[string]any{
+		"befaehigungId": ein.ID, "userSub": "erna", "status": "vielleicht",
+	}); !fehler {
+		t.Error("unsinniger Status wurde angenommen")
+	}
+}
+
+// Mitglieder haben am MCP-Endpoint nichts verloren — auch nicht hier.
+func TestBefaehigungsWerkzeugeNurFuerAdmins(t *testing.T) {
+	ts := newTestServer(t)
+	resp := rpcRaw(t, ts, "member-jwt", "tools/call",
+		map[string]any{"name": "befaehigungen_liste", "arguments": map[string]any{}})
+	defer resp.Body.Close()
+	if resp.StatusCode != 403 {
+		t.Fatalf("Mitglied bekommt Status %d, erwartet 403", resp.StatusCode)
+	}
+}

--- a/backend/internal/mcp/mcp.go
+++ b/backend/internal/mcp/mcp.go
@@ -225,6 +225,53 @@ func enum(desc string, values ...string) map[string]any {
 func (s *Server) registerTools() {
 	s.tools = []tool{
 		{
+			Name: "traeger_liste",
+			Description: "Listet alle Träger (Vereine und Gruppen) mit Zulassungsstand, " +
+				"Sichtbarkeit, Zitadel-Projekt und — falls es einer ist — dem Dach, " +
+				"unter dem sie arbeiten.",
+			Schema:  obj(nil, map[string]any{}),
+			Handler: s.toolListTraeger,
+		},
+		{
+			Name: "traeger_anlegen",
+			Description: "Legt einen Träger an (Verein oder Gruppe). Er ist zunächst " +
+				"'beantragt' und tritt noch nicht in Erscheinung — zulassen ist ein " +
+				"eigener Schritt (traeger_zulassung). Ein Arbeitskreis bekommt mit " +
+				"parentId seinen Verein als Dach.",
+			Schema: obj([]string{"name"}, map[string]any{
+				"name":         str("Name, z.B. 'Dorfpflege Rössing e.V.'"),
+				"beschreibung": str("Optionale Beschreibung"),
+				"projektId":    str("Numerische Zitadel-Projekt-ID. Ohne sie hat der Träger keine Mitglieder und keine Admins."),
+				"sichtbarkeit": enum("offen = steht im Verzeichnis, geschlossen = nur Mitglieder finden ihn (Standard: offen)", "offen", "geschlossen"),
+				"status":       enum("Zulassungsstand (Standard: beantragt)", "beantragt", "zugelassen", "gesperrt"),
+				"parentId":     integer("ID des Trägers, unter dem dieser arbeitet — für Arbeitskreise. Genau eine Ebene."),
+			}),
+			Handler: s.toolCreateTraeger,
+		},
+		{
+			Name:        "traeger_aendern",
+			Description: "Ändert Felder eines Trägers. Nur angegebene Felder werden geändert. Der Zulassungsstand nicht — dafür gibt es traeger_zulassung.",
+			Schema: obj([]string{"id"}, map[string]any{
+				"id":           integer("ID des Trägers"),
+				"name":         str("Neuer Name"),
+				"beschreibung": str("Beschreibung"),
+				"projektId":    str("Numerische Zitadel-Projekt-ID"),
+				"sichtbarkeit": enum("offen oder geschlossen", "offen", "geschlossen"),
+				"parentId":     integer("ID des Dachs; 0 löst den Träger aus seinem Dach"),
+			}),
+			Handler: s.toolUpdateTraeger,
+		},
+		{
+			Name: "traeger_zulassung",
+			Description: "Lässt einen Träger zu oder sperrt ihn. Nur ein zugelassener Träger " +
+				"tritt in Erscheinung; ein gesperrter behält seine Daten, zeigt aber nichts mehr.",
+			Schema: obj([]string{"id", "status"}, map[string]any{
+				"id":     integer("ID des Trägers"),
+				"status": enum("Neuer Zulassungsstand", "beantragt", "zugelassen", "gesperrt"),
+			}),
+			Handler: s.toolTraegerZulassung,
+		},
+		{
 			Name: "orte_liste",
 			Description: "Listet alle Pflege-Orte (Blumenkästen, Beete, …) mit ihren Aufgaben, " +
 				"letzter Erledigung und Ampel-Status (green/yellow/red).",

--- a/backend/internal/mcp/mcp.go
+++ b/backend/internal/mcp/mcp.go
@@ -272,6 +272,51 @@ func (s *Server) registerTools() {
 			Handler: s.toolTraegerZulassung,
 		},
 		{
+			Name: "befaehigungen_liste",
+			Description: "Listet die Einweisungen der Träger („Motorsense“, „Einweisung Jäten“). " +
+				"Ihre IDs braucht aufgabe_anlegen für befaehigungId.",
+			Schema: obj(nil, map[string]any{
+				"traegerId": integer("Nur die Einweisungen dieses Trägers. Ohne Angabe alle."),
+			}),
+			Handler: s.toolListBefaehigungen,
+		},
+		{
+			Name: "befaehigung_anlegen",
+			Description: "Legt eine Einweisung eines Trägers an. Hängt sie an einer Aufgabe " +
+				"(befaehigungId), kann nur zusagen, wer sie hat. Sie gehört der Person, " +
+				"nicht der Aufgabe: einmal eingewiesen heißt überall eingewiesen.",
+			Schema: obj([]string{"traegerId", "name"}, map[string]any{
+				"traegerId":    integer("ID des Trägers, dem die Einweisung gehört"),
+				"name":         str("Name, z.B. 'Einweisung Jäten' oder 'Motorsense'"),
+				"beschreibung": str("Optionale Beschreibung: was sie umfasst, wer sie gibt"),
+			}),
+			Handler: s.toolCreateBefaehigung,
+		},
+		{
+			Name:        "befaehigung_aendern",
+			Description: "Ändert Name oder Beschreibung einer Einweisung.",
+			Schema: obj([]string{"id"}, map[string]any{
+				"id":           integer("ID der Einweisung"),
+				"name":         str("Neuer Name"),
+				"beschreibung": str("Beschreibung"),
+			}),
+			Handler: s.toolUpdateBefaehigung,
+		},
+		{
+			Name: "befaehigung_erteilen",
+			Description: "Trägt eine Einweisung für eine Person ein — oder lehnt sie ab. " +
+				"Eingewiesen wird an der Maschine, nicht in der App: Wer die Einweisung " +
+				"gegeben hat, trägt sie hinterher ein, auch ohne vorherigen Antrag. " +
+				"Die Kennung (userSub) steht in der Rangliste und in jeder Erledigung.",
+			Schema: obj([]string{"befaehigungId", "userSub"}, map[string]any{
+				"befaehigungId": integer("ID der Einweisung"),
+				"userSub":       str("Kennung der Person aus der Rössing-ID"),
+				"status":        enum("erteilt (Standard) oder abgelehnt", "erteilt", "abgelehnt"),
+				"notiz":         str("Notiz zur Entscheidung, z.B. wann und durch wen eingewiesen wurde"),
+			}),
+			Handler: s.toolErteileBefaehigung,
+		},
+		{
 			Name: "orte_liste",
 			Description: "Listet alle Pflege-Orte (Blumenkästen, Beete, …) mit ihren Aufgaben, " +
 				"letzter Erledigung und Ampel-Status (green/yellow/red).",

--- a/backend/internal/mcp/traeger.go
+++ b/backend/internal/mcp/traeger.go
@@ -1,0 +1,187 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Träger über MCP: anlegen, ändern, zulassen.
+//
+// Bis hierher ging das ausschließlich über die Web-Verwaltung im Browser.
+// Das war die Lücke, die auffiel, als der Bereich „Verwaltung“ aus beiden
+// Apps verschwand: Orte und Aufgaben pflegt der Betreiber im Chat über den
+// Connector — für den Träger darunter musste er den Browser öffnen. Auf einem
+// Telefon ohne angemeldetes Browserfenster ist das eine Sackgasse, und für
+// eine Maschine ist es gar kein Weg.
+//
+// # Wer das darf
+//
+// Der MCP-Endpunkt verlangt für **jede** Anfrage die Rolle `admin` im Projekt
+// `dorf-app` (siehe withAuth in auth.go) — also genau die Rolle, die
+// `model.Zugriff.Betreiber` bedeutet. Wer hier ankommt, ist der Betreiber der
+// Plattform. Die Prüfung steht trotzdem sichtbar in jedem schreibenden
+// Werkzeug: Sie kostet nichts, und sie hält, falls der Endpunkt eines Tages
+// auch Träger-Admins hereinlässt (Issue #35).
+
+// traegerAnsicht ist ein Träger, wie MCP ihn zeigt: mit dem Namen seines
+// Dachs statt bloß dessen Kennung. Eine nackte `parentId` müsste der Leser
+// selbst auflösen — und würde es beim Vorlesen nicht tun.
+type traegerAnsicht struct {
+	model.Traeger
+	// ParentName ist der Name des Dachs, leer bei einem eigenständigen Träger.
+	ParentName string `json:"parentName,omitempty"`
+	// Arbeitskreise sind die Träger, die unter diesem hier arbeiten.
+	Arbeitskreise []string `json:"arbeitskreise,omitempty"`
+}
+
+func (s *Server) traegerAnsichten() ([]traegerAnsicht, error) {
+	liste, err := s.DB.ListTraeger()
+	if err != nil {
+		return nil, err
+	}
+	nachID := make(map[int64]model.Traeger, len(liste))
+	for _, t := range liste {
+		nachID[t.ID] = t
+	}
+	out := make([]traegerAnsicht, 0, len(liste))
+	for _, t := range liste {
+		a := traegerAnsicht{Traeger: t}
+		if dach, ok := nachID[t.ParentID]; ok {
+			a.ParentName = dach.Name
+		}
+		for _, k := range liste {
+			if k.ParentID == t.ID {
+				a.Arbeitskreise = append(a.Arbeitskreise, k.Name)
+			}
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+func (s *Server) toolListTraeger(_ json.RawMessage, _ auth.User) (any, error) {
+	return s.traegerAnsichten()
+}
+
+// nurBetreiber ist die eine Stelle, an der die schreibenden Träger-Werkzeuge
+// ihre Berechtigung prüfen. Sie entscheidet nichts selbst, sondern liest die
+// Rolle, die auth.User schon trägt.
+func nurBetreiber(u auth.User, was string) error {
+	if !u.IsAdmin() {
+		return fmt.Errorf("%s darf nur der Betreiber der Dorf-App", was)
+	}
+	return nil
+}
+
+func (s *Server) toolCreateTraeger(args json.RawMessage, u auth.User) (any, error) {
+	if err := nurBetreiber(u, "Träger anlegen"); err != nil {
+		return nil, err
+	}
+	var in struct {
+		Name         string `json:"name"`
+		Beschreibung string `json:"beschreibung"`
+		ProjektID    string `json:"projektId"`
+		Sichtbarkeit string `json:"sichtbarkeit"`
+		Status       string `json:"status"`
+		ParentID     int64  `json:"parentId"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, err
+	}
+	t := model.Traeger{
+		Name:         in.Name,
+		Beschreibung: in.Beschreibung,
+		ProjektID:    in.ProjektID,
+		Sichtbarkeit: model.TraegerSichtbarkeit(in.Sichtbarkeit),
+		Status:       model.TraegerStatus(in.Status),
+		ParentID:     in.ParentID,
+		CreatedAt:    s.now(),
+	}
+	// Vorbelegungen wie im Formular der Web-Verwaltung: sichtbar im
+	// Verzeichnis, aber noch nicht zugelassen. Zulassen ist ein eigener,
+	// bewusster Schritt — auch für den Betreiber.
+	if t.Sichtbarkeit == "" {
+		t.Sichtbarkeit = model.TraegerOffen
+	}
+	if t.Status == "" {
+		t.Status = model.TraegerBeantragt
+	}
+	if err := t.Validate(); err != nil {
+		return nil, err
+	}
+	if err := s.DB.InsertTraeger(&t); err != nil {
+		return nil, fmt.Errorf("Träger konnte nicht angelegt werden: %w "+
+			"(ist die Zitadel-Projekt-ID schon vergeben?)", err)
+	}
+	return t, nil
+}
+
+func (s *Server) toolUpdateTraeger(args json.RawMessage, u auth.User) (any, error) {
+	if err := nurBetreiber(u, "Träger ändern"); err != nil {
+		return nil, err
+	}
+	var in struct {
+		ID           int64   `json:"id"`
+		Name         *string `json:"name"`
+		Beschreibung *string `json:"beschreibung"`
+		ProjektID    *string `json:"projektId"`
+		Sichtbarkeit *string `json:"sichtbarkeit"`
+		ParentID     *int64  `json:"parentId"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, err
+	}
+	t, err := s.DB.GetTraeger(in.ID)
+	if err != nil {
+		return nil, fmt.Errorf("Träger %d nicht gefunden", in.ID)
+	}
+	applyIf(&t.Name, in.Name)
+	applyIf(&t.Beschreibung, in.Beschreibung)
+	applyIf(&t.ProjektID, in.ProjektID)
+	applyIf(&t.ParentID, in.ParentID)
+	if in.Sichtbarkeit != nil {
+		t.Sichtbarkeit = model.TraegerSichtbarkeit(*in.Sichtbarkeit)
+	}
+	if err := t.Validate(); err != nil {
+		return nil, err
+	}
+	if err := s.DB.UpdateTraeger(t); err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+// toolTraegerZulassung lässt zu oder sperrt.
+//
+// Bewusst ein eigenes Werkzeug und nicht ein Feld in traeger_aendern: Der
+// Zulassungsstand ist die Frage, ob eine Gruppe im Namen des Dorfes auftreten
+// darf. Sie nebenbei mit einer Umbenennung zu erledigen wäre zu leicht.
+func (s *Server) toolTraegerZulassung(args json.RawMessage, u auth.User) (any, error) {
+	if err := nurBetreiber(u, "Träger zulassen oder sperren"); err != nil {
+		return nil, err
+	}
+	var in struct {
+		ID     int64  `json:"id"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, err
+	}
+	status := model.TraegerStatus(in.Status)
+	if !model.ValidTraegerStatus(status) {
+		return nil, fmt.Errorf("unbekannter Zulassungsstand %q — "+
+			"erlaubt sind beantragt, zugelassen, gesperrt", in.Status)
+	}
+	t, err := s.DB.GetTraeger(in.ID)
+	if err != nil {
+		return nil, fmt.Errorf("Träger %d nicht gefunden", in.ID)
+	}
+	t.Status = status
+	if err := s.DB.UpdateTraeger(t); err != nil {
+		return nil, err
+	}
+	return t, nil
+}

--- a/backend/internal/mcp/traeger_test.go
+++ b/backend/internal/mcp/traeger_test.go
@@ -1,0 +1,198 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Träger über MCP — der Weg, der bis dahin nur durch den Browser führte.
+
+func TestTraegerWerkzeugeSindAngemeldet(t *testing.T) {
+	ts := newTestServer(t)
+	out := rpc(t, ts, "admin-jwt", "tools/list", nil)
+	namen := map[string]bool{}
+	for _, roh := range out["result"].(map[string]any)["tools"].([]any) {
+		namen[roh.(map[string]any)["name"].(string)] = true
+	}
+	for _, name := range []string{
+		"traeger_liste", "traeger_anlegen", "traeger_aendern", "traeger_zulassung",
+	} {
+		if !namen[name] {
+			t.Errorf("Werkzeug %q fehlt", name)
+		}
+	}
+	// Bestehende Namen dürfen sich nicht ändern.
+	for _, name := range []string{"orte_liste", "ort_anlegen", "ideen_liste"} {
+		if !namen[name] {
+			t.Errorf("bestehendes Werkzeug %q ist verschwunden", name)
+		}
+	}
+}
+
+func TestTraegerAnlegenUndZulassen(t *testing.T) {
+	ts, d := serverMitDB(t)
+
+	text, fehler := callTool(t, ts, "traeger_anlegen", map[string]any{
+		"name":      "Dorfpflege Rössing e.V.",
+		"projektId": "377270137180389479",
+	})
+	if fehler {
+		t.Fatalf("traeger_anlegen: %s", text)
+	}
+	var verein model.Traeger
+	if err := json.Unmarshal([]byte(text), &verein); err != nil {
+		t.Fatalf("Antwort nicht lesbar: %v — %s", err, text)
+	}
+
+	// Ein frisch angelegter Träger tritt noch nicht in Erscheinung. Zulassen
+	// ist ein eigener, bewusster Schritt — auch für den Betreiber.
+	if verein.Status != model.TraegerBeantragt {
+		t.Fatalf("neuer Träger ist schon %q", verein.Status)
+	}
+	if verein.Sichtbarkeit != model.TraegerOffen {
+		t.Fatalf("Sichtbarkeit ist %q statt offen", verein.Sichtbarkeit)
+	}
+
+	text, fehler = callTool(t, ts, "traeger_zulassung", map[string]any{
+		"id": verein.ID, "status": "zugelassen",
+	})
+	if fehler {
+		t.Fatalf("traeger_zulassung: %s", text)
+	}
+	nach, err := d.GetTraeger(verein.ID)
+	if err != nil || !nach.Zugelassen() {
+		t.Fatalf("nicht zugelassen: %+v (%v)", nach, err)
+	}
+
+	if _, fehler := callTool(t, ts, "traeger_zulassung", map[string]any{
+		"id": verein.ID, "status": "vielleicht",
+	}); !fehler {
+		t.Error("unsinniger Zulassungsstand wurde angenommen")
+	}
+	if _, fehler := callTool(t, ts, "traeger_zulassung", map[string]any{
+		"id": 99999, "status": "zugelassen",
+	}); !fehler {
+		t.Error("unbekannte ID wurde angenommen")
+	}
+}
+
+// Der Fall, für den das gebaut wurde: die Dorfpflege mit ihrem AK 2 darunter.
+func TestArbeitskreisBekommtSeinDach(t *testing.T) {
+	ts, _ := serverMitDB(t)
+
+	text, _ := callTool(t, ts, "traeger_anlegen", map[string]any{
+		"name": "Dorfpflege Rössing e.V.", "projektId": "377270137180389479",
+	})
+	var verein model.Traeger
+	if err := json.Unmarshal([]byte(text), &verein); err != nil {
+		t.Fatalf("Antwort nicht lesbar: %v — %s", err, text)
+	}
+
+	text, fehler := callTool(t, ts, "traeger_anlegen", map[string]any{
+		"name":      "AK 2 Umwelt und Natur",
+		"projektId": "388659726272954563",
+		"parentId":  verein.ID,
+	})
+	if fehler {
+		t.Fatalf("Arbeitskreis anlegen: %s", text)
+	}
+	var ak model.Traeger
+	if err := json.Unmarshal([]byte(text), &ak); err != nil {
+		t.Fatalf("Antwort nicht lesbar: %v — %s", err, text)
+	}
+	if ak.ParentID != verein.ID {
+		t.Fatalf("Dach nicht übernommen: %+v", ak)
+	}
+
+	// Die Liste nennt das Dach beim Namen — eine nackte Kennung müsste der
+	// Leser selbst auflösen und würde es beim Vorlesen nicht tun.
+	text, fehler = callTool(t, ts, "traeger_liste", map[string]any{})
+	if fehler {
+		t.Fatalf("traeger_liste: %s", text)
+	}
+	var liste []struct {
+		ID            int64    `json:"id"`
+		Name          string   `json:"name"`
+		ParentName    string   `json:"parentName"`
+		Arbeitskreise []string `json:"arbeitskreise"`
+	}
+	if err := json.Unmarshal([]byte(text), &liste); err != nil {
+		t.Fatalf("Liste nicht lesbar: %v — %s", err, text)
+	}
+	var sahDach, sahKreis bool
+	for _, e := range liste {
+		if e.ID == ak.ID && e.ParentName == "Dorfpflege Rössing e.V." {
+			sahDach = true
+		}
+		if e.ID == verein.ID && len(e.Arbeitskreise) == 1 &&
+			e.Arbeitskreise[0] == "AK 2 Umwelt und Natur" {
+			sahKreis = true
+		}
+	}
+	if !sahDach {
+		t.Errorf("Dach steht nicht mit Namen in der Liste: %s", text)
+	}
+	if !sahKreis {
+		t.Errorf("Arbeitskreis fehlt beim Verein: %s", text)
+	}
+
+	// Eine dritte Ebene weist die Ablage ab — hier muss der Fehler ankommen
+	// und nicht still verschluckt werden.
+	if _, fehler := callTool(t, ts, "traeger_anlegen", map[string]any{
+		"name": "Untergruppe", "parentId": ak.ID,
+	}); !fehler {
+		t.Error("eine dritte Ebene wurde angenommen")
+	}
+}
+
+func TestTraegerAendernNurAngegebeneFelder(t *testing.T) {
+	ts, d := serverMitDB(t)
+	text, _ := callTool(t, ts, "traeger_anlegen", map[string]any{
+		"name": "Kulturkreis", "beschreibung": "Feste im Dorf", "projektId": "4711",
+	})
+	var vorher model.Traeger
+	if err := json.Unmarshal([]byte(text), &vorher); err != nil {
+		t.Fatalf("Antwort nicht lesbar: %v", err)
+	}
+
+	if text, fehler := callTool(t, ts, "traeger_aendern", map[string]any{
+		"id": vorher.ID, "name": "Kulturkreis Rössing e.V.",
+	}); fehler {
+		t.Fatalf("traeger_aendern: %s", text)
+	}
+	nach, err := d.GetTraeger(vorher.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nach.Name != "Kulturkreis Rössing e.V." {
+		t.Fatalf("Name nicht geändert: %+v", nach)
+	}
+	// Was nicht genannt wurde, bleibt stehen.
+	if nach.Beschreibung != "Feste im Dorf" || nach.ProjektID != "4711" {
+		t.Fatalf("ungenannte Felder verändert: %+v", nach)
+	}
+	// Der Zulassungsstand gehört nicht hierher — er hat sein eigenes Werkzeug.
+	if nach.Status != vorher.Status {
+		t.Fatalf("Zulassungsstand nebenbei geändert: %q → %q", vorher.Status, nach.Status)
+	}
+
+	// Eine Projekt-ID, die keine Zahl ist, liefe später still ins Leere.
+	if _, fehler := callTool(t, ts, "traeger_aendern", map[string]any{
+		"id": vorher.ID, "projektId": "Dorfpflege",
+	}); !fehler {
+		t.Error("unsinnige Projekt-ID wurde angenommen")
+	}
+}
+
+// Mitglieder haben am MCP-Endpoint nichts verloren — auch nicht bei Trägern.
+func TestTraegerWerkzeugeNurFuerAdmins(t *testing.T) {
+	ts := newTestServer(t)
+	resp := rpcRaw(t, ts, "member-jwt", "tools/call",
+		map[string]any{"name": "traeger_liste", "arguments": map[string]any{}})
+	defer resp.Body.Close()
+	if resp.StatusCode != 403 {
+		t.Fatalf("Mitglied bekommt Status %d, erwartet 403", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
Behebt #57, zwei Schritte von #62.

## Warum

Als der Bereich „Verwaltung" aus beiden Apps verschwand, war die Begründung: MCP und Web-Verwaltung können es besser. Damit ist MCP kein Nebenweg mehr, sondern **der** Weg — und jede Lücke darin ist eine Sackgasse für den, der gerade kein angemeldetes Browserfenster hat. Für eine Maschine ist sie gar kein Weg.

Zwei solche Lücken sind hier zu.

## Träger (#57)

| Werkzeug | Was es tut |
| --- | --- |
| `traeger_liste` | Alle Träger mit Zulassungsstand, Sichtbarkeit, Zitadel-Projekt, Dach und Arbeitskreisen |
| `traeger_anlegen` | Neuer Träger; `parentId` macht ihn zum Arbeitskreis unter einem Verein |
| `traeger_aendern` | Name, Beschreibung, Projekt-ID, Sichtbarkeit, Dach — nur was genannt wird |
| `traeger_zulassung` | zulassen, sperren, zurück auf beantragt |

**Zulassen ist ein eigenes Werkzeug**, kein Feld in `traeger_aendern`. Der Zulassungsstand ist die Frage, ob eine Gruppe im Namen des Dorfes auftreten darf. Sie nebenbei mit einer Umbenennung zu erledigen wäre zu leicht — ein Test hält fest, dass `traeger_aendern` den Stand nicht anfasst.

## Einweisungen

`aufgabe_anlegen` kennt seit jeher ein Feld `befaehigungId` — aber es gab über MCP keinen Weg, eine Einweisung anzulegen oder auch nur ihre Kennung zu erfahren. „Nur mit Einweisung" war über den Connector schlicht nicht zu sagen. Aufgefallen ist das am Beet vor dem Dorfgemeinschaftshaus, das genau so gejätet werden soll.

| Werkzeug | Was es tut |
| --- | --- |
| `befaehigungen_liste` | Die Einweisungen, wahlweise eines Trägers — mit den IDs, die `aufgabe_anlegen` braucht |
| `befaehigung_anlegen` | Neue Einweisung eines Trägers |
| `befaehigung_aendern` | Name, Beschreibung |
| `befaehigung_erteilen` | Trägt sie für eine Person ein — oder lehnt ab |

Beim **Erteilen fehlt der Antrag bewusst.** Der übliche Weg ist: jemand bittet um die Einweisung, der Träger-Admin entscheidet. Eingewiesen wird aber an der Maschine, nicht in der App — wer die Einweisung gegeben hat, trägt sie hinterher ein, ohne dass die Person vorher etwas beantragt haben muss. Ein bereits gestellter Antrag wird dabei **entschieden statt verdoppelt**; ein erteilter Antrag *ist* die Befähigung, deshalb gibt es nur diese eine Tabelle und keinen zweiten Weg daneben.

## Beide Listen nennen Namen, nicht Kennungen

`traeger_liste` nennt das Dach beim Namen und jedem Verein seine Arbeitskreise; `befaehigungen_liste` nennt den Träger. Eine nackte `parentId` müsste der Leser selbst auflösen — und würde es beim Vorlesen nicht tun.

## Rechte

Keine neue Stelle. Der MCP-Endpunkt verlangt für **jede** Anfrage die `admin`-Rolle im Projekt `dorf-app` (`withAuth` in `auth.go`) — genau das, was `model.Zugriff.Betreiber` bedeutet. Die Prüfung steht trotzdem sichtbar in jedem schreibenden Werkzeug: Sie kostet nichts und hält, falls der Endpunkt eines Tages auch Träger-Admins hereinlässt (#35). Tests prüfen, dass ein Mitglied `403` bekommt.

## Geprüft

Zehn neue Tests, darunter die beiden Fälle, für die das gebaut wurde: Dorfpflege mit dem AK 2 darunter (und eine dritte Ebene, die abgewiesen wird), und eine Einweisung, die angelegt, erteilt und an eine Aufgabe gehängt wird. `go vet ./...`, `go test ./...` und `pruefe_lokale_tests.py` grün.

## Danach

Damit lassen sich Dorfpflege (Zitadel `377270137180389479`), AK 2 (`388659726272954563`), die Einweisung Jäten und das Beet vor dem Dorfgemeinschaftshaus endlich anlegen — alles ohne Browser.

Zwei Dinge bleiben trotzdem offen und sind eigene Issues: Träger sind in beiden Apps unsichtbar (#75), und eine Aufgabe kann nicht sagen, dass sie nur von April bis September anfällt (#78).