### PR TITLE
Die Anmeldung in der Verwaltung überlebt Rollouts — und hält 30 Tage

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -175,7 +175,7 @@ func main() {
 		admin.Register(mux, admin.Config{
 			DB: database, Verifier: verifier, Issuer: issuer,
 			ClientID: clientID, PublicURL: publicURL,
-			SessionKey: []byte(os.Getenv("SESSION_KEY")),
+			SessionKey: sessionKey(database),
 			Mitglieder: mitglieder,
 		})
 		if clientID != "" {
@@ -469,4 +469,33 @@ func envInt64(key string, def int64) int64 {
 		return def
 	}
 	return n
+}
+
+// sessionKey liefert den Schlüssel, mit dem die Web-Verwaltung ihre Cookies
+// signiert.
+//
+// SESSION_KEY aus der Umgebung hat Vorrang — ausdrücklich schlägt
+// stillschweigend. Ohne ihn kommt der Schlüssel aus der Datenbank, die auf
+// einem PVC liegt und Rollouts überlebt; beim ersten Start entsteht er dort
+// von selbst.
+//
+// Der Grund für den Umbau: Vorher hieß „SESSION_KEY nicht gesetzt“ still
+// „bei jedem Start ein neuer Zufallsschlüssel“ — und damit war nach jedem
+// Rollout jede Anmeldung in der Verwaltung ungültig. An einem Tag mit
+// mehreren Auslieferungen musste man sich alle paar Stunden neu anmelden,
+// ohne dass irgendwo stand, warum.
+func sessionKey(database *db.DB) []byte {
+	if v := os.Getenv("SESSION_KEY"); v != "" {
+		return []byte(v)
+	}
+	key, err := database.SessionKey()
+	if err != nil {
+		// Kein Grund, den Server nicht zu starten: Die Verwaltung bekommt
+		// dann einen Zufallsschlüssel und verlangt nach dem nächsten Start
+		// eine neue Anmeldung. Laut gesagt wird es trotzdem.
+		slog.Warn("Session-Schlüssel nicht aus der Datenbank lesbar — "+
+			"Anmeldungen in der Verwaltung überleben keinen Neustart", "fehler", err)
+		return nil
+	}
+	return key
 }

--- a/backend/internal/admin/admin.go
+++ b/backend/internal/admin/admin.go
@@ -274,6 +274,8 @@ func (a *App) requireAdmin(h func(http.ResponseWriter, *http.Request, session)) 
 			http.Redirect(w, r, "/admin/", http.StatusSeeOther)
 			return
 		}
+		// Wer die Verwaltung benutzt, bleibt angemeldet.
+		a.sitzungAuffrischen(w, s)
 		h(w, r, s)
 	}
 }
@@ -297,6 +299,9 @@ func (a *App) handleAdminHome(w http.ResponseWriter, r *http.Request) {
 		a.render(w, r, http.StatusOK, "anmelden", view{Title: "Anmelden"})
 		return
 	}
+	// Auch hier verlängern: Die Startseite ist genau die Stelle, an die
+	// jemand nach ein paar Tagen zurückkommt.
+	a.sitzungAuffrischen(w, s)
 	a.render(w, r, http.StatusOK, "verwaltung", view{Title: "Verwaltung", Nav: "verwaltung",
 		Data: a.bereichsDaten()})
 }

