### PR TITLE
Wer keinen Namen hat, heißt Lustiger Lurch

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,16 @@ keine der beiden Apps noch einmal.
   Nachtrag, den die Verwaltung unter fremdem Namen eingetragen hat, die
   genannte Person. Die SQL-Gruppierung bleibt unangetastet, ersetzt wird erst
   für die Anzeige. Datenschutz-Folgen: siehe `backend/SICHERHEIT.md`.
+  **Spitzname statt Leerstelle**: Hat jemand weder Nickname noch Anzeigenamen
+  und liefert auch die Rössing-ID keinen Namen, stand die Person bisher
+  namenlos in der Rangliste — mit Punkten, Litern und Auszeichnungen, aber
+  ohne Beschriftung. Statt der Leerstelle steht dort jetzt ein freundlicher
+  Spitzname („Lustiger Lurch"), der allein aus der Zitadel-Kennung entsteht
+  (`model.AnonymousName`): dieselbe Person heißt nach jedem Neustart und in
+  jeder Kopie der Datenbank gleich, und aus dem Namen lässt sich nichts über
+  sie ableiten. Er steht **hinter** jedem echten Namen und macht niemanden
+  sichtbarer: Wer weder Anzeigenamen noch Nickname freigegeben hat, fehlt
+  weiterhin in `GET /api/v1/members`.
 - **Push-Benachrichtigungen**: Neben der Abrufliste (`GET
   /api/v1/me/notifications`) verschickt der Server Anfragen und Hinweise über
   **Firebase Cloud Messaging** (`internal/push`, HTTP v1, Zugriffstoken aus

--- a/backend/SICHERHEIT.md
+++ b/backend/SICHERHEIT.md
@@ -202,6 +202,33 @@ gespeicherter Name); erst ganz zum Schluss, nach Auszeichnungen und der Suche
 nach dem eigenen Eintrag, wird der Anzeigename ersetzt. Dadurch spaltet sich
 keine Person in zwei Zeilen, wenn sie sich umbenennt.
 
+### Spitzname statt Leerstelle (Stand 31.08.2026)
+
+Hat eine Person weder Nickname noch Anzeigenamen **und** liefert ihre
+Rössing-ID keinen Namen (`name` und `preferred_username` beide leer), stand sie
+namenlos in der Rangliste — die Zeile war da, mit Punkten, Litern und
+Auszeichnungen, nur ohne Beschriftung. An dieser Stelle steht jetzt ein
+Spitzname („Lustiger Lurch", `model.AnonymousName`).
+
+- **Woher er kommt:** SHA-256 über eine feste Domänentrennung plus die
+  Zitadel-Kennung; je vier Byte wählen ein Adjektiv und ein Tier aus zwei von
+  Hand gepflegten Wortlisten im Quelltext (`internal/model/anonymousname.go`).
+  Kein Zufall, kein Zustand, keine Spalte — dieselbe Kennung ergibt in jedem
+  Prozess, nach jedem Neustart und in jeder Sicherungskopie denselben Namen.
+- **Was er verrät:** nichts. Weder Name, Nickname, E-Mail noch Telefon gehen
+  ein, aus dem Spitznamen ist also keines dieser Felder zurückzurechnen. Er ist
+  ein stabiles Pseudonym zur Kennung — und die Kennung (`userSub`) steht in
+  denselben Antworten ohnehin, es entsteht also keine neue Verkettbarkeit.
+- **Was er nicht tut:** Er macht niemanden sichtbarer. `Profile.AsMember`
+  bleibt unverändert — wer weder Anzeigenamen noch Nickname freigegeben hat,
+  fehlt in `GET /api/v1/members` weiterhin ganz. Der Spitzname füllt nur
+  Leerstellen dort, wo die Person ohnehin schon in einer Liste steht.
+- **Beleidigungsfreiheit** ist geprüfte Eigenschaft, nicht Sorgfalt:
+  `TestWortlistenSindHarmlos` geht alle 784 Paarungen durch und weist sowohl
+  einzelne Wörter als auch feststehende herabsetzende Kombinationen ab.
+  `TestAnonymousNameIstStabil` hält ein paar Namen fest verdrahtet — er schlägt
+  an, sobald eine Änderung der Wortlisten alle Namenlosen umbenennen würde.
+
 ### Migration
 
 `CREATE TABLE IF NOT EXISTS profiles` — rein additiv. An `places`,

--- a/backend/internal/api/profil_test.go
+++ b/backend/internal/api/profil_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
 )
 
 // Tests der Profilverwaltung: eigenes Profil, Sichtbarkeit gegenüber anderen
@@ -458,5 +460,55 @@ func TestHistorieNutztProfilnamen(t *testing.T) {
 	letzte := orte.Places[0].Tasks[0].LastCompletion
 	if letzte == nil || letzte.UserName != "Gießmeisterin" {
 		t.Fatalf("letzte Erledigung = %+v, erwartet den Nickname", letzte)
+	}
+}
+
+// TestRanglisteZeigtSpitznameStattLeerstelle baut den Zustand nach, der in
+// der Produktion aufgefallen ist: ein Konto ohne jeden Namen — die Rössing-ID
+// liefert weder „name“ noch „preferred_username“, also ist auch der bei der
+// Meldung eingefrorene Name leer. Die Zeile stand mit Punkten, Litern und
+// Auszeichnungen in der Rangliste, nur eben ohne Namen.
+//
+// Der Umweg über die Datenbank ist Absicht: Der Dev-Verifier kann kein Token
+// ohne Namen ausstellen (er setzt notfalls die Kennung ein), der echte
+// OIDC-Verifier sehr wohl.
+func TestRanglisteZeigtSpitznameStattLeerstelle(t *testing.T) {
+	ts, srv := newTestServer(t)
+	_, taskID := createPlaceWithTask(t, ts)
+
+	const namenlos = "namenlose-kennung"
+	if err := srv.DB.UpsertProfile(&model.Profile{
+		UserSub: namenlos, Visibility: model.DefaultVisibility(), UpdatedAt: srv.now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	liter := 20.0
+	if err := srv.DB.InsertCompletion(&model.Completion{
+		TaskID: taskID, UserSub: namenlos, Liters: &liter, DoneAt: srv.now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	liste := rangliste(t, ts, profilKarl)
+	if len(liste.Entries) == 0 {
+		t.Fatal("die Rangliste ist leer")
+	}
+	eintrag := liste.Entries[0]
+	if eintrag.UserSub != namenlos {
+		t.Fatalf("Platz 1 = %+v, erwartet die namenlose Kennung", eintrag)
+	}
+	if eintrag.UserName == "" {
+		t.Fatal("Platz 1 steht weiterhin ohne Namen in der Rangliste")
+	}
+	if got, want := eintrag.UserName, model.AnonymousName(namenlos); got != want {
+		t.Fatalf("Platz 1 heißt %q, erwartet den Spitznamen %q", got, want)
+	}
+
+	// Im Verzeichnis der Dorfbewohner ändert sich dagegen nichts: Wer keinen
+	// Namen freigegeben hat, erscheint dort weiterhin nicht.
+	for _, m := range mitglieder(t, ts, profilKarl).Members {
+		if m.UserSub == namenlos {
+			t.Fatalf("der Spitzname holt jemanden ins Verzeichnis: %+v", m)
+		}
 	}
 }

--- a/backend/internal/model/anonymousname.go
+++ b/backend/internal/model/anonymousname.go
@@ -1,0 +1,139 @@
+package model
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+)
+
+// Spitzname für Namenlose.
+//
+// Wer weder Nickname noch Anzeigenamen gesetzt hat und dessen Rössing-ID
+// keinen Namen mitliefert, stand bisher als Leerstelle in der Rangliste: eine
+// Zeile mit Punkten, Litern und Auszeichnungen — nur ohne Namen. Statt der
+// Leerstelle bekommt diese Person hier einen freundlichen Platzhalter
+// („Lustiger Lurch“).
+//
+// Der Platzhalter ist KEIN Name. Er steht an der Stelle, an der sonst nichts
+// stünde, und tritt hinter jeden selbst gewählten oder aus der Rössing-ID
+// übernommenen Namen zurück (siehe Profile.EffectiveName). Er macht auch
+// niemanden sichtbar, der es nicht ohnehin schon ist: Wer in einer Liste
+// fehlt, fehlt weiterhin (siehe Profile.AsMember).
+//
+// Was er über die Person verrät: nichts. Er entsteht allein aus der
+// Zitadel-Kennung, nicht aus Name, Nickname, E-Mail oder Telefonnummer — aus
+// „Lustiger Lurch“ lässt sich deshalb keines dieser Felder zurückrechnen. Die
+// Kennung selbst steht ohnehin in denselben Antworten (`userSub`), es kommt
+// also auch keine neue Verkettung hinzu.
+
+// anonymousNameSalt trennt diese Ableitung von jeder anderen Verwendung
+// derselben Kennung. Kein Geheimnis — nur eine feste Domänentrennung, damit
+// der Spitzname sich nicht mit einem anderen Hash derselben Kennung deckt.
+const anonymousNameSalt = "dorf-app/spitzname/v1:"
+
+// anonymousAdjectives sind die Adjektive des Spitznamens, in starker
+// Beugung männlich Nominativ („Lustiger …“) — deshalb enden alle auf „-er“
+// und deshalb sind in anonymousAnimals nur männliche Tiere aufgeführt.
+//
+// Die Auswahl ist bewusst eng: ausschließlich freundliche oder neutrale
+// Wörter. Verboten sind nicht nur Schimpfwörter, sondern auch alles, was
+// herablassend gelesen werden könnte („brav“, „putzig“, „drollig“), alles
+// über Alter, Körper oder Fähigkeiten („alt“, „dick“, „langsam“, „blind“)
+// und alles Ironiefähige („komisch“, „schräg“, „seltsam“).
+//
+// Wer die Liste ändert, ändert die Spitznamen aller Namenlosen: Die Auswahl
+// läuft über den Rest einer Division durch die Listenlänge, ein eingefügtes
+// oder entferntes Wort verschiebt also alle. Das ist keine Falle, sondern
+// eine bewusste Abwägung — dafür braucht es keine Tabelle und keine
+// Datenwanderung. Der Golden-Test in anonymousname_test.go schlägt an,
+// sobald sich etwas verschiebt.
+var anonymousAdjectives = []string{
+	"Freundlicher",
+	"Fröhlicher",
+	"Flinker",
+	"Emsiger",
+	"Mutiger",
+	"Sanfter",
+	"Ruhiger",
+	"Kluger",
+	"Geduldiger",
+	"Gelassener",
+	"Herzlicher",
+	"Sonniger",
+	"Eifriger",
+	"Froher",
+	"Wachsamer",
+	"Zufriedener",
+	"Gemütlicher",
+	"Verträumter",
+	"Verspielter",
+	"Geschickter",
+	"Pfiffiger",
+	"Quirliger",
+	"Lustiger",
+	"Goldener",
+	"Silberner",
+	"Hilfsbereiter",
+	"Tapferer",
+	"Aufgeweckter",
+}
+
+// anonymousAnimals sind die Tiere des Spitznamens. Alle sind männlich („der
+// Dachs“), sonst passte die Endung des Adjektivs nicht.
+//
+// Auch hier ist die Auswahl eng, und zwar Paar für Paar geprüft: Tiere, die
+// im Deutschen als Beschimpfung eines Menschen taugen, fehlen bewusst —
+// Esel, Ochse, Affe, Wurm, Ratte, Bock, Pfau, Gockel, Kauz, Vogel („komischer
+// Vogel“), Molch („Lustmolch“), Reiher („reihern“), Specht, Rabe, Spatz,
+// Frosch („sei kein Frosch“), Maulwurf („blind wie ein …“), Krebs (Krankheit).
+// Was fehlt, fehlt aus einem Grund; wer etwas hinzufügt, prüft es gegen alle
+// Adjektive, nicht nur für sich allein.
+var anonymousAnimals = []string{
+	"Lurch",
+	"Dachs",
+	"Igel",
+	"Otter",
+	"Marder",
+	"Biber",
+	"Luchs",
+	"Waschbär",
+	"Fuchs",
+	"Storch",
+	"Kranich",
+	"Fink",
+	"Zeisig",
+	"Kolibri",
+	"Falter",
+	"Käfer",
+	"Salamander",
+	"Seestern",
+	"Delfin",
+	"Pinguin",
+	"Elch",
+	"Schwan",
+	"Uhu",
+	"Falke",
+	"Hase",
+	"Grashüpfer",
+	"Seehund",
+	"Ameisenbär",
+}
+
+// AnonymousName bildet eine Zitadel-Kennung auf einen Spitznamen ab.
+//
+// Reproduzierbar statt gewürfelt: Dieselbe Kennung ergibt in jedem Prozess,
+// nach jedem Neustart und in jeder Kopie der Datenbank denselben Namen. Ein
+// gewürfelter und gespeicherter Wert bräuchte eine Spalte, einen Schreibweg
+// beim ersten Lesen und eine Nachrüstung für die Bestandsprofile — und beim
+// Einspielen einer Sicherung ohne diese Spalte hieße jemand plötzlich anders.
+//
+// Ohne Kennung gibt es keinen Spitznamen: Wo nichts identifiziert wird, ist
+// auch nichts zu benennen.
+func AnonymousName(userSub string) string {
+	if userSub == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(anonymousNameSalt + userSub))
+	adjective := anonymousAdjectives[binary.BigEndian.Uint32(sum[0:4])%uint32(len(anonymousAdjectives))]
+	animal := anonymousAnimals[binary.BigEndian.Uint32(sum[4:8])%uint32(len(anonymousAnimals))]
+	return adjective + " " + animal
+}

--- a/backend/internal/model/anonymousname_test.go
+++ b/backend/internal/model/anonymousname_test.go
@@ -1,0 +1,283 @@
+package model
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"unicode"
+)
+
+// --- Stabilität ---------------------------------------------------------------
+
+// TestAnonymousNameIstStabil: Dieselbe Kennung ergibt denselben Namen — im
+// selben Aufruf, im nächsten und nach einem Neustart des Servers. Die
+// erwarteten Werte stehen hier fest verdrahtet: Sie sind der Alarm, der
+// anschlägt, wenn jemand die Wortlisten umsortiert oder ein Wort einfügt und
+// damit alle Namenlosen umbenennt.
+func TestAnonymousNameIstStabil(t *testing.T) {
+	golden := map[string]string{
+		"111111111111111111": "Ruhiger Schwan",
+		"222222222222222222": "Freundlicher Dachs",
+		"333333333333333333": "Goldener Falke",
+		"444444444444444444": "Sonniger Uhu",
+		"erna-sub":           "Tapferer Salamander",
+	}
+	for sub, want := range golden {
+		if got := AnonymousName(sub); got != want {
+			t.Errorf("AnonymousName(%q) = %q, erwartet %q — wurden die Wortlisten geändert? "+
+				"Dann heißen alle Namenlosen ab jetzt anders.", sub, got, want)
+		}
+	}
+	// Zweimal gefragt, zweimal dasselbe: keine Zufallsquelle, keine Uhr.
+	for sub := range golden {
+		if AnonymousName(sub) != AnonymousName(sub) {
+			t.Errorf("AnonymousName(%q) ist nicht reproduzierbar", sub)
+		}
+	}
+}
+
+// TestAnonymousNameBrauchtEineKennung: Ohne Kennung gibt es nichts zu
+// benennen — und damit auch keinen Spitznamen für ein leeres Profil.
+func TestAnonymousNameBrauchtEineKennung(t *testing.T) {
+	if got := AnonymousName(""); got != "" {
+		t.Errorf("AnonymousName(\"\") = %q, erwartet den leeren String", got)
+	}
+	if got := (Profile{}).EffectiveName(); got != "" {
+		t.Errorf("leeres Profil = %q, erwartet den leeren String", got)
+	}
+}
+
+// TestAnonymousNameHaengtNurAnDerKennung: Der Spitzname darf nichts über die
+// Person verraten. Er entsteht deshalb allein aus der Kennung — Name,
+// Nickname, E-Mail, Telefon und Notiz gehen nicht ein.
+func TestAnonymousNameHaengtNurAnDerKennung(t *testing.T) {
+	sub := "555555555555555555"
+	erwartet := AnonymousName(sub)
+	p := Profile{UserSub: sub, Phone: "05066 123456", Email: "erna@example.org",
+		Note: "erreichbar abends"}
+	if got := p.EffectiveName(); got != erwartet {
+		t.Errorf("EffectiveName mit Kontaktdaten = %q, erwartet %q", got, erwartet)
+	}
+	// Und umgekehrt: zwei verschiedene Kennungen dürfen nicht auf denselben
+	// Namen zusammenfallen, nur weil sie sich ähnlich sehen.
+	if AnonymousName("600000000000000001") == AnonymousName("600000000000000002") {
+		t.Error("benachbarte Kennungen ergeben denselben Spitznamen")
+	}
+}
+
+// TestAnonymousNameStreut: Die Namen verteilen sich über beide Wortlisten.
+// Ein Fehler in der Indexrechnung (etwa dieselben vier Bytes für beide
+// Wörter) fiele sonst nicht auf — alle hießen dann „Freundlicher Lurch“.
+func TestAnonymousNameStreut(t *testing.T) {
+	adjektive := map[string]bool{}
+	tiere := map[string]bool{}
+	for i := 0; i < 2000; i++ {
+		name := AnonymousName("sub-" + strconv.Itoa(i))
+		teile := strings.SplitN(name, " ", 2)
+		if len(teile) != 2 {
+			t.Fatalf("Spitzname ohne zwei Teile: %q", name)
+		}
+		adjektive[teile[0]] = true
+		tiere[teile[1]] = true
+	}
+	if len(adjektive) != len(anonymousAdjectives) {
+		t.Errorf("%d von %d Adjektiven kamen vor", len(adjektive), len(anonymousAdjectives))
+	}
+	if len(tiere) != len(anonymousAnimals) {
+		t.Errorf("%d von %d Tieren kamen vor", len(tiere), len(anonymousAnimals))
+	}
+}
+
+// --- Vorrang echter Namen -----------------------------------------------------
+
+// TestEchteNamenGehenVor: Der Spitzname ist der letzte Ausweg. Wer einen
+// Nickname, einen Anzeigenamen oder einen Namen in der Rössing-ID hat, behält
+// ihn — sonst wäre aus einem Platzhalter eine Umbenennung geworden.
+func TestEchteNamenGehenVor(t *testing.T) {
+	sub := "777777777777777777"
+	spitzname := AnonymousName(sub)
+	faelle := []struct {
+		was     string
+		profil  Profile
+		erwartt string
+	}{
+		{"Nickname schlägt alles",
+			Profile{UserSub: sub, Nickname: "Gießmeisterin", DisplayName: "Erna Beispiel", TokenName: "Erna"},
+			"Gießmeisterin"},
+		{"Anzeigename ohne Nickname",
+			Profile{UserSub: sub, DisplayName: "Erna Beispiel", TokenName: "Erna"},
+			"Erna Beispiel"},
+		{"Name aus der Rössing-ID",
+			Profile{UserSub: sub, TokenName: "Erna"},
+			"Erna"},
+		{"gar nichts — erst hier greift der Spitzname",
+			Profile{UserSub: sub},
+			spitzname},
+	}
+	for _, f := range faelle {
+		if got := f.profil.EffectiveName(); got != f.erwartt {
+			t.Errorf("%s: EffectiveName = %q, erwartet %q", f.was, got, f.erwartt)
+		}
+	}
+	if spitzname == "" {
+		t.Fatal("der Spitzname ist leer — dann füllt er keine Leerstelle")
+	}
+}
+
+// TestSpitznameFuelltDieRangliste: Der Weg, den Rangliste, Historie und
+// Vergabe gehen (NameResolver.Resolve), liefert für ein namenloses Profil den
+// Spitznamen — und lässt einen eingefrorenen fremden Namen in Ruhe.
+func TestSpitznameFuelltDieRangliste(t *testing.T) {
+	sub := "888888888888888888"
+	namen := NameResolver{sub: {UserSub: sub}}
+
+	if got := namen.Resolve(sub, ""); got != AnonymousName(sub) {
+		t.Errorf("Rangliste = %q, erwartet den Spitznamen %q", got, AnonymousName(sub))
+	}
+	// Eine von der Verwaltung nachgetragene Meldung läuft unter fremdem
+	// Namen; der bleibt stehen (siehe MatchesStoredName).
+	if got := namen.Resolve(sub, "Karl Nachbar"); got != "Karl Nachbar" {
+		t.Errorf("Nachtrag = %q, erwartet den eingefrorenen Namen", got)
+	}
+	// Wer gar kein Profil hat, bekommt keinen Spitznamen: Über ihn ist
+	// nichts bekannt, nicht einmal, dass er die App je geöffnet hat.
+	if got := namen.Resolve("fremde-kennung", "Alte Meldung"); got != "Alte Meldung" {
+		t.Errorf("ohne Profil = %q, erwartet den gespeicherten Namen", got)
+	}
+}
+
+// TestSpitznameHoltNiemandenInsVerzeichnis: Wer weder Anzeigenamen noch
+// Nickname freigegeben hat, taucht in der Dorfbewohner-Liste weiterhin nicht
+// auf. Der Spitzname füllt Leerstellen; er darf niemanden sichtbarer machen,
+// als er es vorher war.
+func TestSpitznameHoltNiemandenInsVerzeichnis(t *testing.T) {
+	sub := "999999999999999999"
+	ohneAlles := Profile{UserSub: sub, Visibility: DefaultVisibility()}
+	if _, ok := ohneAlles.AsMember(false); ok {
+		t.Error("ein namenloses Profil steht plötzlich im Verzeichnis")
+	}
+	zurueckhaltend := Profile{UserSub: sub, DisplayName: "Erna Beispiel", Nickname: "Gießmeisterin",
+		Visibility: ProfileVisibility{DisplayName: VisibilityAdmins, Nickname: VisibilityAdmins,
+			Phone: VisibilityAdmins, Email: VisibilityAdmins, Note: VisibilityAdmins}}
+	if _, ok := zurueckhaltend.AsMember(false); ok {
+		t.Error("ein zurückhaltendes Profil steht plötzlich im Verzeichnis")
+	}
+	// Für die Verwaltung dagegen ist die Leerstelle nur unpraktisch: Sie
+	// sieht die Zeile ohnehin und bekommt jetzt einen Namen dazu.
+	m, ok := ohneAlles.AsMember(true)
+	if !ok || m.Name != AnonymousName(sub) {
+		t.Errorf("Verwaltungssicht = %q (ok=%v), erwartet den Spitznamen", m.Name, ok)
+	}
+}
+
+// --- Beleidigungsfreiheit -----------------------------------------------------
+
+// verbotenePaare sind Wortkombinationen, die im Deutschen als Herabsetzung
+// gelesen werden — auch dann, wenn beide Wörter für sich harmlos wirken.
+// Genau darum wird hier Paar für Paar geprüft und nicht Wort für Wort.
+var verbotenePaare = []string{
+	"komischer vogel", "schräger vogel", "schräger typ", "seltsamer kauz",
+	"komischer kauz", "alter kauz", "lustiger molch", "geiler bock",
+	"sturer bock", "fauler hund", "armer hund", "armer wurm", "armer tropf",
+	"dummer esel", "blöder esel", "eitler pfau", "stolzer gockel",
+	"lahme ente", "blinde kuh", "dumme gans", "alte schachtel", "alter sack",
+	"fetter wal", "flotter otto", "toter fisch", "kalter fisch",
+	"trauriger wicht", "armer wicht", "dicker brocken", "blinder maulwurf",
+	"frecher dachs", "schmutziger fink", "brummiger bär", "faules stück",
+	"tapsiger bär", "lahmer sack", "müder krieger",
+}
+
+// verboteneTiere sind Tiere, die im Deutschen als Beschimpfung eines
+// Menschen dienen. Sie haben in der Liste nichts zu suchen — egal, wie
+// freundlich das Adjektiv davor ist.
+var verboteneTiere = []string{
+	"esel", "ochse", "affe", "wurm", "ratte", "bock", "pfau", "gockel",
+	"kauz", "vogel", "molch", "reiher", "specht", "rabe", "spatz", "kater",
+	"krebs", "sau", "schwein", "eber", "keiler", "ziege", "kuh", "gans",
+	"ente", "hund", "hammel", "schaf", "made", "laus", "zecke", "wanze",
+	"floh", "kröte", "schlange", "geier", "hyäne", "walross", "nilpferd",
+	"maulwurf", "frosch", "wicht", "tropf",
+}
+
+// verboteneAdjektive stehen in derselben Beugung wie die Liste selbst, damit
+// exakt verglichen werden kann. Sie treffen Alter, Körper, Verstand,
+// Fähigkeiten — und alles, was herablassend oder ironisch gemeint sein kann.
+var verboteneAdjektive = []string{
+	"alter", "junger", "dicker", "fetter", "dünner", "dürrer", "kleiner",
+	"großer", "hässlicher", "dummer", "blöder", "fauler", "lahmer",
+	"langsamer", "blinder", "tauber", "krummer", "schiefer", "schräger",
+	"komischer", "seltsamer", "sonderbarer", "schrulliger", "armer",
+	"trauriger", "einsamer", "müder", "sturer", "eitler", "frecher",
+	"wilder", "schmutziger", "dreckiger", "tollpatschiger", "ängstlicher",
+	"schüchterner", "braver", "artiger", "putziger", "drolliger",
+	"possierlicher", "tapsiger", "nasser", "geiler", "stolzer", "brummiger",
+}
+
+// TestWortlistenSindHarmlos prüft die Wortlisten so, wie sie gelesen werden:
+// nicht Wort für Wort, sondern in jeder Kombination, die entstehen kann.
+// Verglichen wird auf ganze Wörter, nicht auf Teilstücke — sonst schlüge
+// „Falter“ wegen „alt“ und „Seehund“ wegen „hund“ an, und der Test wäre nach
+// dem dritten Fehlalarm abgeschaltet.
+func TestWortlistenSindHarmlos(t *testing.T) {
+	enthaelt := func(liste []string, wort string) bool {
+		for _, x := range liste {
+			if x == wort {
+				return true
+			}
+		}
+		return false
+	}
+	for _, adjektiv := range anonymousAdjectives {
+		for _, tier := range anonymousAnimals {
+			paar := adjektiv + " " + tier
+			klein := strings.ToLower(paar)
+			if enthaelt(verbotenePaare, klein) {
+				t.Errorf("die Paarung %q ist eine feststehende Herabsetzung", paar)
+			}
+			if enthaelt(verboteneAdjektive, strings.ToLower(adjektiv)) {
+				t.Errorf("%q: das Adjektiv %q setzt herab", paar, adjektiv)
+			}
+			if enthaelt(verboteneTiere, strings.ToLower(tier)) {
+				t.Errorf("%q: %q dient im Deutschen als Beschimpfung", paar, tier)
+			}
+		}
+	}
+}
+
+// TestWortlistenSindWohlgeformt hält die Form fest, von der der Rest abhängt:
+// Adjektive in starker Beugung männlich („-er“), Tiere männlich und
+// einzelnes Wort, alles groß geschrieben, nichts doppelt.
+func TestWortlistenSindWohlgeformt(t *testing.T) {
+	if len(anonymousAdjectives) == 0 || len(anonymousAnimals) == 0 {
+		t.Fatal("eine der Wortlisten ist leer — dann gibt es keinen Spitznamen")
+	}
+	pruefe := func(was string, liste []string) {
+		gesehen := map[string]bool{}
+		for _, wort := range liste {
+			if gesehen[wort] {
+				t.Errorf("%s: %q steht doppelt in der Liste", was, wort)
+			}
+			gesehen[wort] = true
+			if wort == "" || strings.ContainsAny(wort, " \t\n") {
+				t.Errorf("%s: %q ist kein einzelnes Wort", was, wort)
+			}
+			for _, r := range wort {
+				if unicode.IsControl(r) {
+					t.Errorf("%s: %q enthält ein Steuerzeichen", was, wort)
+				}
+			}
+			if r := []rune(wort); len(r) > 0 && !unicode.IsUpper(r[0]) {
+				t.Errorf("%s: %q fängt klein an", was, wort)
+			}
+		}
+	}
+	pruefe("Adjektiv", anonymousAdjectives)
+	pruefe("Tier", anonymousAnimals)
+
+	for _, adjektiv := range anonymousAdjectives {
+		if !strings.HasSuffix(adjektiv, "er") {
+			t.Errorf("das Adjektiv %q endet nicht auf „-er“ — dann passt es nicht zu einem "+
+				"männlichen Tier („Lustiger Lurch“)", adjektiv)
+		}
+	}
+}

--- a/backend/internal/model/profil.go
+++ b/backend/internal/model/profil.go
@@ -74,15 +74,23 @@ type Profile struct {
 }
 
 // EffectiveName ist der Name, unter dem die Person im Dorf auftritt:
-// Nickname, sonst Anzeigename, sonst der Name aus der Rössing-ID.
+// Nickname, sonst Anzeigename, sonst der Name aus der Rössing-ID — und wenn
+// nichts davon da ist, der Spitzname (siehe AnonymousName).
+//
+// Der Spitzname steht ausdrücklich am Ende: Er ersetzt keinen Namen, er
+// vertritt ihn nur dort, wo sonst eine Leerstelle stünde. Genau das war der
+// Fall — die Rangliste zeigte Zeilen mit Punkten, Litern und Auszeichnungen,
+// aber ohne Namen.
 func (p Profile) EffectiveName() string {
 	switch {
 	case p.Nickname != "":
 		return p.Nickname
 	case p.DisplayName != "":
 		return p.DisplayName
-	default:
+	case p.TokenName != "":
 		return p.TokenName
+	default:
+		return AnonymousName(p.UserSub)
 	}
 }
 
@@ -174,6 +182,16 @@ func (p Profile) AsMember(istVerwaltung bool) (Member, bool) {
 	}
 	// Der angezeigte Name folgt derselben Regel wie in der Rangliste, nutzt
 	// aber nur die freigegebenen Felder.
+	//
+	// Hier greift der Spitzname bewusst NICHT. In der Rangliste steht die
+	// Person ohnehin schon, nur ohne Namen — dort füllt er eine Leerstelle.
+	// Im Verzeichnis dagegen fehlt sie ganz, und zwar weil sie weder
+	// Anzeigenamen noch Nickname freigegeben hat. Sie als „Lustiger Lurch“
+	// aufzunehmen wäre keine Kosmetik, sondern ein neuer Eintrag: Er verriete,
+	// dass es dieses Konto gibt, und machte aus einer Entscheidung gegen die
+	// Liste eine Aufnahme in sie. Ein Eintrag ohne Namen und ohne Kontaktdaten
+	// nützt dem Verzeichnis („wer macht mit, wie erreiche ich sie“) auch
+	// nichts.
 	switch {
 	case m.Nickname != "":
 		m.Name = m.Nickname


### PR DESCRIPTION
Fixes #79

Wer weder Nickname noch Anzeigenamen gesetzt hat und dessen Rössing-ID keinen
Namen mitliefert, stand namenlos in der Rangliste — die Zeile war da, mit Rang,
Litern und Auszeichnungen, nur die Beschriftung fehlte. Dort steht jetzt ein
freundlicher Spitzname.

Ein paar echte Beispiele aus dem Golden-Test:

| Kennung | Spitzname |
| --- | --- |
| `111111111111111111` | Ruhiger Schwan |
| `222222222222222222` | Freundlicher Dachs |
| `333333333333333333` | Goldener Falke |
| `444444444444444444` | Sonniger Uhu |
| `erna-sub` | Tapferer Salamander |

## Wie der Name entsteht

`model.AnonymousName(userSub)` in `backend/internal/model/anonymousname.go`:
SHA-256 über eine feste Domänentrennung plus die Zitadel-Kennung; die ersten
vier Byte wählen ein Adjektiv, die nächsten vier ein Tier — aus zwei von Hand
gepflegten Wortlisten (28 × 28 = 784 Namen) im Quelltext, nicht in einer
erzeugten Datei. Nur Standardbibliothek (`crypto/sha256`, `encoding/binary`),
keine neue Abhängigkeit.

Die Adjektive stehen in starker Beugung männlich („Lustiger …"), die Tiere sind
deshalb alle männlich. Beides ist im Test festgehalten, damit die Grammatik
nicht bei der nächsten Ergänzung kippt.

## Warum er stabil ist

Er wird **abgeleitet**, nicht gewürfelt und gespeichert. Dieselbe Kennung ergibt
in jedem Prozess, nach jedem Neustart, in jeder Kopie und in jeder
wiederhergestellten Sicherung denselben Namen. Ein gewürfelter Wert in der
Datenbank bräuchte eine Spalte, einen Schreibweg beim ersten Lesen und eine
Nachrüstung für die Bestandsprofile — und beim Einspielen einer Sicherung, die
diese Spalte nicht kennt, hieße jemand plötzlich anders. Ohne Zustand gibt es
diesen Fall nicht.

Ein Golden-Test verdrahtet fünf Namen fest. Er ist der Alarm für die einzige
echte Falle dieser Konstruktion: Die Auswahl läuft über den Rest einer Division
durch die Listenlänge, ein eingefügtes oder umsortiertes Wort verschiebt also
**alle** Spitznamen. Das ist eine bewusste Abwägung gegen eine Tabelle — und wer
die Listen anfasst, sieht am roten Test, was er auslöst.

## Was er über die Person verrät

Nichts. Es geht ausschließlich die Zitadel-Kennung ein — nicht Name, Nickname,
Anzeigename, E-Mail, Telefon oder Notiz. Aus „Ruhiger Schwan" ist keines dieser
Felder zurückzurechnen.

Er ist ein stabiles Pseudonym **zur Kennung**: Wer die Kennung hat, kann den
Spitznamen ausrechnen. Das ist keine neue Verkettbarkeit — `userSub` steht in
denselben Antworten ohnehin drin (siehe die Rangliste im Issue), und die
Zuordnung Kennung → Person entsteht dadurch nicht.

Zwei Personen können denselben Spitznamen bekommen (bei 784 Namen und einer
Handvoll Namenlosen unwahrscheinlich, aber möglich). Das ist bewusst in Kauf
genommen: Jede Auflösung von Kollisionen müsste die Namen **aller** anderen
kennen, und damit wäre der Name nicht mehr aus der Kennung allein bestimmt.

## Welche Sichtbarkeit sich ändert

**Keine — und das war eine Entscheidung.**

`Profile.EffectiveName` bekommt einen vierten Fall ganz am Ende. Er greift nur,
wenn Nickname, Anzeigename und Name aus der Rössing-ID alle leer sind. Jeder
echte Name geht vor; ein von der Verwaltung unter fremdem Namen eingetragener
Nachtrag bleibt unberührt (`MatchesStoredName`). Damit füllen sich die
Leerstellen überall dort, wo `model.NameResolver` schon heute den Namen
auflöst: Rangliste, Ortshistorie, letzte Erledigung in der Ortsliste, Vergabe
(„… wurde gerade schon von X übernommen"), Befähigungsanträge, Web-Verwaltung
und Chat.

`Profile.AsMember` bleibt **absichtlich unverändert**. Im Verzeichnis der
Dorfbewohner fehlen diese Leute weiterhin ganz. Der Unterschied ist fachlich,
nicht kosmetisch:

- In der Rangliste **steht** die Person bereits. Sie ist dort nicht versteckt,
  sondern unbenannt; ihr eine Beschriftung zu geben ändert nichts daran, wer
  sichtbar ist.
- Im Verzeichnis **fehlt** sie, und zwar weil sie weder Anzeigenamen noch
  Nickname freigegeben hat. Sie als „Lustiger Lurch" aufzunehmen wäre ein neuer
  Eintrag: Er verriete, dass es dieses Konto gibt, und machte aus einer
  Entscheidung gegen die Liste eine Aufnahme in sie. Ein Eintrag ohne Namen und
  ohne Kontaktdaten nützt dem Verzeichnis („wer macht mit, wie erreiche ich
  sie") ohnehin nichts.

Die Verwaltungssicht (`AsMember(true)`) bekommt den Spitznamen als Namen — sie
sieht die Zeile ohnehin, bisher nur ohne Beschriftung.

Wer gar kein Profil hat, bekommt weiterhin **keinen** Spitznamen: Über ihn ist
nichts bekannt, nicht einmal, dass er die App je geöffnet hat. Bestandsdaten
behalten ihren gespeicherten Namen, „Unbekannt" in der Vergabe bleibt für genau
diesen Fall.

`model.Zugriff` ist nicht angefasst; es entsteht keine zweite Sichtbarkeitsprüfung.

## Beleidigungsfreiheit

Als geprüfte Eigenschaft, nicht als Sorgfaltspflicht. `TestWortlistenSindHarmlos`
geht **alle 784 Paarungen** durch und prüft drei Dinge: keine feststehende
herabsetzende Kombination („komischer Vogel", „sturer Bock", „armer Wurm",
„flotter Otto" …), kein Tier aus der Liste der gängigen Beschimpfungen (Esel,
Ochse, Affe, Wurm, Kauz, Vogel, Molch, Reiher, Specht, Rabe, Kater, Krebs …),
kein Adjektiv über Alter, Körper, Verstand oder Fähigkeiten — und auch keins,
das herablassend gemeint sein kann („brav", „putzig", „drollig").

Verglichen wird auf **ganze Wörter**, nicht auf Teilstücke: Sonst schlüge
„Falter" wegen „alt" und „Seehund" wegen „hund" an, und der Test wäre nach dem
dritten Fehlalarm abgeschaltet. Was in den Listen fehlt, fehlt aus einem Grund;
die Kommentare im Quelltext nennen ihn.

## Tests

Alle lokal, keiner fasst einen entfernten Server an
(`.github/scripts/pruefe_lokale_tests.py` geht durch).

- `TestAnonymousNameIstStabil` — Golden-Werte, zweimal gefragt zweimal dasselbe
- `TestAnonymousNameBrauchtEineKennung` — ohne Kennung kein Name
- `TestAnonymousNameHaengtNurAnDerKennung` — Kontaktdaten gehen nicht ein
- `TestAnonymousNameStreut` — beide Listen werden vollständig genutzt
- `TestEchteNamenGehenVor` — Nickname > Anzeigename > Rössing-ID > Spitzname
- `TestSpitznameFuelltDieRangliste` — der Weg über `NameResolver.Resolve`
- `TestSpitznameHoltNiemandenInsVerzeichnis` — `AsMember` unverändert
- `TestWortlistenSindHarmlos`, `TestWortlistenSindWohlgeformt`
- `TestRanglisteZeigtSpitznameStattLeerstelle` (`internal/api`) — baut den in
  der Produktion beobachteten Zustand über die API nach, inklusive der Probe,
  dass das Verzeichnis unberührt bleibt

## Apps

**Keine Änderung an `android/` oder `ios/` nötig.** Beide zeigen `userName` so
an, wie er kommt; bisher war das ein leerer String, jetzt ein Spitzname. Genau
deshalb sitzt die Regel im Backend: Sonst hätten Android, iOS, Web-Verwaltung
und Chat vier Fassungen desselben Namens, und dieselbe Person hieße je nach
Telefon anders.

## Bewusst offen gelassen

Beim Lesen ist ein zweiter, unabhängiger Befund aufgefallen: Der
Sichtbarkeits-Schalter am Anzeigenamen bzw. Nickname wirkt nur im Verzeichnis,
nicht in Rangliste und Historie — ein Anzeigename auf „nur für Verwaltende"
steht trotzdem für alle in der Rangliste. Das ist hier **nicht** mitgeändert,
damit der Spitzname keine Sichtbarkeitsänderung mitschleppt; er liegt als #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyFr41QjEr7CGPjtAkUhwz
