### PR TITLE
Am Ort steht, wer sich kümmert

### DIFF
--- a/android/app/src/main/java/de/roessing/app/data/Model.kt
+++ b/android/app/src/main/java/de/roessing/app/data/Model.kt
@@ -157,6 +157,16 @@ data class PlaceDto(
     val lon: Double,
     val active: Boolean = true,
     val status: String = "green",
+    /**
+     * Der Verein oder Arbeitskreis, dem dieser Ort gehört — der
+     * Ansprechpartner. Leer, wenn das Backend ihn nicht mitschickt.
+     *
+     * Der Name kommt fertig vom Server, samt Verdeckung: Eine geschlossene
+     * Gruppe heißt für Außenstehende „Eine Gruppe aus dem Dorf". Die App
+     * entscheidet daran nichts, sie zeigt an — sonst gäbe es die
+     * Sichtbarkeitsregel zweimal.
+     */
+    val traegerName: String = "",
     val tasks: List<TaskDto> = emptyList(),
 ) {
     val careStatus: CareStatus get() = parseStatus(status)

--- a/android/app/src/main/java/de/roessing/app/ui/PlaceDetail.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/PlaceDetail.kt
@@ -14,6 +14,10 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
@@ -104,6 +108,27 @@ fun PlaceDetail(
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Text(place.name, style = MaterialTheme.typography.headlineSmall)
             StatusPill(place.careStatus, statusLabel(place.careStatus))
+        }
+        // Wer sich kümmert. Ohne diese Zeile weiß niemand, an wen er sich
+        // wenden soll — und für einen Ort, den man von außen sehen, aber nur
+        // mit Einweisung anfassen darf, ist genau das die wichtigste Angabe.
+        if (place.traegerName.isNotEmpty()) {
+            Spacer(Modifier.height(6.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Filled.Group,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    place.traegerName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("ort-traeger"),
+                )
+            }
         }
         if (place.description.isNotEmpty()) {
             Spacer(Modifier.height(4.dp))

--- a/android/app/src/test/java/de/roessing/app/TraegerAmOrtTest.kt
+++ b/android/app/src/test/java/de/roessing/app/TraegerAmOrtTest.kt
@@ -1,0 +1,38 @@
+package de.roessing.app
+
+import de.roessing.app.data.PlaceDto
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Wer sich um einen Ort kümmert, kommt fertig vom Server — samt Verdeckung:
+ * Eine geschlossene Gruppe heißt für Außenstehende „Eine Gruppe aus dem Dorf".
+ * Die App entscheidet daran nichts, sonst gäbe es die Sichtbarkeitsregel
+ * zweimal.
+ */
+class TraegerAmOrtTest {
+    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+
+    @Test
+    fun `Traegername wird gelesen`() {
+        val ort = json.decodeFromString<PlaceDto>(
+            """{"id":3,"name":"Beet vor dem Dorfgemeinschaftshaus","lat":52.18,"lon":9.81,
+                "traegerName":"AK 2 Umwelt und Natur"}""",
+        )
+        assertEquals("AK 2 Umwelt und Natur", ort.traegerName)
+    }
+
+    /**
+     * Ältere Stände des Backends schicken das Feld nicht mit. Dann bleibt die
+     * Zeile leer, statt dass die ganze Liste unlesbar wird.
+     */
+    @Test
+    fun `ohne Traeger bleibt es leer`() {
+        val ort = json.decodeFromString<PlaceDto>(
+            """{"id":1,"name":"Unter den Eichen","lat":52.18,"lon":9.81}""",
+        )
+        assertTrue(ort.traegerName.isEmpty())
+    }
+}

--- a/ios/Dorf/Bereiche/Mithelfen/OrtDetailView.swift
+++ b/ios/Dorf/Bereiche/Mithelfen/OrtDetailView.swift
@@ -62,6 +62,17 @@ struct OrtDetailView: View {
 
                 VStack(alignment: .leading, spacing: 8) {
                     Ampelpunkt(ampel: ort.ampel)
+                    // Wer sich kümmert. Ohne diese Zeile weiß niemand, an wen
+                    // er sich wenden soll — und für einen Ort, den man von
+                    // außen sehen, aber nur mit Einweisung anfassen darf, ist
+                    // genau das die wichtigste Angabe.
+                    if !ort.traegerName.isEmpty {
+                        Label(ort.traegerName, systemImage: "person.2")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .accessibilityLabel("Betreut von \(ort.traegerName)")
+                            .accessibilityIdentifier("ort-traeger")
+                    }
                     if !ort.description.isEmpty {
                         Text(ort.description)
                             .font(.body)

--- a/ios/Dorf/Daten/Modelle.swift
+++ b/ios/Dorf/Daten/Modelle.swift
@@ -310,10 +310,18 @@ nonisolated struct Ort: Codable, Identifiable, Hashable, Sendable {
     var lon: Double
     var active: Bool = true
     var status: String = "green"
+    /// Der Verein oder Arbeitskreis, dem dieser Ort gehört — der
+    /// Ansprechpartner. Leer, wenn das Backend ihn nicht mitschickt.
+    ///
+    /// Der Name kommt fertig vom Server, samt Verdeckung: Eine geschlossene
+    /// Gruppe heißt für Außenstehende „Eine Gruppe aus dem Dorf“
+    /// (`model.TraegerAnzeigeName`). Die App entscheidet hier nichts, sie
+    /// zeigt an — sonst gäbe es die Sichtbarkeitsregel zweimal.
+    var traegerName: String = ""
     var tasks: [Aufgabe] = []
 
     enum CodingKeys: String, CodingKey {
-        case id, name, description, kind, lat, lon, active, status, tasks
+        case id, name, description, kind, lat, lon, active, status, traegerName, tasks
     }
 
     init(from decoder: Decoder) throws {
@@ -326,14 +334,16 @@ nonisolated struct Ort: Codable, Identifiable, Hashable, Sendable {
         lon = c.wert(.lon, 0)
         active = c.wert(.active, true)
         status = c.wert(.status, "green")
+        traegerName = c.wert(.traegerName, "")
         tasks = c.wert(.tasks, [])
     }
 
     init(id: Int64, name: String, description: String = "", kind: String = "blumenkasten",
          lat: Double, lon: Double, active: Bool = true, status: String = "green",
-         tasks: [Aufgabe] = []) {
+         traegerName: String = "", tasks: [Aufgabe] = []) {
         self.id = id; self.name = name; self.description = description; self.kind = kind
         self.lat = lat; self.lon = lon; self.active = active; self.status = status
+        self.traegerName = traegerName
         self.tasks = tasks
     }
 

--- a/ios/DorfTests/ModelleTests.swift
+++ b/ios/DorfTests/ModelleTests.swift
@@ -86,3 +86,30 @@ struct ModelleTests {
         #expect(RFC3339.datum("kein Datum") == nil)
     }
 }
+
+// MARK: - Der Träger am Ort
+
+/// Wer sich um einen Ort kümmert, kommt fertig vom Server — samt Verdeckung:
+/// Eine geschlossene Gruppe heißt für Außenstehende „Eine Gruppe aus dem
+/// Dorf". Die App entscheidet daran nichts, sonst gäbe es die
+/// Sichtbarkeitsregel zweimal.
+struct TraegerAmOrtTests {
+    @Test func traegerNameWirdGelesen() throws {
+        let roh = """
+        {"id":3,"name":"Beet vor dem Dorfgemeinschaftshaus","lat":52.18,"lon":9.81,
+         "traegerName":"AK 2 Umwelt und Natur"}
+        """.data(using: .utf8)!
+        let ort = try JSONDecoder().decode(Ort.self, from: roh)
+        #expect(ort.traegerName == "AK 2 Umwelt und Natur")
+    }
+
+    /// Ältere Stände des Backends schicken das Feld nicht mit. Dann bleibt die
+    /// Zeile leer statt dass die ganze Liste unlesbar wird.
+    @Test func ohneTraegerBleibtEsLeer() throws {
+        let roh = """
+        {"id":1,"name":"Unter den Eichen","lat":52.18,"lon":9.81}
+        """.data(using: .utf8)!
+        let ort = try JSONDecoder().decode(Ort.self, from: roh)
+        #expect(ort.traegerName.isEmpty)
+    }
+}


### PR DESCRIPTION
Kleiner Teil von #75, aber der, der gerade gebraucht wird.

## Warum

Das Beet vor dem Dorfgemeinschaftshaus gehört seit heute dem **AK 2 Umwelt und Natur**, und jäten darf es nur, wer eingewiesen ist. Von außen soll man trotzdem sehen, dass sich jemand kümmert — und **wer**. Genau das war nicht möglich: Beide Apps kannten den Begriff „Träger" bis eben gar nicht, eine Suche über `ios/Dorf` und `android/app/src/main` lieferte null Treffer.

## Was sich ändert

Das Backend schickt den Namen **längst mit** — `traegerName` je Ort, gesetzt in `api.go` über `Zugriff.TraegerAnzeigeName`. Die Apps haben ihn nur weggeworfen. Jetzt lesen sie ihn und zeigen ihn in der Ortsansicht unter dem Namen, mit dem Personen-Symbol.

**Die Apps entscheiden daran nichts.** Die Verdeckung passiert im Backend: Eine geschlossene Gruppe heißt für Außenstehende „Eine Gruppe aus dem Dorf" (`model.TraegerNameVerdeckt`). Hätte die App eine eigene Regel, gäbe es die Sichtbarkeit zweimal — und beim nächsten Sonderfall einmal falsch.

Fällt das Feld weg, weil ein älteres Backend antwortet, bleibt die Zeile leer, statt dass die ganze Antwort unlesbar wird. Ein Test hält das auf beiden Seiten fest.

## Beide Fassungen

iOS und Android, gleicher Umfang, gleiche Angabe — nach `CLAUDE.md` ist ein Stand sonst nicht fertig.

- iOS: `xcodebuild test` — **241 Tests in 17 Suiten grün** (2 neu).
- Android: `./gradlew testDebugUnitTest assembleDebug` grün (2 neu).
- `pruefe_lokale_tests.py` grün.

## Was offen bleibt

**#75 selbst**: ein Verzeichnis der Träger — wer sie sind, was sie tun, welche Arbeitskreise dazugehören, ob man selbst Mitglied ist, und ein Weg vom Träger zurück zu seinen Orten. Dazu die Entscheidungen, die dort noch niemand getroffen hat (sieht ein Nicht-Angemeldeter das Verzeichnis? wo hängt es in der Navigation?).