--- a/backend/internal/admin/oidc.go
+++ b/backend/internal/admin/oidc.go
@@ -172,14 +172,14 @@ func (a *App) handleCallback(w http.ResponseWriter, r *http.Request) {
 		Sub: user.Sub, Name: user.Name, Email: user.Email, Admin: user.IsAdmin(),
 		Rollen:  rollenListe(user),
 		IDToken: tok.IDToken,
-		Exp:     a.now().Add(8 * time.Hour).Unix(),
+		Exp:     a.now().Add(sitzungsdauer).Unix(),
 	}
 	value, err := a.signer.encode(cookieSession, s)
 	if err != nil {
 		a.fail(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	a.setCookie(w, cookieSession, value, 8*60*60)
+	a.setCookie(w, cookieSession, value, int(sitzungsdauer.Seconds()))
 	a.setFlash(w, "success", "Angemeldet als "+anzeigeName(s))
 	http.Redirect(w, r, ziel, http.StatusSeeOther)
 }

--- a/backend/internal/admin/session.go
+++ b/backend/internal/admin/session.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // Cookie-Namen. Alle Cookies sind HttpOnly und SameSite=Lax; „Secure“ wird
@@ -17,6 +18,23 @@ const (
 	cookieSession = "dorf_admin_session"
 	cookieFlow    = "dorf_admin_flow"
 	cookieFlash   = "dorf_admin_flash"
+)
+
+// Wie lange eine Anmeldung in der Verwaltung hält, und ab wann sie beim
+// nächsten Aufruf verlängert wird.
+//
+// Dreißig Tage klingen lang. Sie sind es auch — und zwar mit Absicht: Die
+// Verwaltung benutzen ein paar Leute im Dorf nebenbei, oft alle paar Tage
+// einmal. Wer sich dabei jedes Mal neu anmelden muss, benutzt sie irgendwann
+// nicht mehr. Getragen wird das Cookie von HttpOnly, Secure und SameSite=Lax,
+// und es öffnet nichts, was die Rolle in der Rössing-ID nicht ohnehin öffnet.
+//
+// Verlängert wird gleitend, aber höchstens einmal am Tag: Wer die Verwaltung
+// benutzt, bleibt angemeldet; wer sie einen Monat nicht anfasst, fliegt
+// heraus. Die Schwelle spart das Neu-Setzen des Cookies bei jedem Klick.
+const (
+	sitzungsdauer     = 30 * 24 * time.Hour
+	sitzungsauffrisch = 24 * time.Hour
 )
 
 // session ist der Inhalt des Session-Cookies. Es enthält bewusst KEIN
@@ -135,6 +153,26 @@ func (a *App) sessionOf(r *http.Request) (session, bool) {
 		return session{}, false
 	}
 	return s, true
+}
+
+// sitzungAuffrischen schiebt das Ablaufdatum nach vorn, wenn seit der letzten
+// Auffrischung ein Tag vergangen ist. So bleibt angemeldet, wer die
+// Verwaltung benutzt — ohne bei jedem Klick ein Cookie neu zu setzen.
+//
+// Schlägt das Signieren fehl, passiert nichts: Die bestehende Sitzung gilt
+// weiter, sie läuft nur irgendwann ab. Ein Fehler beim Verlängern darf
+// niemanden hinauswerfen.
+func (a *App) sitzungAuffrischen(w http.ResponseWriter, s session) {
+	frisch := a.now().Add(sitzungsdauer)
+	if time.Unix(s.Exp, 0).After(frisch.Add(-sitzungsauffrisch)) {
+		return
+	}
+	s.Exp = frisch.Unix()
+	value, err := a.signer.encode(cookieSession, s)
+	if err != nil {
+		return
+	}
+	a.setCookie(w, cookieSession, value, int(sitzungsdauer.Seconds()))
 }
 
 // --- Flash-Nachrichten ------------------------------------------------------

--- a/backend/internal/admin/sitzung_test.go
+++ b/backend/internal/admin/sitzung_test.go
@@ -1,0 +1,111 @@
+package admin
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// Wie lange eine Anmeldung in der Verwaltung hält.
+//
+// Der Anlass: Der Betreiber musste sich „nach 1h oder so" neu anmelden. Das
+// lag an zwei Dingen — einem Signierschlüssel, der jeden Neustart nicht
+// überlebte (siehe db.SessionKey), und einer Sitzung, die nach acht Stunden
+// endete, ohne sich je zu verlängern.
+
+// sitzungAus liest das Session-Cookie aus einer Antwort, oder nil.
+func sitzungAus(w http.Header) *http.Cookie {
+	for _, c := range (&http.Response{Header: w}).Cookies() {
+		if c.Name == cookieSession {
+			return c
+		}
+	}
+	return nil
+}
+
+// Wer die Verwaltung benutzt, bleibt angemeldet: Bei jedem Aufruf wandert das
+// Ablaufdatum nach vorn — aber höchstens einmal am Tag, damit nicht bei jedem
+// Klick ein Cookie neu gesetzt wird.
+func TestSitzungWirdBeimBenutzenVerlaengert(t *testing.T) {
+	a, mux, _, _ := aufbau(t)
+
+	// Eine Sitzung, die schon fast zwei Tage alt ist.
+	alt := session{Sub: "u1", Name: "Testadmin", Admin: true,
+		Exp: a.now().Add(sitzungsdauer - 2*sitzungsauffrisch).Unix()}
+	wert, err := a.signer.encode(cookieSession, alt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := hole(t, mux, "/admin/", &http.Cookie{Name: cookieSession, Value: wert})
+
+	c := sitzungAus(w.Header())
+	if c == nil {
+		t.Fatal("die Sitzung wurde nicht verlängert")
+	}
+	var neu session
+	if !a.signer.decode(cookieSession, c.Value, &neu) {
+		t.Fatalf("verlängertes Cookie ist nicht lesbar: %q", c.Value)
+	}
+	if neu.Exp <= alt.Exp {
+		t.Errorf("Ablauf nicht nach vorn geschoben: %d → %d", alt.Exp, neu.Exp)
+	}
+	if want := a.now().Add(sitzungsdauer).Unix(); neu.Exp != want {
+		t.Errorf("Ablauf ist %d, erwartet %d", neu.Exp, want)
+	}
+	// Wer angemeldet war, bleibt es auch — mit denselben Rechten.
+	if neu.Sub != "u1" || !neu.Admin {
+		t.Errorf("Sitzung beim Verlängern verändert: %+v", neu)
+	}
+	if c.MaxAge != int(sitzungsdauer.Seconds()) {
+		t.Errorf("MaxAge ist %d, erwartet %d", c.MaxAge, int(sitzungsdauer.Seconds()))
+	}
+}
+
+// Eine frische Sitzung wird nicht bei jedem Klick neu gesetzt.
+func TestFrischeSitzungWirdNichtStaendigNeuGesetzt(t *testing.T) {
+	a, mux, _, cookie := aufbau(t)
+	// testApp gibt eine Sitzung mit einer Stunde Restlaufzeit — die ist für
+	// diesen Fall zu alt. Also eine ganz frische bauen.
+	wert, err := a.signer.encode(cookieSession, session{Sub: "u1", Admin: true,
+		Exp: a.now().Add(sitzungsdauer).Unix()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cookie.Value = wert
+
+	w := hole(t, mux, "/admin/", cookie)
+	if c := sitzungAus(w.Header()); c != nil {
+		t.Errorf("frische Sitzung wurde unnötig neu gesetzt: %+v", c)
+	}
+}
+
+// Eine abgelaufene Sitzung wird nicht wiederbelebt — Verlängern gilt nur für
+// Sitzungen, die noch gelten.
+func TestAbgelaufeneSitzungWirdNichtVerlaengert(t *testing.T) {
+	a, mux, _, _ := aufbau(t)
+	wert, err := a.signer.encode(cookieSession, session{Sub: "u1", Admin: true,
+		Exp: a.now().Add(-time.Minute).Unix()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := hole(t, mux, "/admin/mithelfen/", &http.Cookie{Name: cookieSession, Value: wert})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("abgelaufene Sitzung kam durch: Status %d", w.Code)
+	}
+	if c := sitzungAus(w.Header()); c != nil && c.MaxAge > 0 {
+		t.Errorf("abgelaufene Sitzung wurde verlängert: %+v", c)
+	}
+}
+
+// Dreißig Tage sind Absicht, nicht Zufall: Die Verwaltung benutzen ein paar
+// Leute im Dorf nebenbei. Wer sich dabei jedes Mal neu anmelden muss, benutzt
+// sie irgendwann nicht mehr.
+func TestSitzungsdauerIstLang(t *testing.T) {
+	if sitzungsdauer < 7*24*time.Hour {
+		t.Errorf("Sitzungsdauer ist %v — zu kurz für eine Verwaltung, "+
+			"die man alle paar Tage einmal anfasst", sitzungsdauer)
+	}
+	if sitzungsauffrisch >= sitzungsdauer {
+		t.Error("verlängert wird nie, wenn die Schwelle über der Dauer liegt")
+	}
+}

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -2,7 +2,9 @@
 package db
 
 import (
+	"crypto/rand"
 	"database/sql"
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -297,6 +299,48 @@ func (d *DB) WateringFactor() (float64, error) {
 		return 1.0, nil
 	}
 	return f, nil
+}
+
+// SessionKey liefert den Schlüssel, mit dem die Web-Verwaltung ihre
+// Cookies signiert — und legt ihn beim ersten Aufruf an.
+//
+// **Warum in der Datenbank und nicht in einem Secret:** Ohne einen festen
+// Schlüssel würfelt der Server bei jedem Start einen neuen, und dann ist
+// jede Anmeldung nach dem nächsten Rollout ungültig. An einem Tag mit
+// mehreren Auslieferungen heißt das: alle paar Stunden neu anmelden. Ein
+// Secret im Cluster wäre der übliche Weg, verlangt aber, dass jemand es
+// anlegt und versiegelt — und wer das vergisst, merkt es erst, wenn sich
+// die Leute beschweren.
+//
+// Die Datenbank liegt ohnehin auf einem PVC, das Rollouts überlebt, und der
+// Server ist der Einzige, der sie liest. Der Schlüssel entsteht damit von
+// selbst und bleibt, ohne dass ihn ein Mensch anfassen muss.
+//
+// SESSION_KEY aus der Umgebung hat weiterhin Vorrang: Ausdrücklich schlägt
+// stillschweigend.
+func (d *DB) SessionKey() ([]byte, error) {
+	var v string
+	err := d.sql.QueryRow(`SELECT value FROM settings WHERE key='admin_session_key'`).Scan(&v)
+	if err == nil {
+		if roh, derr := base64.StdEncoding.DecodeString(v); derr == nil && len(roh) >= 32 {
+			return roh, nil
+		}
+		// Unbrauchbar gespeichert (von Hand verändert?) — neu erzeugen statt
+		// mit einem zu kurzen Schlüssel weiterzumachen.
+	} else if err != sql.ErrNoRows {
+		return nil, err
+	}
+
+	roh := make([]byte, 32)
+	if _, err := rand.Read(roh); err != nil {
+		return nil, err
+	}
+	if _, err := d.sql.Exec(`INSERT INTO settings(key,value) VALUES('admin_session_key',?)
+		ON CONFLICT(key) DO UPDATE SET value=excluded.value`,
+		base64.StdEncoding.EncodeToString(roh)); err != nil {
+		return nil, err
+	}
+	return roh, nil
 }
 
 func (d *DB) SetWateringFactor(f float64) error {


### PR DESCRIPTION
Der Betreiber musste sich in der Web-Verwaltung „nach 1h oder so" neu anmelden. Zwei Ursachen, die sich addiert haben.

## 1. Der Signierschlüssel überlebte keinen Neustart

`SESSION_KEY` ist in der Produktion **nicht gesetzt** — und ohne ihn würfelt `newSigner` beim Start einen zufälligen Schlüssel. Jedes Rollout warf damit alle Angemeldeten heraus. Heute ist mehrfach ausgeliefert worden; das erklärt die eine Stunde.

Der Kommentar im Deployment sagt das sogar („Anmeldungen überleben dann kein Rollout"), aber niemand merkt es, bevor sich Leute beschweren.

Der Schlüssel kommt jetzt aus der `settings`-Tabelle und **entsteht dort beim ersten Start von selbst**. Die Datenbank liegt ohnehin auf einem PVC, das Rollouts überlebt, und der Server ist der Einzige, der sie liest. Damit braucht es kein Secret, das jemand anlegen, versiegeln und vergessen kann. `SESSION_KEY` aus der Umgebung hat weiter Vorrang — ausdrücklich schlägt stillschweigend.

Warum nicht ein SealedSecret: Es wäre der übliche Weg, verlangt aber Cluster-Zugang zum Versiegeln und einen Menschen, der es tut. Genau dieser Mensch hat es bisher nicht getan, und das ist der Fehler, den wir gerade beheben.

## 2. Die Sitzung endete nach acht Stunden und verlängerte sich nie

Jetzt **30 Tage, gleitend verlängert** — aber höchstens einmal am Tag, damit nicht bei jedem Klick ein Cookie neu gesetzt wird. Wer die Verwaltung benutzt, bleibt angemeldet; wer sie einen Monat nicht anfasst, fliegt heraus. Verlängert wird sowohl in `requireAdmin` als auch auf der Startseite — dort kommt jemand nach ein paar Tagen zuerst an.

Dreißig Tage sind lang, und das ist Absicht: Die Verwaltung benutzen ein paar Leute im Dorf nebenbei. Wer sich jedes Mal neu anmelden muss, benutzt sie irgendwann nicht mehr. Getragen wird das Cookie von HttpOnly, Secure und SameSite=Lax, und es öffnet nichts, was die Rolle in der Rössing-ID nicht ohnehin öffnet. Eine abgelaufene Sitzung wird **nicht** wiederbelebt.

## Geprüft

Vier neue Tests: verlängert beim Benutzen, verlängert nicht bei jedem Klick, belebt nichts Abgelaufenes wieder, und die Dauer bleibt lang. `go vet ./...`, `go test ./...`, `pruefe_lokale_tests.py` — grün.

Wirksam wird es mit dem nächsten Rollout; **dieses eine Mal wirft es noch alle heraus**, danach nicht mehr.