### PR TITLE
Aufgaben kennen ihre Jahreszeit — im Winter ruht das Beet

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Die App fürs Dorf: Login mit der **Rössing-ID**, danach eine Startseite mit
 Bereichen. Der erste Bereich heißt **„Mithelfen"** — was gerade im Dorf
-ansteht: Karte der Blumenkästen und Beete mit Ampel-Status (grün/gelb/rot),
+ansteht: Karte der Blumenkästen und Beete mit Ampel-Status (grün/gelb/rot,
+dazu grau für „außer Dienst"),
 Gieß- und Jätpläne, Erledigungen melden, Rangliste. Dazu **Mein Profil** und
 **Dorfbewohner**. Weitere Bereiche kommen; das Gießen ist ausdrücklich nur der
 Anfang.
@@ -129,6 +130,22 @@ keine der beiden Apps noch einmal.
   sobald er verstrichen ist; erledigt bleibt sie grün und wird nicht wieder
   fällig. Der globale **Hitzefaktor** (z.B. 0.5) beschleunigt nur
   Gieß-Aufgaben — auf einen Termin wirkt er nicht.
+  Eine **regelmäßige** Aufgabe kann außerdem sagen, in welchem Teil des
+  Jahres sie überhaupt anfällt: `seasonStartMonth`/`seasonEndMonth`, ganze
+  Monate und einschließlich (4 und 9 = 1. April bis 30. September, in
+  Ortszeit des Dorfes). Steht der Anfang nach dem Ende, geht der Zeitraum
+  über den Jahreswechsel (11/2 = November bis Februar). Ohne Angabe (0/0)
+  fällt sie ganzjährig an — so laufen alle Bestandsaufgaben weiter.
+  Außerhalb ihrer Jahreszeit ist die Aufgabe **außer Dienst**: Der Status
+  heißt dann `dormant`, sie wird weder gelb noch rot, die Vergabe fragt
+  niemanden, und es geht keine Erinnerung raus. Sie wird dabei ausdrücklich
+  **nicht grün** — ein Beet, an dem im Winter nichts zu jäten ist, ist nicht
+  in Ordnung gebracht worden. Der Zähler läuft im Hintergrund weiter, nur die
+  Ampel schweigt: Wer im September zuletzt gejätet hat, ist am 1. April
+  wieder fällig, ohne dass jemand etwas anfassen muss. Ein Ort, dessen
+  sämtliche aktiven Aufgaben ruhen, ruht mit; steht eine ganzjährige daneben,
+  entscheidet die. Eine **einmalige** Aufgabe hat einen Termin und deshalb
+  keine Jahreszeit — beides zusammen wird abgewiesen.
   Mit `removeWhenDone` verschwindet eine einmalige Aufgabe nach der Meldung
   von Karte und Liste. Gelöscht wird sie dabei **nicht**, sondern *abgeräumt*
   (`removed_at`): An ihr hängen die Erledigungen, und die zählen weiter für
@@ -636,7 +653,8 @@ Code-Tausch, Werkzeugaufruf — wird in `backend/e2e/web/tests/mcp-connector.spe
 gegen ein echtes Zitadel durchlaufen.
 
 Tools: `orte_liste`, `ort_anlegen/aendern/loeschen`,
-`aufgabe_anlegen/aendern/loeschen` (regelmäßig mit `intervalDays`, einmalig
+`aufgabe_anlegen/aendern/loeschen` (regelmäßig mit `intervalDays` und
+wahlweise einer Jahreszeit `seasonStartMonth`/`seasonEndMonth`, einmalig
 mit `oneOff` + `dueDate`, dazu `removeWhenDone`), `erledigung_melden`,
 `erledigung_zuruecknehmen`, `rangliste`, `hitzefaktor_setzen`.
 

--- a/backend/internal/admin/admin.go
+++ b/backend/internal/admin/admin.go
@@ -165,6 +165,8 @@ var funcs = template.FuncMap{
 	"vergabeStand":   vergabeStandText,
 	"ortsart":        ortsart,
 	"aufgabenart":    aufgabenart,
+	// Jahreszeit einer Aufgabe im Klartext („April bis September“).
+	"season": seasonText,
 	// Träger: Zulassungsstand, Sichtbarkeit und Anträge im Klartext.
 	"traegerStatus":       traegerStatusText,
 	"traegerBadge":        traegerBadge,
@@ -314,6 +316,8 @@ func statusText(s model.Status) string {
 		return "fällig"
 	case model.StatusRed:
 		return "überfällig"
+	case model.StatusDormant:
+		return "außer Dienst"
 	default:
 		return "in Ordnung"
 	}
@@ -326,9 +330,50 @@ func statusBadge(s model.Status) string {
 		return "badge-warning"
 	case model.StatusRed:
 		return "badge-error"
+	case model.StatusDormant:
+		// Grau: außerhalb ihrer Jahreszeit ist an der Aufgabe nichts zu tun
+		// — aber sie ist auch nicht „in Ordnung gebracht" worden.
+		return "badge-ghost"
 	default:
 		return "badge-success"
 	}
+}
+
+// monthNames sind die Monatsnamen für Auswahl und Anzeige der Jahreszeit,
+// 1-basiert (der Platz 0 bleibt leer: „ganzjährig").
+var monthNames = [13]string{"", "Januar", "Februar", "März", "April", "Mai", "Juni",
+	"Juli", "August", "September", "Oktober", "November", "Dezember"}
+
+// monthName liefert den Monatsnamen; 0 und Unsinn ergeben nichts.
+func monthName(m int) string {
+	if m < 1 || m > 12 {
+		return ""
+	}
+	return monthNames[m]
+}
+
+// seasonText beschreibt die Jahreszeit einer Aufgabe im Klartext.
+// Ganzjährig ergibt einen leeren Text — dann steht schlicht nichts da.
+func seasonText(t model.CareTask) string {
+	s, ok := t.SeasonOf()
+	if !ok {
+		return ""
+	}
+	return monthName(int(s.Start)) + " bis " + monthName(int(s.End))
+}
+
+// monthOption ist ein Eintrag der Monatsauswahl im Formular.
+type monthOption struct {
+	Number int
+	Name   string
+}
+
+func monthOptions() []monthOption {
+	out := make([]monthOption, 0, 12)
+	for m := 1; m <= 12; m++ {
+		out = append(out, monthOption{Number: m, Name: monthNames[m]})
+	}
+	return out
 }
 
 // --- Träger im Klartext -----------------------------------------------------

--- a/backend/internal/admin/mithelfen.go
+++ b/backend/internal/admin/mithelfen.go
@@ -402,6 +402,8 @@ type aufgabeFormularDaten struct {
 	// Befaehigungen sind die Einweisungen des Trägers, dem der Ort gehört —
 	// nur aus ihnen lässt sich eine auswählen.
 	Befaehigungen []model.Befaehigung
+	// Months füllt die Auswahl der Jahreszeit.
+	Months []monthOption
 }
 
 func (a *App) aufgabeNeuFormular(w http.ResponseWriter, r *http.Request, _ session) {
@@ -426,6 +428,7 @@ func (a *App) zeigeAufgabeNeu(w http.ResponseWriter, r *http.Request, status int
 			Neu: true, Ort: p, Aufgabe: t, LiterText: liter, Fehler: fehler,
 			Ziel:          fmt.Sprintf("%s/orte/%d/aufgaben/neu", mithelfenBasis, p.ID),
 			Befaehigungen: a.befaehigungenVon(p),
+			Months:        monthOptions(),
 		},
 	})
 }
@@ -479,6 +482,7 @@ func (a *App) zeigeAufgabe(w http.ResponseWriter, r *http.Request, status int, p
 			Ort: p, Aufgabe: t, LiterText: liter, Fehler: fehler,
 			Ziel:          fmt.Sprintf("%s/aufgaben/%d", mithelfenBasis, t.ID),
 			Befaehigungen: a.befaehigungenVon(p),
+			Months:        monthOptions(),
 		},
 	})
 }
@@ -852,10 +856,37 @@ func aufgabeAusFormular(r *http.Request) (model.CareTask, string, api.TaskInput,
 		return entwurf, literText, in, fmt.Errorf("Intervall und Rot-Schwelle müssen Zahlen sein")
 	}
 	in.IntervalDays, in.RedAfterDays = intervall, rot
+	// Die Jahreszeit gehört zur regelmäßigen Aufgabe; bei einmaligen wird
+	// sie wie das Intervall schlicht übergangen. Fehlen die Felder ganz,
+	// bleibt die gespeicherte Jahreszeit stehen (Zeiger = unverändert).
+	if von, ok := formMonth(r, "seasonStartMonth"); ok {
+		in.SeasonStartMonth = &von
+		entwurf.SeasonStartMonth = von
+	}
+	if bis, ok := formMonth(r, "seasonEndMonth"); ok {
+		in.SeasonEndMonth = &bis
+		entwurf.SeasonEndMonth = bis
+	}
 	if err := in.Validate(); err != nil {
 		return entwurf, literText, in, err
 	}
 	return entwurf, literText, in, nil
+}
+
+// formMonth liest einen Monat aus der Auswahl der Jahreszeit. Der zweite
+// Rückgabewert sagt, ob das Feld überhaupt geschickt wurde — nur dann darf
+// eine gespeicherte Jahreszeit überschrieben werden. Unlesbares zählt als 0
+// („ganzjährig"); die eigentliche Prüfung macht TaskInput.Validate.
+func formMonth(r *http.Request, field string) (int, bool) {
+	raw, ok := r.Form[field]
+	if !ok || len(raw) == 0 {
+		return 0, false
+	}
+	m, err := strconv.Atoi(strings.TrimSpace(raw[0]))
+	if err != nil {
+		return 0, true
+	}
+	return m, true
 }
 
 // --- Einstellungen ----------------------------------------------------------

--- a/backend/internal/admin/season_test.go
+++ b/backend/internal/admin/season_test.go
@@ -1,0 +1,122 @@
+package admin
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Die Jahreszeit einer Aufgabe in der Web-Verwaltung (#78) — als zwei
+// Auswahlfelder, ohne JavaScript, wie der Rest des Formulars.
+
+func TestAufgabeFormularBietetJahreszeit(t *testing.T) {
+	a, h, _, sitzung := aufbau(t)
+	p := ortAnlegenDB(t, a)
+
+	w := hole(t, h, "/admin/mithelfen/orte/"+strconv.FormatInt(p.ID, 10)+"/aufgaben/neu", sitzung)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Formular: HTTP %d", w.Code)
+	}
+	koerper := w.Body.String()
+	for _, muss := range []string{"feld-season-start", "feld-season-end", "ganzjährig", "September"} {
+		if !strings.Contains(koerper, muss) {
+			t.Errorf("im Formular fehlt %q", muss)
+		}
+	}
+}
+
+func TestJahreszeitUeberFormularSetzenUndAbraeumen(t *testing.T) {
+	a, h, d, sitzung := aufbau(t)
+	p := ortAnlegenDB(t, a)
+	pfad := "/admin/mithelfen/orte/" + strconv.FormatInt(p.ID, 10) + "/aufgaben/neu"
+
+	w := sende(t, h, pfad, url.Values{
+		"art":              {"jaeten"},
+		"titel":            {"Beet jäten"},
+		"wiederholung":     {"regelmaessig"},
+		"intervall":        {"56"},
+		"rot":              {"70"},
+		"seasonStartMonth": {"4"},
+		"seasonEndMonth":   {"9"},
+		"aktiv":            {"1"},
+	}, sitzung)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("Anlegen: HTTP %d — %s", w.Code, w.Body.String())
+	}
+	aufgaben, err := d.ListTasks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(aufgaben) != 1 {
+		t.Fatalf("%d Aufgaben, erwartet 1", len(aufgaben))
+	}
+	if aufgaben[0].SeasonStartMonth != 4 || aufgaben[0].SeasonEndMonth != 9 {
+		t.Fatalf("Jahreszeit = %d/%d, erwartet 4/9",
+			aufgaben[0].SeasonStartMonth, aufgaben[0].SeasonEndMonth)
+	}
+
+	// Die Ortsseite sagt im Klartext, wann die Aufgabe anfällt.
+	w = hole(t, h, "/admin/mithelfen/orte/"+strconv.FormatInt(p.ID, 10), sitzung)
+	if !strings.Contains(w.Body.String(), "April bis September") {
+		t.Error("die Ortsseite nennt die Jahreszeit nicht")
+	}
+
+	// Und zurück auf ganzjährig.
+	w = sende(t, h, "/admin/mithelfen/aufgaben/"+strconv.FormatInt(aufgaben[0].ID, 10), url.Values{
+		"art":              {"jaeten"},
+		"wiederholung":     {"regelmaessig"},
+		"intervall":        {"56"},
+		"rot":              {"70"},
+		"seasonStartMonth": {"0"},
+		"seasonEndMonth":   {"0"},
+		"aktiv":            {"1"},
+	}, sitzung)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("Speichern: HTTP %d — %s", w.Code, w.Body.String())
+	}
+	geaendert, err := d.GetTask(aufgaben[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, saisonal := geaendert.SeasonOf(); saisonal {
+		t.Fatalf("Jahreszeit nicht abgeräumt: %d/%d",
+			geaendert.SeasonStartMonth, geaendert.SeasonEndMonth)
+	}
+}
+
+// Eine halbe Angabe kommt als Fehlermeldung zurück, nicht als stille
+// Auslegung — und das Formular steht danach noch da.
+func TestHalbeJahreszeitWirdAbgewiesen(t *testing.T) {
+	a, h, _, sitzung := aufbau(t)
+	p := ortAnlegenDB(t, a)
+
+	w := sende(t, h, "/admin/mithelfen/orte/"+strconv.FormatInt(p.ID, 10)+"/aufgaben/neu", url.Values{
+		"art":              {"jaeten"},
+		"wiederholung":     {"regelmaessig"},
+		"intervall":        {"56"},
+		"rot":              {"70"},
+		"seasonStartMonth": {"4"},
+		"seasonEndMonth":   {"0"},
+		"aktiv":            {"1"},
+	}, sitzung)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("HTTP %d, erwartet 400", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "formularfehler") {
+		t.Error("keine Fehlermeldung im Formular")
+	}
+}
+
+// Die Anzeige einer ruhenden Aufgabe: „außer Dienst", grau statt grün.
+func TestStatusAnzeigeRuhend(t *testing.T) {
+	if got := statusText(model.StatusDormant); got != "außer Dienst" {
+		t.Errorf("statusText = %q", got)
+	}
+	if got := statusBadge(model.StatusDormant); got != "badge-ghost" {
+		t.Errorf("statusBadge = %q", got)
+	}
+}

--- a/backend/internal/admin/static/karte.js
+++ b/backend/internal/admin/static/karte.js
@@ -8,7 +8,10 @@
   if (!behaelter) return;
 
   var mitte = [9.87, 52.211];
-  var farben = ["match", ["get", "status"], "yellow", "#f9a825", "red", "#c62828", "#2e7d32"];
+  // "dormant": außerhalb ihrer Jahreszeit ist an einem Ort nichts zu tun —
+  // ein grauer Punkt, kein grüner (siehe model.StatusDormant).
+  var farben = ["match", ["get", "status"],
+    "yellow", "#f9a825", "red", "#c62828", "dormant", "#9e9e9e", "#2e7d32"];
 
   function zustand(wert) {
     document.body.dataset.mapState = wert;

--- a/backend/internal/admin/templates/pflege_aufgabe.html
+++ b/backend/internal/admin/templates/pflege_aufgabe.html
@@ -67,6 +67,37 @@
           </div>
         </div>
 
+        <label class="fieldset-legend">Jahreszeit — bei regelmäßig</label>
+        <div class="grid grid-cols-2 gap-3">
+          <div>
+            <label class="fieldset-legend" for="feld-season-start">Von Monat</label>
+            <select name="seasonStartMonth" id="feld-season-start" class="select w-full">
+              <option value="0">ganzjährig</option>
+              {{range .Data.Months}}
+                <option value="{{.Number}}"
+                        {{if eq .Number $.Data.Aufgabe.SeasonStartMonth}}selected{{end}}>{{.Name}}</option>
+              {{end}}
+            </select>
+          </div>
+          <div>
+            <label class="fieldset-legend" for="feld-season-end">Bis Monat</label>
+            <select name="seasonEndMonth" id="feld-season-end" class="select w-full">
+              <option value="0">ganzjährig</option>
+              {{range .Data.Months}}
+                <option value="{{.Number}}"
+                        {{if eq .Number $.Data.Aufgabe.SeasonEndMonth}}selected{{end}}>{{.Name}}</option>
+              {{end}}
+            </select>
+          </div>
+        </div>
+        <p class="text-sm text-base-content/70">
+          Beide Monate zählen ganz mit: April bis September heißt vom 1. April bis zum
+          30. September. Außerhalb ist die Aufgabe außer Dienst — sie wird weder gelb noch
+          rot, und niemand wird dafür gefragt. Steht der Anfang nach dem Ende
+          (November bis Februar), geht die Jahreszeit über den Jahreswechsel.
+          „Ganzjährig“ nimmt die Beschränkung wieder weg.
+        </p>
+
         <label class="fieldset-legend" for="feld-termin">Fällig am — bei einmalig</label>
         <input type="date" name="termin" id="feld-termin"
                value="{{datumFeld .Data.Aufgabe.DueDate}}" class="input w-full">

--- a/backend/internal/admin/templates/pflege_ort.html
+++ b/backend/internal/admin/templates/pflege_ort.html
@@ -67,6 +67,7 @@
             {{end}}
           </span>
           {{if .OneOff}}<span class="badge badge-info badge-sm" data-einmalig>einmalig</span>{{end}}
+          {{with season .CareTask}}<span class="badge badge-ghost badge-sm" data-season>{{.}}</span>{{end}}
           {{if .RemoveWhenDone}}<span class="badge badge-ghost badge-sm" data-entfernen>verschwindet nach dem Erledigen</span>{{end}}
           {{if not .Active}}<span class="badge badge-ghost badge-sm">inaktiv</span>{{end}}
         </div>

--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -210,15 +210,11 @@ func AssemblePlacesFuer(d *db.DB, now time.Time, z model.Zugriff) ([]model.Place
 			// ausschreiben, ohne sich dabei zu offenbaren.
 			p.TraegerName = z.TraegerAnzeigeName(t)
 		}
-		pws := model.PlaceWithStatus{Place: p, Tasks: byPlace[p.ID], Status: model.StatusGreen}
+		pws := model.PlaceWithStatus{Place: p, Tasks: byPlace[p.ID]}
 		if pws.Tasks == nil {
 			pws.Tasks = []model.TaskWithStatus{}
 		}
-		for _, t := range pws.Tasks {
-			if t.Active {
-				pws.Status = model.Worst(pws.Status, t.Status)
-			}
-		}
+		pws.Status = model.PlaceStatus(pws.Tasks)
 		out = append(out, pws)
 	}
 	// Vergabestand je Aufgabe: wer hat zugesagt, wie viele helfen hier mit.
@@ -473,6 +469,15 @@ type TaskInput struct {
 	// wie die Aufgabe. Aus demselben Grund ein Zeiger: fehlt das Feld, bleibt
 	// die Einweisung, wie sie ist — ausdrückliche 0 nimmt sie weg.
 	BefaehigungID *int64 `json:"befaehigungId"`
+	// SeasonStartMonth/SeasonEndMonth: die Jahreszeit der Aufgabe, in ganzen
+	// Monaten und einschließlich (4 und 9 = April bis September). 0/0 nimmt
+	// sie wieder weg, die Aufgabe fällt dann ganzjährig an.
+	//
+	// Zeiger aus demselben Grund wie oben: Eine ältere App-Version schickt
+	// die Felder nicht mit, und ein geändertes Gießintervall darf einer
+	// Aufgabe nicht ihre Jahreszeit wegnehmen.
+	SeasonStartMonth *int `json:"seasonStartMonth"`
+	SeasonEndMonth   *int `json:"seasonEndMonth"`
 
 	// termin ist das geprüfte DueDate. Validate() setzt es, Apply() nutzt es.
 	termin *time.Time
@@ -502,9 +507,19 @@ func (in *TaskInput) Validate() error {
 			return err
 		}
 		in.termin = &termin
+		// Eine einmalige Aufgabe hat einen Termin, keinen Rhythmus — und
+		// damit auch keine Jahreszeit. Wer beides angibt, meint zwei
+		// verschiedene Dinge und bekommt eine Absage statt einer stillen
+		// Auslegung.
+		if seasonGiven(in.SeasonStartMonth) || seasonGiven(in.SeasonEndMonth) {
+			return errors.New("eine einmalige Aufgabe hat keine Jahreszeit: entweder Termin oder Zeitraum")
+		}
 		// Intervalle spielen bei einem Termin keine Rolle; sie werden
 		// bewusst genullt, damit nirgends zwei Wahrheiten stehen.
 		in.IntervalDays, in.RedAfterDays = 0, 0
+		// Eine vorher gespeicherte Jahreszeit fällt beim Umstellen weg.
+		null := 0
+		in.SeasonStartMonth, in.SeasonEndMonth = &null, &null
 		return nil
 	}
 	if in.DueDate != "" {
@@ -521,7 +536,27 @@ func (in *TaskInput) Validate() error {
 	if in.RedAfterDays < in.IntervalDays {
 		return errors.New("redAfterDays muss >= intervalDays sein")
 	}
+	if err := model.ValidSeasonMonths(monthOrZero(in.SeasonStartMonth),
+		monthOrZero(in.SeasonEndMonth)); err != nil {
+		return err
+	}
+	if in.SeasonStartMonth != nil && in.SeasonEndMonth != nil {
+		von, bis := model.NormalizeSeasonMonths(*in.SeasonStartMonth, *in.SeasonEndMonth)
+		in.SeasonStartMonth, in.SeasonEndMonth = &von, &bis
+	}
 	return nil
+}
+
+// seasonGiven sagt, ob wirklich eine Jahreszeit gemeint war — eine
+// mitgeschickte 0 heißt „ganzjährig" und ist keine.
+func seasonGiven(month *int) bool { return month != nil && *month != 0 }
+
+// monthOrZero liest einen optionalen Monat; fehlt er, gilt „ganzjährig".
+func monthOrZero(month *int) int {
+	if month == nil {
+		return 0
+	}
+	return *month
 }
 
 // ParseTermin liest das Fälligkeitsdatum einer einmaligen Aufgabe.
@@ -555,6 +590,12 @@ func (in *TaskInput) Apply(t *model.CareTask) {
 	}
 	if in.BefaehigungID != nil {
 		t.BefaehigungID = *in.BefaehigungID
+	}
+	if in.SeasonStartMonth != nil {
+		t.SeasonStartMonth = *in.SeasonStartMonth
+	}
+	if in.SeasonEndMonth != nil {
+		t.SeasonEndMonth = *in.SeasonEndMonth
 	}
 	t.Kind, t.Title = model.TaskKind(in.Kind), in.Title
 	t.Liters = in.Liters

--- a/backend/internal/api/season_test.go
+++ b/backend/internal/api/season_test.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// Die Jahreszeit einer Aufgabe über die REST-Schnittstelle (#78).
+//
+// Die Testuhr steht auf dem 12. August 2026. Eine Aufgabe „November bis
+// Februar" ist an diesem Tag also außer Dienst, eine „April bis September"
+// im Dienst — damit lassen sich beide Seiten prüfen, ohne an der Uhr zu
+// drehen.
+
+// aufgabeMitJahreszeit legt einen Ort samt Aufgabe an und liefert beide IDs.
+func aufgabeMitJahreszeit(t *testing.T, ts string, von, bis int) (int64, int64) {
+	t.Helper()
+	placeID := ortAnlegen(t, ts, adminToken, "Beet am Dorfgemeinschaftshaus")
+	resp := doReq(t, "POST", ts+fmt.Sprintf("/api/v1/places/%d/tasks", placeID), adminToken,
+		map[string]any{"kind": "jaeten", "intervalDays": 56, "redAfterDays": 70,
+			"seasonStartMonth": von, "seasonEndMonth": bis})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("Aufgabe anlegen: HTTP %d", resp.StatusCode)
+	}
+	return placeID, decode[struct {
+		ID int64 `json:"id"`
+	}](t, resp).ID
+}
+
+// Der Fall aus dem Issue: Im Winter zeigt die Karte keinen roten Punkt für
+// ein Beet, an dem nichts zu jäten ist — die Aufgabe ist außer Dienst, und
+// der Ort mit ihr.
+func TestAufgabeAusserhalbDerJahreszeitIstAusserDienst(t *testing.T) {
+	ts, _ := newTestServer(t)
+	aufgabeMitJahreszeit(t, ts.URL, 11, 2) // November bis Februar
+
+	orte := getPlaces(t, ts)
+	if len(orte.Places) != 1 || len(orte.Places[0].Tasks) != 1 {
+		t.Fatalf("unerwartete Ortsliste: %+v", orte)
+	}
+	if got := orte.Places[0].Tasks[0].Status; got != "dormant" {
+		t.Errorf("Aufgabenstatus im August = %q, erwartet \"dormant\"", got)
+	}
+	if got := orte.Places[0].Status; got != "dormant" {
+		t.Errorf("Ortsstatus = %q, erwartet \"dormant\"", got)
+	}
+}
+
+// Innerhalb ihrer Jahreszeit rechnet die Ampel wie eh und je.
+func TestAufgabeInnerhalbDerJahreszeitZaehltNormal(t *testing.T) {
+	ts, _ := newTestServer(t)
+	// April bis September: Der 12. August liegt mittendrin, die Aufgabe ist
+	// am Anlegetag frisch und damit grün.
+	aufgabeMitJahreszeit(t, ts.URL, 4, 9)
+
+	orte := getPlaces(t, ts)
+	if got := orte.Places[0].Tasks[0].Status; got != "green" {
+		t.Errorf("Aufgabenstatus am Anlegetag = %q, erwartet \"green\"", got)
+	}
+	if got := orte.Places[0].Status; got != "green" {
+		t.Errorf("Ortsstatus = %q, erwartet \"green\"", got)
+	}
+}
+
+// Ein Ort mit einer ruhenden und einer ganzjährigen Aufgabe richtet sich
+// nach der, an der etwas zu tun ist.
+func TestOrtMitRuhenderUndGanzjaehrigerAufgabe(t *testing.T) {
+	ts, _ := newTestServer(t)
+	placeID, _ := aufgabeMitJahreszeit(t, ts.URL, 11, 2)
+	resp := doReq(t, "POST", ts.URL+fmt.Sprintf("/api/v1/places/%d/tasks", placeID), adminToken,
+		map[string]any{"kind": "sonstiges", "title": "Müll aufsammeln",
+			"intervalDays": 7, "redAfterDays": 14})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("zweite Aufgabe anlegen: HTTP %d", resp.StatusCode)
+	}
+	orte := getPlaces(t, ts)
+	if got := orte.Places[0].Status; got != "green" {
+		t.Errorf("Ortsstatus = %q, erwartet \"green\" — die ganzjährige Aufgabe entscheidet", got)
+	}
+}
+
+// Wer eine Jahreszeit angibt, muss beide Monate angeben; eine einmalige
+// Aufgabe hat gar keine.
+func TestJahreszeitWirdGeprueft(t *testing.T) {
+	ts, _ := newTestServer(t)
+	placeID := ortAnlegen(t, ts.URL, adminToken, "Beet")
+	pfad := fmt.Sprintf("/api/v1/places/%d/tasks", placeID)
+
+	faelle := map[string]map[string]any{
+		"nur Anfangsmonat": {"kind": "jaeten", "intervalDays": 56, "redAfterDays": 70,
+			"seasonStartMonth": 4},
+		"nur Endmonat": {"kind": "jaeten", "intervalDays": 56, "redAfterDays": 70,
+			"seasonEndMonth": 9},
+		"Monat 13": {"kind": "jaeten", "intervalDays": 56, "redAfterDays": 70,
+			"seasonStartMonth": 13, "seasonEndMonth": 9},
+		"einmalig mit Jahreszeit": {"kind": "sonstiges", "oneOff": true,
+			"dueDate": "2026-09-01", "seasonStartMonth": 4, "seasonEndMonth": 9},
+	}
+	for name, koerper := range faelle {
+		t.Run(name, func(t *testing.T) {
+			resp := doReq(t, "POST", ts.URL+pfad, adminToken, koerper)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("HTTP %d, erwartet 400", resp.StatusCode)
+			}
+			if msg := decode[struct {
+				Error string `json:"error"`
+			}](t, resp).Error; msg == "" {
+				t.Error("ohne Begründung abgewiesen")
+			}
+		})
+	}
+}
+
+// Eine ältere App-Version schickt die Felder nicht mit. Ein geändertes
+// Intervall darf der Aufgabe dann nicht ihre Jahreszeit wegnehmen.
+func TestAendernOhneJahreszeitLaesstSieStehen(t *testing.T) {
+	ts, _ := newTestServer(t)
+	_, taskID := aufgabeMitJahreszeit(t, ts.URL, 4, 9)
+
+	resp := doReq(t, "PUT", ts.URL+fmt.Sprintf("/api/v1/tasks/%d", taskID), adminToken,
+		map[string]any{"kind": "jaeten", "intervalDays": 42, "redAfterDays": 56})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Ändern: HTTP %d", resp.StatusCode)
+	}
+	geaendert := decode[struct {
+		IntervalDays     float64 `json:"intervalDays"`
+		SeasonStartMonth int     `json:"seasonStartMonth"`
+		SeasonEndMonth   int     `json:"seasonEndMonth"`
+	}](t, resp)
+	if geaendert.IntervalDays != 42 {
+		t.Errorf("Intervall = %v, erwartet 42", geaendert.IntervalDays)
+	}
+	if geaendert.SeasonStartMonth != 4 || geaendert.SeasonEndMonth != 9 {
+		t.Errorf("Jahreszeit = %d/%d, erwartet 4/9",
+			geaendert.SeasonStartMonth, geaendert.SeasonEndMonth)
+	}
+}
+
+// Ausdrücklich 0 nimmt die Jahreszeit wieder weg.
+func TestJahreszeitLaesstSichAbraeumen(t *testing.T) {
+	ts, _ := newTestServer(t)
+	_, taskID := aufgabeMitJahreszeit(t, ts.URL, 11, 2)
+
+	resp := doReq(t, "PUT", ts.URL+fmt.Sprintf("/api/v1/tasks/%d", taskID), adminToken,
+		map[string]any{"kind": "jaeten", "intervalDays": 56, "redAfterDays": 70,
+			"seasonStartMonth": 0, "seasonEndMonth": 0})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Ändern: HTTP %d", resp.StatusCode)
+	}
+	orte := getPlaces(t, ts)
+	if got := orte.Places[0].Tasks[0].Status; got == "dormant" {
+		t.Error("die Aufgabe ruht noch, obwohl die Jahreszeit weg ist")
+	}
+}

--- a/backend/internal/chat/season_test.go
+++ b/backend/internal/chat/season_test.go
@@ -1,0 +1,41 @@
+package chat
+
+import (
+	"testing"
+)
+
+// Auch im Chat lässt sich die Jahreszeit einer Aufgabe setzen (#78) — und
+// eine Änderung an etwas anderem räumt sie nicht nebenbei ab.
+
+func TestChatSetztUndBehaeltDieJahreszeit(t *testing.T) {
+	dd := neuesDorf(t)
+	s := dd.sitzung(t, tokenVorstand)
+
+	if _, err := rufeWerkzeug(t, s, "aufgabe_aendern", map[string]any{
+		"id": dd.Giessen.ID, "saisonVon": 4.0, "saisonBis": 9.0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	aufgabe, err := dd.DB.GetTask(dd.Giessen.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if aufgabe.SeasonStartMonth != 4 || aufgabe.SeasonEndMonth != 9 {
+		t.Fatalf("Jahreszeit = %d/%d, erwartet 4/9",
+			aufgabe.SeasonStartMonth, aufgabe.SeasonEndMonth)
+	}
+
+	if _, err := rufeWerkzeug(t, s, "aufgabe_aendern", map[string]any{
+		"id": dd.Giessen.ID, "intervallTage": 10.0, "rotNachTagen": 20.0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	aufgabe, err = dd.DB.GetTask(dd.Giessen.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if aufgabe.SeasonStartMonth != 4 || aufgabe.SeasonEndMonth != 9 {
+		t.Fatalf("die Intervalländerung hat die Jahreszeit angefasst: %d/%d",
+			aufgabe.SeasonStartMonth, aufgabe.SeasonEndMonth)
+	}
+}

--- a/backend/internal/chat/verwaltung.go
+++ b/backend/internal/chat/verwaltung.go
@@ -79,6 +79,8 @@ func verwaltungsWerkzeuge() []Werkzeug {
 				"aktiv": schemaJaNein("Aufgabe aktiv?"),
 				"sichtbarkeit": schemaAuswahl("Wer sieht die Aufgabe", "oeffentlich",
 					"nur_mitglieder"),
+				"saisonVon": schemaGanzzahl("Erster Monat der Jahreszeit (1–12); 0 nimmt sie weg"),
+				"saisonBis": schemaGanzzahl("Letzter Monat der Jahreszeit (1–12); 0 nimmt sie weg"),
 			}),
 			Aendert: true,
 			Handler: werkzeugAufgabeAendern,
@@ -252,6 +254,8 @@ func werkzeugAufgabeAendern(args json.RawMessage, s Sitzung) (any, error) {
 		EntfernenWennErledigt *bool    `json:"entfernenWennErledigt"`
 		Aktiv                 *bool    `json:"aktiv"`
 		Sichtbarkeit          *string  `json:"sichtbarkeit"`
+		SaisonVon             *int     `json:"saisonVon"`
+		SaisonBis             *int     `json:"saisonBis"`
 	}
 	if err := entpacke(args, &in); err != nil {
 		return nil, err
@@ -269,6 +273,12 @@ func werkzeugAufgabeAendern(args json.RawMessage, s Sitzung) (any, error) {
 	uebernimm(&eingabe.DueDate, in.Termin)
 	uebernimm(&eingabe.RemoveWhenDone, in.EntfernenWennErledigt)
 	uebernimm(&eingabe.Sichtbarkeit, in.Sichtbarkeit)
+	if in.SaisonVon != nil {
+		eingabe.SeasonStartMonth = in.SaisonVon
+	}
+	if in.SaisonBis != nil {
+		eingabe.SeasonEndMonth = in.SaisonBis
+	}
 	if in.Liter != nil {
 		eingabe.Liters = in.Liter
 	}
@@ -574,6 +584,10 @@ func eingabeAus(t model.CareTask) api.TaskInput {
 		OneOff:         t.OneOff,
 		RemoveWhenDone: t.RemoveWhenDone,
 		Sichtbarkeit:   string(t.Sichtbarkeit),
+		// Die Jahreszeit wird mitgeführt, damit eine Änderung an etwas
+		// anderem sie nicht stillschweigend abräumt.
+		SeasonStartMonth: &t.SeasonStartMonth,
+		SeasonEndMonth:   &t.SeasonEndMonth,
 	}
 	if t.OneOff && t.DueDate != nil {
 		in.DueDate = t.DueDate.Format(time.RFC3339)

--- a/backend/internal/chat/werkzeuge.go
+++ b/backend/internal/chat/werkzeuge.go
@@ -143,6 +143,10 @@ func Werkzeuge() []Werkzeug {
 				"termin":        schemaText("Nur einmalig: Fälligkeitsdatum (2026-08-20 oder RFC3339)"),
 				"sichtbarkeit": schemaAuswahl("Wer sieht die Aufgabe (Vorgabe: oeffentlich)",
 					"oeffentlich", "nur_mitglieder"),
+				"saisonVon": schemaGanzzahl("Nur regelmäßig: erster Monat der Jahreszeit (1–12). " +
+					"Ohne Angabe fällt die Aufgabe ganzjährig an"),
+				"saisonBis": schemaGanzzahl("Nur regelmäßig: letzter Monat der Jahreszeit (1–12). " +
+					"4 und 9 heißt April bis September; 11 und 2 geht über den Jahreswechsel"),
 			}),
 			Aendert: true,
 			Handler: werkzeugAufgabeAnlegen,
@@ -307,6 +311,8 @@ func werkzeugAufgabeAnlegen(args json.RawMessage, s Sitzung) (any, error) {
 		Einmalig      bool     `json:"einmalig"`
 		Termin        string   `json:"termin"`
 		Sichtbarkeit  string   `json:"sichtbarkeit"`
+		SaisonVon     *int     `json:"saisonVon"`
+		SaisonBis     *int     `json:"saisonBis"`
 	}
 	if err := entpacke(args, &in); err != nil {
 		return nil, err
@@ -317,7 +323,8 @@ func werkzeugAufgabeAnlegen(args json.RawMessage, s Sitzung) (any, error) {
 	}
 	eingabe := api.TaskInput{Kind: in.Art, Title: in.Titel, Liters: in.Liter,
 		IntervalDays: in.IntervallTage, RedAfterDays: in.RotNachTagen,
-		OneOff: in.Einmalig, DueDate: in.Termin, Sichtbarkeit: in.Sichtbarkeit}
+		OneOff: in.Einmalig, DueDate: in.Termin, Sichtbarkeit: in.Sichtbarkeit,
+		SeasonStartMonth: in.SaisonVon, SeasonEndMonth: in.SaisonBis}
 	if err := eingabe.Validate(); err != nil {
 		return nil, err
 	}

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -184,6 +184,12 @@ CREATE INDEX IF NOT EXISTS idx_devices_person ON push_devices(user_sub);
 		`ALTER TABLE care_tasks ADD COLUMN due_date TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE care_tasks ADD COLUMN remove_when_done INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE care_tasks ADD COLUMN removed_at TEXT NOT NULL DEFAULT ''`,
+		// Jahreszeit einer wiederkehrenden Aufgabe (#78): der Monat, in dem
+		// sie beginnt, und der, in dem sie endet — beide einschließlich.
+		// 0/0 heißt ganzjährig, und genau das bekommt jede Bestandsaufgabe:
+		// Der laufende Betrieb ändert sich durch die Spalten nicht.
+		`ALTER TABLE care_tasks ADD COLUMN season_start_month INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE care_tasks ADD COLUMN season_end_month INTEGER NOT NULL DEFAULT 0`,
 		// Ort und Aufgabe im Klartext bei der Zustellung: Wird die Aufgabe
 		// gelöscht, ist sie nicht mehr nachschlagbar — der Hinweis soll
 		// trotzdem sagen können, worum es ging (siehe loeseNotificationsVomVorgang).
@@ -438,12 +444,14 @@ func (d *DB) InsertTask(t *model.CareTask) error {
 		t.Sichtbarkeit = model.AufgabeOeffentlich
 	}
 	res, err := d.sql.Exec(`INSERT INTO care_tasks(place_id,kind,title,liters,interval_days,red_after_days,
-			one_off,due_date,remove_when_done,active,created_at,sichtbarkeit,befaehigung_id)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			one_off,due_date,remove_when_done,active,created_at,sichtbarkeit,befaehigung_id,
+			season_start_month,season_end_month)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		t.PlaceID, string(t.Kind), t.Title, t.Liters, t.IntervalDays, t.RedAfterDays,
 		boolToInt(t.OneOff), zeitText(t.DueDate), boolToInt(t.RemoveWhenDone),
 		boolToInt(t.Active), t.CreatedAt.UTC().Format(timeFormat),
-		string(t.Sichtbarkeit), t.BefaehigungID)
+		string(t.Sichtbarkeit), t.BefaehigungID,
+		t.SeasonStartMonth, t.SeasonEndMonth)
 	if err != nil {
 		return err
 	}
@@ -456,10 +464,12 @@ func (d *DB) UpdateTask(t *model.CareTask) error {
 		t.Sichtbarkeit = model.AufgabeOeffentlich
 	}
 	res, err := d.sql.Exec(`UPDATE care_tasks SET kind=?,title=?,liters=?,interval_days=?,red_after_days=?,
-			one_off=?,due_date=?,remove_when_done=?,active=?,sichtbarkeit=?,befaehigung_id=? WHERE id=?`,
+			one_off=?,due_date=?,remove_when_done=?,active=?,sichtbarkeit=?,befaehigung_id=?,
+			season_start_month=?,season_end_month=? WHERE id=?`,
 		string(t.Kind), t.Title, t.Liters, t.IntervalDays, t.RedAfterDays,
 		boolToInt(t.OneOff), zeitText(t.DueDate), boolToInt(t.RemoveWhenDone),
-		boolToInt(t.Active), string(t.Sichtbarkeit), t.BefaehigungID, t.ID)
+		boolToInt(t.Active), string(t.Sichtbarkeit), t.BefaehigungID,
+		t.SeasonStartMonth, t.SeasonEndMonth, t.ID)
 	if err != nil {
 		return err
 	}
@@ -488,7 +498,8 @@ func (d *DB) DeleteTask(id int64) error {
 }
 
 const taskSpalten = `id,place_id,kind,title,liters,interval_days,red_after_days,
-	one_off,due_date,remove_when_done,removed_at,active,created_at,sichtbarkeit,befaehigung_id`
+	one_off,due_date,remove_when_done,removed_at,active,created_at,sichtbarkeit,befaehigung_id,
+	season_start_month,season_end_month`
 
 // GetTask liefert auch abgeräumte Aufgaben — die Rangliste und die Historie
 // müssen ihre Erledigungen weiter zuordnen können.
@@ -522,7 +533,7 @@ func scanTask(row scannable) (*model.CareTask, error) {
 	var created, kind, dueDate, removedAt, sichtbarkeit string
 	err := row.Scan(&t.ID, &t.PlaceID, &kind, &t.Title, &t.Liters, &t.IntervalDays, &t.RedAfterDays,
 		&oneOff, &dueDate, &removeWhenDone, &removedAt, &active, &created,
-		&sichtbarkeit, &t.BefaehigungID)
+		&sichtbarkeit, &t.BefaehigungID, &t.SeasonStartMonth, &t.SeasonEndMonth)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/db/migration_test.go
+++ b/backend/internal/db/migration_test.go
@@ -147,6 +147,12 @@ func TestMigrationBestandsdatenBleiben(t *testing.T) {
 	if task.IntervalDays != 7 || task.RedAfterDays != 14 {
 		t.Errorf("Intervalle verändert: %+v", task)
 	}
+	// Die Jahreszeit (#78) kommt additiv dazu: Wer nichts angegeben hat,
+	// gießt weiter das ganze Jahr über.
+	if _, saisonal := task.SeasonOf(); saisonal {
+		t.Errorf("Bestandsaufgabe bekam eine Jahreszeit: %d/%d",
+			task.SeasonStartMonth, task.SeasonEndMonth)
+	}
 
 	cs, err := d.ListCompletions(1, 10)
 	if err != nil {

--- a/backend/internal/db/season_test.go
+++ b/backend/internal/db/season_test.go
@@ -1,0 +1,78 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Die Jahreszeit einer Aufgabe (#78) muss die Datei überleben — sonst stünde
+// sie nach dem nächsten Neustart wieder ganzjährig da.
+
+func TestJahreszeitUeberlebtDieDatenbank(t *testing.T) {
+	d := testDB(t)
+	jetzt := time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC)
+
+	ort := model.Place{Name: "Dorfgemeinschaftshaus", Kind: model.PlaceBed,
+		Lat: 52.211, Lon: 9.87, Active: true, CreatedAt: jetzt}
+	if err := d.InsertPlace(&ort); err != nil {
+		t.Fatal(err)
+	}
+
+	aufgabe := model.CareTask{PlaceID: ort.ID, Kind: model.TaskWeeding,
+		IntervalDays: 56, RedAfterDays: 70,
+		SeasonStartMonth: 4, SeasonEndMonth: 9,
+		Active: true, CreatedAt: jetzt}
+	if err := d.InsertTask(&aufgabe); err != nil {
+		t.Fatal(err)
+	}
+
+	gelesen, err := d.GetTask(aufgabe.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gelesen.SeasonStartMonth != 4 || gelesen.SeasonEndMonth != 9 {
+		t.Fatalf("Jahreszeit = %d/%d, erwartet 4/9",
+			gelesen.SeasonStartMonth, gelesen.SeasonEndMonth)
+	}
+
+	// Zurück auf ganzjährig — auch das muss ankommen.
+	gelesen.SeasonStartMonth, gelesen.SeasonEndMonth = 0, 0
+	if err := d.UpdateTask(gelesen); err != nil {
+		t.Fatal(err)
+	}
+	wieder, err := d.GetTask(aufgabe.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, saisonal := wieder.SeasonOf(); saisonal {
+		t.Fatalf("Jahreszeit nicht abgeräumt: %d/%d",
+			wieder.SeasonStartMonth, wieder.SeasonEndMonth)
+	}
+}
+
+// Ohne Angabe ist eine Aufgabe ganzjährig — die Vorbelegung der neuen
+// Spalten.
+func TestAufgabeOhneAngabeIstGanzjaehrig(t *testing.T) {
+	d := testDB(t)
+	jetzt := time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC)
+	ort := model.Place{Name: "Kasten 1", Kind: model.PlaceFlowerbox,
+		Lat: 52.211, Lon: 9.87, Active: true, CreatedAt: jetzt}
+	if err := d.InsertPlace(&ort); err != nil {
+		t.Fatal(err)
+	}
+	aufgabe := model.CareTask{PlaceID: ort.ID, Kind: model.TaskWatering,
+		IntervalDays: 7, RedAfterDays: 14, Active: true, CreatedAt: jetzt}
+	if err := d.InsertTask(&aufgabe); err != nil {
+		t.Fatal(err)
+	}
+	gelesen, err := d.GetTask(aufgabe.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, saisonal := gelesen.SeasonOf(); saisonal {
+		t.Fatalf("unerwartete Jahreszeit: %d/%d",
+			gelesen.SeasonStartMonth, gelesen.SeasonEndMonth)
+	}
+}

--- a/backend/internal/mcp/mcp.go
+++ b/backend/internal/mcp/mcp.go
@@ -365,7 +365,10 @@ func (s *Server) registerTools() {
 				"z.B. Gießplan (kind=giessen, liters=10, intervalDays=7, redAfterDays=14) " +
 				"oder Jäten (kind=jaeten, intervalDays=21, redAfterDays=35) — oder EINMALIG " +
 				"mit Termin statt Intervall (oneOff=true, dueDate=2026-08-20), z.B. " +
-				"„einmal zum Bahnhof fahren\". Beides zusammen geht nicht.",
+				"„einmal zum Bahnhof fahren\". Beides zusammen geht nicht. " +
+				"Eine regelmäßige Aufgabe kann auf einen Teil des Jahres beschränkt werden " +
+				"(seasonStartMonth=4, seasonEndMonth=9 = April bis September); außerhalb " +
+				"ruht sie und erzeugt weder Ampel noch Erinnerung.",
 			Schema: obj([]string{"placeId", "kind"}, map[string]any{
 				"placeId":        integer("ID des Ortes"),
 				"kind":           enum("Art der Aufgabe", "giessen", "jaeten", "sonstiges"),
@@ -378,6 +381,10 @@ func (s *Server) registerTools() {
 				"oneOff":         boolean("Einmalige Aufgabe statt eines wiederkehrenden Plans"),
 				"dueDate":        str("Nur einmalig: Fälligkeitsdatum (2026-08-20 oder RFC3339). Gelb ab drei Tagen davor, rot danach"),
 				"removeWhenDone": boolean("Nach dem Erledigen von Karte und Liste nehmen (Erledigung zählt weiter für die Rangliste)"),
+				"seasonStartMonth": integer("Nur regelmäßig: erster Monat der Jahreszeit (1–12, einschließlich). " +
+					"Ohne Angabe fällt die Aufgabe ganzjährig an"),
+				"seasonEndMonth": integer("Nur regelmäßig: letzter Monat der Jahreszeit (1–12, einschließlich). " +
+					"Anfang größer als Ende geht über den Jahreswechsel, z.B. 11 bis 2 = November bis Februar"),
 			}),
 			Handler: s.toolCreateTask,
 		},
@@ -396,6 +403,9 @@ func (s *Server) registerTools() {
 				"dueDate":        str("Fälligkeitsdatum einmaliger Aufgaben (2026-08-20 oder RFC3339)"),
 				"removeWhenDone": boolean("Nach dem Erledigen entfernen"),
 				"active":         boolean("Aufgabe aktiv?"),
+				"seasonStartMonth": integer("Erster Monat der Jahreszeit (1–12); 0 nimmt die " +
+					"Jahreszeit weg, die Aufgabe fällt dann wieder ganzjährig an"),
+				"seasonEndMonth": integer("Letzter Monat der Jahreszeit (1–12); 0 = ganzjährig"),
 			}),
 			Handler: s.toolUpdateTask,
 		},
@@ -595,6 +605,9 @@ func (s *Server) toolUpdateTask(args json.RawMessage, u auth.User) (any, error) 
 		Active         *bool    `json:"active"`
 		Sichtbarkeit   *string  `json:"sichtbarkeit"`
 		BefaehigungID  *int64   `json:"befaehigungId"`
+		// Jahreszeit: siehe model.Season. 0 nimmt sie weg.
+		SeasonStartMonth *int `json:"seasonStartMonth"`
+		SeasonEndMonth   *int `json:"seasonEndMonth"`
 	}
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil, err
@@ -638,17 +651,34 @@ func (s *Server) toolUpdateTask(args json.RawMessage, u auth.User) (any, error) 
 		}
 		t.DueDate = &termin
 	}
+	if in.SeasonStartMonth != nil {
+		t.SeasonStartMonth = *in.SeasonStartMonth
+	}
+	if in.SeasonEndMonth != nil {
+		t.SeasonEndMonth = *in.SeasonEndMonth
+	}
 	if t.OneOff {
 		if t.DueDate == nil {
 			return nil, fmt.Errorf("dueDate fehlt: eine einmalige Aufgabe braucht ein Fälligkeitsdatum")
 		}
 		// Intervalle spielen bei einem Termin keine Rolle.
 		t.IntervalDays, t.RedAfterDays = 0, 0
+		// Ein Termin hat keine Jahreszeit — wer beides angibt, meint zwei
+		// verschiedene Dinge.
+		if in.SeasonStartMonth != nil && *in.SeasonStartMonth != 0 ||
+			in.SeasonEndMonth != nil && *in.SeasonEndMonth != 0 {
+			return nil, fmt.Errorf("eine einmalige Aufgabe hat keine Jahreszeit: entweder Termin oder Zeitraum")
+		}
+		t.SeasonStartMonth, t.SeasonEndMonth = 0, 0
 	} else {
 		t.DueDate = nil
 		if t.IntervalDays <= 0 || t.RedAfterDays < t.IntervalDays {
 			return nil, fmt.Errorf("ungültige Intervalle: intervalDays > 0 und redAfterDays >= intervalDays nötig")
 		}
+		if err := model.ValidSeasonMonths(t.SeasonStartMonth, t.SeasonEndMonth); err != nil {
+			return nil, err
+		}
+		t.SeasonStartMonth, t.SeasonEndMonth = model.NormalizeSeasonMonths(t.SeasonStartMonth, t.SeasonEndMonth)
 	}
 	if err := s.DB.UpdateTask(t); err != nil {
 		return nil, err

--- a/backend/internal/mcp/season_test.go
+++ b/backend/internal/mcp/season_test.go
@@ -1,0 +1,154 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// MCP ist der Verwaltungsweg (#62): Was sich in der Web-Verwaltung
+// einstellen lässt, muss auch aus Claude heraus gehen — sonst ist die
+// Jahreszeit einer Aufgabe (#78) wieder nur im Browser erreichbar.
+
+// mcpOrt legt einen Ort an und liefert seine ID.
+func mcpOrt(t *testing.T, ts *httptest.Server) int64 {
+	t.Helper()
+	text, fehler := callTool(t, ts, "ort_anlegen", map[string]any{
+		"name": "Dorfgemeinschaftshaus", "kind": "beet", "lat": 52.211, "lon": 9.87,
+	})
+	if fehler {
+		t.Fatalf("ort_anlegen: %s", text)
+	}
+	var ort struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(text), &ort); err != nil {
+		t.Fatalf("Antwort unlesbar: %s", text)
+	}
+	return ort.ID
+}
+
+type mcpAufgabe struct {
+	ID               int64 `json:"id"`
+	SeasonStartMonth int   `json:"seasonStartMonth"`
+	SeasonEndMonth   int   `json:"seasonEndMonth"`
+}
+
+func TestMcpLegtAufgabeMitJahreszeitAn(t *testing.T) {
+	ts := newTestServer(t)
+	ortID := mcpOrt(t, ts)
+
+	text, fehler := callTool(t, ts, "aufgabe_anlegen", map[string]any{
+		"placeId": ortID, "kind": "jaeten", "intervalDays": 56, "redAfterDays": 70,
+		"seasonStartMonth": 4, "seasonEndMonth": 9,
+	})
+	if fehler {
+		t.Fatalf("aufgabe_anlegen: %s", text)
+	}
+	var aufgabe mcpAufgabe
+	if err := json.Unmarshal([]byte(text), &aufgabe); err != nil {
+		t.Fatalf("Antwort unlesbar: %s", text)
+	}
+	if aufgabe.SeasonStartMonth != 4 || aufgabe.SeasonEndMonth != 9 {
+		t.Fatalf("Jahreszeit = %d/%d, erwartet April bis September",
+			aufgabe.SeasonStartMonth, aufgabe.SeasonEndMonth)
+	}
+}
+
+func TestMcpAendertUndRaeumtDieJahreszeitAb(t *testing.T) {
+	ts := newTestServer(t)
+	ortID := mcpOrt(t, ts)
+	text, _ := callTool(t, ts, "aufgabe_anlegen", map[string]any{
+		"placeId": ortID, "kind": "jaeten", "intervalDays": 56, "redAfterDays": 70,
+	})
+	var aufgabe mcpAufgabe
+	if err := json.Unmarshal([]byte(text), &aufgabe); err != nil {
+		t.Fatalf("Antwort unlesbar: %s", text)
+	}
+
+	text, fehler := callTool(t, ts, "aufgabe_aendern", map[string]any{
+		"id": aufgabe.ID, "seasonStartMonth": 11, "seasonEndMonth": 2,
+	})
+	if fehler {
+		t.Fatalf("aufgabe_aendern: %s", text)
+	}
+	if err := json.Unmarshal([]byte(text), &aufgabe); err != nil {
+		t.Fatalf("Antwort unlesbar: %s", text)
+	}
+	if aufgabe.SeasonStartMonth != 11 || aufgabe.SeasonEndMonth != 2 {
+		t.Fatalf("Jahreszeit = %d/%d, erwartet November bis Februar",
+			aufgabe.SeasonStartMonth, aufgabe.SeasonEndMonth)
+	}
+
+	// Eine Änderung an etwas anderem lässt sie stehen.
+	text, _ = callTool(t, ts, "aufgabe_aendern", map[string]any{
+		"id": aufgabe.ID, "title": "Beet jäten",
+	})
+	if err := json.Unmarshal([]byte(text), &aufgabe); err != nil {
+		t.Fatalf("Antwort unlesbar: %s", text)
+	}
+	if aufgabe.SeasonStartMonth != 11 || aufgabe.SeasonEndMonth != 2 {
+		t.Fatalf("Jahreszeit ging beim Umbenennen verloren: %d/%d",
+			aufgabe.SeasonStartMonth, aufgabe.SeasonEndMonth)
+	}
+
+	// Und ausdrückliche 0 nimmt sie weg. Frische Struktur, weil eine
+	// ganzjährige Aufgabe die Felder gar nicht mehr mitschickt.
+	text, _ = callTool(t, ts, "aufgabe_aendern", map[string]any{
+		"id": aufgabe.ID, "seasonStartMonth": 0, "seasonEndMonth": 0,
+	})
+	var ganzjaehrig mcpAufgabe
+	if err := json.Unmarshal([]byte(text), &ganzjaehrig); err != nil {
+		t.Fatalf("Antwort unlesbar: %s", text)
+	}
+	if ganzjaehrig.SeasonStartMonth != 0 || ganzjaehrig.SeasonEndMonth != 0 {
+		t.Fatalf("Jahreszeit nicht abgeräumt: %d/%d",
+			ganzjaehrig.SeasonStartMonth, ganzjaehrig.SeasonEndMonth)
+	}
+}
+
+// Halbe Angaben und Unmögliches müssen im Klartext abgewiesen werden — damit
+// Claude dem Menschen erklären kann, was fehlt.
+func TestMcpWeistUnmoeglicheJahreszeitAb(t *testing.T) {
+	ts := newTestServer(t)
+	ortID := mcpOrt(t, ts)
+
+	faelle := map[string]map[string]any{
+		"nur Anfangsmonat": {"placeId": ortID, "kind": "jaeten",
+			"intervalDays": 56, "redAfterDays": 70, "seasonStartMonth": 4},
+		"Monat 13": {"placeId": ortID, "kind": "jaeten",
+			"intervalDays": 56, "redAfterDays": 70,
+			"seasonStartMonth": 13, "seasonEndMonth": 9},
+		"einmalig mit Jahreszeit": {"placeId": ortID, "kind": "sonstiges",
+			"oneOff": true, "dueDate": "2026-09-01",
+			"seasonStartMonth": 4, "seasonEndMonth": 9},
+	}
+	for name, args := range faelle {
+		t.Run(name, func(t *testing.T) {
+			text, fehler := callTool(t, ts, "aufgabe_anlegen", args)
+			if !fehler {
+				t.Fatalf("wurde angenommen: %s", text)
+			}
+			if strings.TrimSpace(text) == "" {
+				t.Error("ohne Begründung abgewiesen")
+			}
+		})
+	}
+}
+
+// Die neuen Angaben müssen im Werkzeug-Schema stehen, sonst schickt Claude
+// sie nie mit.
+func TestMcpSchemaKenntDieJahreszeit(t *testing.T) {
+	ts := newTestServer(t)
+	out := rpc(t, ts, "admin-jwt", "tools/list", nil)
+	roh, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, feld := range []string{"seasonStartMonth", "seasonEndMonth"} {
+		if !strings.Contains(string(roh), feld) {
+			t.Errorf("%q fehlt in der Werkzeugliste", feld)
+		}
+	}
+}

--- a/backend/internal/model/model.go
+++ b/backend/internal/model/model.go
@@ -12,16 +12,31 @@ const (
 	StatusGreen  Status = "green"  // kürzlich erledigt
 	StatusYellow Status = "yellow" // Intervall überschritten, bitte erledigen
 	StatusRed    Status = "red"    // Rot-Schwelle überschritten, dringend
+	// StatusDormant: außer Dienst — die Aufgabe fällt zu dieser Jahreszeit
+	// gar nicht an (siehe season.go). Sie ist dann weder fällig noch gelb
+	// noch rot, und niemand wird deswegen gefragt. Bewusst kein „grün":
+	// Ein Beet, an dem im Winter nichts zu jäten ist, ist nicht in Ordnung
+	// gebracht worden, sondern gerade nicht im Dienst.
+	StatusDormant Status = "dormant"
 )
+
+// statusRank ordnet die Ampel: schlechter heißt größer. Ruhend steht unter
+// grün — an einer ruhenden Aufgabe ist noch weniger zu tun als an einer
+// frisch erledigten.
+var statusRank = map[Status]int{StatusDormant: 0, StatusGreen: 1, StatusYellow: 2, StatusRed: 3}
 
 // Worst liefert den schlechteren von zwei Status.
 func Worst(a, b Status) Status {
-	rank := map[Status]int{StatusGreen: 0, StatusYellow: 1, StatusRed: 2}
-	if rank[b] > rank[a] {
+	if statusRank[b] > statusRank[a] {
 		return b
 	}
 	return a
 }
+
+// NeedsWork sagt, ob an der Aufgabe gerade wirklich etwas zu tun ist. Wer
+// fragen, erinnern oder vergeben will, fragt das — nicht „ist sie nicht
+// grün": Ruhend ist auch nicht grün, aber es ist nichts zu tun.
+func (s Status) NeedsWork() bool { return s == StatusYellow || s == StatusRed }
 
 // PlaceKind beschreibt die Art eines Ortes.
 type PlaceKind string
@@ -83,6 +98,13 @@ type CareTask struct {
 	// RedAfterDays: Nach so vielen Tagen ohne Erledigung wird sie rot.
 	// Bei einmaligen Aufgaben ohne Bedeutung (0).
 	RedAfterDays float64 `json:"redAfterDays"`
+	// SeasonStartMonth/SeasonEndMonth: der Teil des Jahres, in dem die
+	// Aufgabe überhaupt anfällt — jeweils ein ganzer Monat, einschließlich
+	// (4 und 9 heißt 1. April bis 30. September). 0/0 heißt ganzjährig und
+	// ist die Vorbelegung des gesamten Bestands. Anfang > Ende geht über den
+	// Jahreswechsel (11/2 = November bis Februar). Siehe season.go.
+	SeasonStartMonth int `json:"seasonStartMonth,omitempty"`
+	SeasonEndMonth   int `json:"seasonEndMonth,omitempty"`
 	// OneOff: einmalige Aufgabe („einmal zum Bahnhof fahren") statt eines
 	// wiederkehrenden Pflegeplans. An die Stelle des Intervalls tritt dann
 	// das Fälligkeitsdatum.
@@ -195,6 +217,15 @@ type PlaceWithStatus struct {
 // der Aufgabe als Startpunkt. factor skaliert die Schwellen: 1.0 = normal,
 // 0.5 = Hitzewelle (doppelt so schnell gelb/rot). Der Aufrufer entscheidet,
 // für welche Aufgabenarten der Faktor gilt (typisch: nur Gießen).
+//
+// Hat die Aufgabe eine Jahreszeit (season.go), gilt sie nur in deren
+// Fenster. Außerhalb ruht sie: StatusDormant, und die beiden Zeitpunkte
+// zeigen auf den Beginn des nächsten Fensters — der Tag, ab dem wieder etwas
+// zu tun ist. Der Zähler läuft dabei bewusst weiter: Wer im September zuletzt
+// gejätet hat, ist am 1. April fällig, ohne dass jemand etwas anfassen muss.
+// Deshalb wird die Basis nicht zurückgesetzt, sondern nur die Anzeige der
+// Schwellen auf den Fensterbeginn gezogen — vor dem 1. April kann nichts
+// fällig gewesen sein.
 func ComputeStatus(task CareTask, last *Completion, now time.Time, factor float64) (Status, time.Time, time.Time) {
 	if task.OneOff {
 		return statusEinmalig(task, last, now)
@@ -209,6 +240,15 @@ func ComputeStatus(task CareTask, last *Completion, now time.Time, factor float6
 	dayHours := 24 * factor
 	dueAt := base.Add(time.Duration(task.IntervalDays * dayHours * float64(time.Hour)))
 	redAt := base.Add(time.Duration(task.RedAfterDays * dayHours * float64(time.Hour)))
+	if season, ok := task.SeasonOf(); ok {
+		von, _, drin := season.Window(now, Location())
+		dueAt, redAt = laterOf(dueAt, von), laterOf(redAt, von)
+		if !drin {
+			// Der Hitzefaktor ändert daran nichts: Er staucht Schwellen,
+			// er verlängert keine Jahreszeit.
+			return StatusDormant, dueAt, redAt
+		}
+	}
 	// RedAfterDays < IntervalDays wäre eine Fehlkonfiguration; rot gewinnt dann.
 	switch {
 	case !now.Before(redAt):
@@ -218,6 +258,40 @@ func ComputeStatus(task CareTask, last *Completion, now time.Time, factor float6
 	default:
 		return StatusGreen, dueAt, redAt
 	}
+}
+
+// laterOf liefert den späteren der beiden Zeitpunkte.
+func laterOf(a, b time.Time) time.Time {
+	if a.Before(b) {
+		return b
+	}
+	return a
+}
+
+// PlaceStatus fasst die Aufgaben eines Ortes zu dem einen Punkt zusammen,
+// der auf der Karte steht: der schlechteste Status seiner aktiven Aufgaben.
+//
+// Ruhen sie alle, ruht der Ort — ein Beet, an dem im Winter nichts zu jäten
+// ist, meldet nicht „alles gut", sondern ist außer Dienst. Ein Ort ohne
+// aktive Aufgabe bleibt grün, wie bisher.
+func PlaceStatus(tasks []TaskWithStatus) Status {
+	status := StatusGreen
+	aktive, ruhende := 0, 0
+	for _, t := range tasks {
+		if !t.Active {
+			continue
+		}
+		aktive++
+		if t.Status == StatusDormant {
+			ruhende++
+			continue
+		}
+		status = Worst(status, t.Status)
+	}
+	if aktive > 0 && aktive == ruhende {
+		return StatusDormant
+	}
+	return status
 }
 
 // statusEinmalig ist die Ampel einer einmaligen Aufgabe. An die Stelle des

--- a/backend/internal/model/season.go
+++ b/backend/internal/model/season.go
@@ -1,0 +1,112 @@
+package model
+
+import (
+	"fmt"
+	"time"
+)
+
+// Jahreszeit einer wiederkehrenden Aufgabe.
+//
+// Das Beet vor dem Dorfgemeinschaftshaus wird von April bis September
+// gejätet — im Dezember ist dort nichts zu tun. Eine Aufgabe, die nur ihr
+// Intervall kennt, zählt trotzdem weiter und färbt die Karte rot für Arbeit,
+// die es gar nicht gibt (#78).
+//
+// Gerechnet wird in ganzen Monaten und in Ortszeit des Dorfes. Ganze Monate
+// reichen: Niemand sagt „ab dem 12. April", und Monatsgrenzen kennen weder
+// Schaltjahr- noch Wochentagsprobleme. Ortszeit, weil den Zeitraum jemand in
+// Rössing im Kopf hat und nicht in UTC.
+//
+// Die Jahreszeit hängt an der Aufgabe, nicht am Ort: Am selben Beet kann
+// Jäten saisonal und „Müll aufsammeln" ganzjährig sein.
+type Season struct {
+	// Start und End sind einschließlich. Start > End heißt: Der Zeitraum
+	// geht über den Jahreswechsel (November bis Februar).
+	Start time.Month
+	End   time.Month
+}
+
+// SeasonOf liefert die Jahreszeit der Aufgabe. Ohne Angabe (0/0) fällt sie
+// das ganze Jahr an — so laufen alle Bestandsaufgaben unverändert weiter.
+func (t CareTask) SeasonOf() (Season, bool) {
+	if t.SeasonStartMonth == 0 || t.SeasonEndMonth == 0 {
+		return Season{}, false
+	}
+	return Season{Start: time.Month(t.SeasonStartMonth), End: time.Month(t.SeasonEndMonth)}, true
+}
+
+// ValidSeasonMonths prüft ein Monatspaar, wie es von außen hereinkommt
+// (REST, MCP, Web-Verwaltung, Chat). 0/0 bedeutet ganzjährig; alles andere
+// braucht beide Monate im Bereich 1–12.
+func ValidSeasonMonths(start, end int) error {
+	if start == 0 && end == 0 {
+		return nil
+	}
+	if start == 0 || end == 0 {
+		return fmt.Errorf("die Jahreszeit braucht Anfangs- und Endmonat (oder beides leer für ganzjährig)")
+	}
+	if start < 1 || start > 12 || end < 1 || end > 12 {
+		return fmt.Errorf("Anfangs- und Endmonat müssen zwischen 1 (Januar) und 12 (Dezember) liegen")
+	}
+	return nil
+}
+
+// NormalizeSeasonMonths macht aus „Januar bis Dezember" das ganzjährige 0/0.
+// Sonst gäbe es zwei Schreibweisen für dieselbe Sache, und die Anzeige
+// müsste beide kennen.
+func NormalizeSeasonMonths(start, end int) (int, int) {
+	if start == 1 && end == 12 {
+		return 0, 0
+	}
+	return start, end
+}
+
+// Window liefert das Zeitfenster [von, bis), in dem now liegt, und ob now
+// wirklich darin liegt. Liegt es außerhalb, ist von der Beginn des nächsten
+// Fensters — der Zeitpunkt also, ab dem die Aufgabe wieder anfällt.
+//
+// Über den Jahreswechsel hinweg (Start > End) beginnt das Fenster im einen
+// und endet im nächsten Jahr; deshalb werden drei Jahrgänge geprüft.
+func (s Season) Window(now time.Time, loc *time.Location) (von time.Time, bis time.Time, drin bool) {
+	if loc == nil {
+		loc = time.UTC
+	}
+	n := now.In(loc)
+	for _, jahr := range []int{n.Year() - 1, n.Year(), n.Year() + 1} {
+		von, bis := s.fenster(jahr, loc)
+		if !n.Before(von) && n.Before(bis) {
+			return von, bis, true
+		}
+	}
+	// Außerhalb: das nächste Fenster, das noch beginnt.
+	for _, jahr := range []int{n.Year(), n.Year() + 1} {
+		von, bis := s.fenster(jahr, loc)
+		if n.Before(von) {
+			return von, bis, false
+		}
+	}
+	// Unerreichbar, solange Start und End gültige Monate sind.
+	von, bis = s.fenster(n.Year()+1, loc)
+	return von, bis, false
+}
+
+// fenster ist das Zeitfenster des Jahrgangs, der im Jahr jahr beginnt.
+// Die Obergrenze ist ausschließlich: Der 1. Oktober 00:00 gehört nicht mehr
+// zu „April bis September".
+func (s Season) fenster(jahr int, loc *time.Location) (time.Time, time.Time) {
+	von := time.Date(jahr, s.Start, 1, 0, 0, 0, 0, loc)
+	endJahr := jahr
+	if s.Start > s.End {
+		endJahr++
+	}
+	// time.Date normalisiert Monat 13 zum Januar des Folgejahres — genau
+	// das ist bei End = Dezember gemeint.
+	bis := time.Date(endJahr, s.End+1, 1, 0, 0, 0, 0, loc)
+	return von, bis
+}
+
+// Contains sagt, ob der Zeitpunkt in die Jahreszeit fällt.
+func (s Season) Contains(now time.Time, loc *time.Location) bool {
+	_, _, drin := s.Window(now, loc)
+	return drin
+}

--- a/backend/internal/model/season_test.go
+++ b/backend/internal/model/season_test.go
@@ -1,0 +1,258 @@
+package model
+
+import (
+	"testing"
+	"time"
+)
+
+// Das Beet vor dem Dorfgemeinschaftshaus: alle acht Wochen jäten, aber nur
+// von April bis September (#78).
+func beet() CareTask {
+	return CareTask{
+		Kind: TaskWeeding, IntervalDays: 56, RedAfterDays: 70,
+		SeasonStartMonth: 4, SeasonEndMonth: 9,
+		CreatedAt: dorfzeit(2026, time.April, 1),
+	}
+}
+
+// dorfzeit ist Mitternacht Ortszeit des Dorfes — in dieser Zeit werden die
+// Monatsgrenzen gezogen.
+func dorfzeit(jahr int, monat time.Month, tag int) time.Time {
+	return time.Date(jahr, monat, tag, 0, 0, 0, 0, Location())
+}
+
+func TestSeasonFensterEinschliesslich(t *testing.T) {
+	s := Season{Start: time.April, End: time.September}
+	cases := []struct {
+		name string
+		zeit time.Time
+		drin bool
+	}{
+		{"31. März kurz vor Mitternacht", dorfzeit(2026, time.April, 1).Add(-time.Second), false},
+		{"1. April 00:00", dorfzeit(2026, time.April, 1), true},
+		{"Mitte Juli", dorfzeit(2026, time.July, 15), true},
+		{"30. September 23:59", dorfzeit(2026, time.October, 1).Add(-time.Minute), true},
+		{"1. Oktober 00:00", dorfzeit(2026, time.October, 1), false},
+		{"Dezember", dorfzeit(2026, time.December, 24), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := s.Contains(c.zeit, Location()); got != c.drin {
+				t.Fatalf("Contains = %v, erwartet %v", got, c.drin)
+			}
+		})
+	}
+}
+
+// Ein Zeitraum über den Jahreswechsel: November bis Februar. Der Januar
+// gehört dazu, der Juni nicht.
+func TestSeasonUeberDenJahreswechsel(t *testing.T) {
+	s := Season{Start: time.November, End: time.February}
+	cases := []struct {
+		zeit time.Time
+		drin bool
+	}{
+		{dorfzeit(2026, time.October, 31), false},
+		{dorfzeit(2026, time.November, 1), true},
+		{dorfzeit(2026, time.December, 31), true},
+		{dorfzeit(2027, time.January, 15), true},
+		{dorfzeit(2027, time.February, 28), true},
+		{dorfzeit(2027, time.March, 1), false},
+		{dorfzeit(2027, time.June, 1), false},
+	}
+	for _, c := range cases {
+		if got := s.Contains(c.zeit, Location()); got != c.drin {
+			t.Errorf("%s: Contains = %v, erwartet %v", c.zeit.Format("2006-01-02"), got, c.drin)
+		}
+	}
+}
+
+// Außerhalb des Fensters zeigt Window auf den Beginn des nächsten — das ist
+// der Tag, ab dem wieder etwas zu tun ist.
+func TestSeasonNaechstesFenster(t *testing.T) {
+	s := Season{Start: time.April, End: time.September}
+	von, _, drin := s.Window(dorfzeit(2026, time.December, 24), Location())
+	if drin {
+		t.Fatal("der Heiligabend liegt nicht in der Jätesaison")
+	}
+	if want := dorfzeit(2027, time.April, 1); !von.Equal(want) {
+		t.Fatalf("nächstes Fenster ab %v, erwartet %v", von, want)
+	}
+
+	von, _, drin = s.Window(dorfzeit(2026, time.February, 3), Location())
+	if drin {
+		t.Fatal("der Februar liegt nicht in der Jätesaison")
+	}
+	if want := dorfzeit(2026, time.April, 1); !von.Equal(want) {
+		t.Fatalf("nächstes Fenster ab %v, erwartet %v", von, want)
+	}
+}
+
+// Der Dezember als letzter Monat darf nicht am 1. Dezember enden — Monat 13
+// ist der Januar des Folgejahres.
+func TestSeasonBisDezember(t *testing.T) {
+	s := Season{Start: time.October, End: time.December}
+	if !s.Contains(dorfzeit(2026, time.December, 31), Location()) {
+		t.Error("der 31. Dezember gehört noch zu Oktober–Dezember")
+	}
+	if s.Contains(dorfzeit(2027, time.January, 1), Location()) {
+		t.Error("der 1. Januar gehört nicht mehr dazu")
+	}
+}
+
+// Der Kern von #78: Im November ist an dem Beet nichts zu jäten. Die Aufgabe
+// ist dann nicht rot, aber auch nicht grün — sie ist außer Dienst.
+func TestAufgabeAusserhalbIhrerJahreszeitRuht(t *testing.T) {
+	letzte := done(dorfzeit(2026, time.September, 20))
+	status, _, _ := ComputeStatus(beet(), letzte, dorfzeit(2026, time.November, 16), 1)
+	if status != StatusDormant {
+		t.Fatalf("Status im November = %s, erwartet %s", status, StatusDormant)
+	}
+	if status.NeedsWork() {
+		t.Fatal("an einer ruhenden Aufgabe ist nichts zu tun")
+	}
+}
+
+// Am 30. September rot, am 1. Oktober außer Dienst — und nicht plötzlich
+// grün, als hätte jemand gejätet.
+func TestUebergangAmSaisonendeIstNichtGruen(t *testing.T) {
+	letzte := done(dorfzeit(2026, time.June, 1))
+	vorher, _, _ := ComputeStatus(beet(), letzte, dorfzeit(2026, time.October, 1).Add(-time.Minute), 1)
+	if vorher != StatusRed {
+		t.Fatalf("am 30. September = %s, erwartet %s", vorher, StatusRed)
+	}
+	nachher, _, _ := ComputeStatus(beet(), letzte, dorfzeit(2026, time.October, 1), 1)
+	if nachher != StatusDormant {
+		t.Fatalf("am 1. Oktober = %s, erwartet %s", nachher, StatusDormant)
+	}
+}
+
+// Beim Start im April ist sie fällig, ohne dass jemand etwas angefasst hat:
+// Der Zähler läuft über den Winter weiter, nur die Ampel schweigt.
+func TestSaisonbeginnIstSofortFaellig(t *testing.T) {
+	letzte := done(dorfzeit(2026, time.September, 20))
+	status, dueAt, redAt := ComputeStatus(beet(), letzte, dorfzeit(2027, time.April, 1), 1)
+	if !status.NeedsWork() {
+		t.Fatalf("am 1. April = %s, erwartet fällig", status)
+	}
+	// Fällig werden kann sie frühestens mit dem Fenster — nicht im Februar.
+	if want := dorfzeit(2027, time.April, 1); !dueAt.Equal(want) {
+		t.Errorf("dueAt = %v, erwartet %v", dueAt, want)
+	}
+	if want := dorfzeit(2027, time.April, 1); !redAt.Equal(want) {
+		t.Errorf("redAt = %v, erwartet %v", redAt, want)
+	}
+}
+
+// Innerhalb der Jahreszeit rechnet die Ampel wie eh und je.
+func TestInnerhalbDerJahreszeitGiltDasIntervall(t *testing.T) {
+	letzte := done(dorfzeit(2026, time.May, 1))
+	cases := []struct {
+		name  string
+		jetzt time.Time
+		want  Status
+	}{
+		{"eine Woche später", dorfzeit(2026, time.May, 8), StatusGreen},
+		{"nach 56 Tagen gelb", dorfzeit(2026, time.May, 1).Add(56 * 24 * time.Hour), StatusYellow},
+		{"nach 70 Tagen rot", dorfzeit(2026, time.May, 1).Add(70 * 24 * time.Hour), StatusRed},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, _, _ := ComputeStatus(beet(), letzte, c.jetzt, 1)
+			if got != c.want {
+				t.Fatalf("Status = %s, erwartet %s", got, c.want)
+			}
+		})
+	}
+}
+
+// Der Hitzefaktor staucht Schwellen, er verlängert keine Jahreszeit: Im
+// Dezember bleibt auch bei Faktor 0.1 alles ruhig.
+func TestHitzefaktorVerlaengertDieJahreszeitNicht(t *testing.T) {
+	giessen := CareTask{
+		Kind: TaskWatering, IntervalDays: 3, RedAfterDays: 6,
+		SeasonStartMonth: 5, SeasonEndMonth: 9,
+		CreatedAt: dorfzeit(2026, time.May, 1),
+	}
+	status, _, _ := ComputeStatus(giessen, done(dorfzeit(2026, time.September, 28)),
+		dorfzeit(2026, time.December, 20), 0.1)
+	if status != StatusDormant {
+		t.Fatalf("Status = %s, erwartet %s", status, StatusDormant)
+	}
+}
+
+// Ohne Angabe fällt eine Aufgabe ganzjährig an — so laufen alle
+// Bestandsaufgaben unverändert weiter.
+func TestOhneJahreszeitBleibtAllesWieBisher(t *testing.T) {
+	ganzjaehrig := beet()
+	ganzjaehrig.SeasonStartMonth, ganzjaehrig.SeasonEndMonth = 0, 0
+	status, _, _ := ComputeStatus(ganzjaehrig, done(dorfzeit(2026, time.September, 20)),
+		dorfzeit(2026, time.December, 16), 1)
+	if status != StatusRed {
+		t.Fatalf("Status = %s, erwartet %s — ohne Jahreszeit zählt nur das Intervall", status, StatusRed)
+	}
+}
+
+// Eine einmalige Aufgabe hat einen Termin und keine Jahreszeit; ein
+// versehentlich gesetzter Zeitraum darf ihren Termin nicht verschlucken.
+func TestEinmaligeAufgabeIgnoriertDieJahreszeit(t *testing.T) {
+	faellig := dorfzeit(2026, time.December, 20)
+	einmalig := CareTask{
+		Kind: TaskOther, OneOff: true, DueDate: &faellig,
+		SeasonStartMonth: 4, SeasonEndMonth: 9,
+		CreatedAt: dorfzeit(2026, time.December, 1),
+	}
+	status, _, _ := ComputeStatus(einmalig, nil, dorfzeit(2026, time.December, 21), 1)
+	if status != StatusRed {
+		t.Fatalf("Status = %s, erwartet %s", status, StatusRed)
+	}
+}
+
+func TestValidSeasonMonths(t *testing.T) {
+	if err := ValidSeasonMonths(0, 0); err != nil {
+		t.Errorf("0/0 (ganzjährig) muss erlaubt sein: %v", err)
+	}
+	if err := ValidSeasonMonths(4, 9); err != nil {
+		t.Errorf("April bis September muss erlaubt sein: %v", err)
+	}
+	if err := ValidSeasonMonths(11, 2); err != nil {
+		t.Errorf("November bis Februar muss erlaubt sein: %v", err)
+	}
+	if err := ValidSeasonMonths(4, 0); err == nil {
+		t.Error("halbe Angabe muss abgewiesen werden")
+	}
+	if err := ValidSeasonMonths(0, 9); err == nil {
+		t.Error("halbe Angabe muss abgewiesen werden")
+	}
+	if err := ValidSeasonMonths(13, 2); err == nil {
+		t.Error("Monat 13 gibt es nicht")
+	}
+	if von, bis := NormalizeSeasonMonths(1, 12); von != 0 || bis != 0 {
+		t.Errorf("Januar–Dezember = %d/%d, erwartet ganzjährig (0/0)", von, bis)
+	}
+}
+
+// Ein Ort, an dem alle Aufgaben ruhen, ruht mit. Steht daneben etwas
+// Ganzjähriges, entscheidet das.
+func TestPlaceStatus(t *testing.T) {
+	ruht := TaskWithStatus{CareTask: CareTask{Active: true}, Status: StatusDormant}
+	gruen := TaskWithStatus{CareTask: CareTask{Active: true}, Status: StatusGreen}
+	rot := TaskWithStatus{CareTask: CareTask{Active: true}, Status: StatusRed}
+	pausiert := TaskWithStatus{CareTask: CareTask{Active: false}, Status: StatusRed}
+
+	if got := PlaceStatus([]TaskWithStatus{ruht, ruht}); got != StatusDormant {
+		t.Errorf("nur ruhende Aufgaben = %s, erwartet %s", got, StatusDormant)
+	}
+	if got := PlaceStatus([]TaskWithStatus{ruht, gruen}); got != StatusGreen {
+		t.Errorf("ruhend + grün = %s, erwartet %s", got, StatusGreen)
+	}
+	if got := PlaceStatus([]TaskWithStatus{ruht, rot}); got != StatusRed {
+		t.Errorf("ruhend + rot = %s, erwartet %s", got, StatusRed)
+	}
+	if got := PlaceStatus([]TaskWithStatus{pausiert}); got != StatusGreen {
+		t.Errorf("nur pausierte Aufgaben = %s, erwartet %s", got, StatusGreen)
+	}
+	if got := PlaceStatus(nil); got != StatusGreen {
+		t.Errorf("ohne Aufgaben = %s, erwartet %s", got, StatusGreen)
+	}
+}

--- a/backend/internal/vergabe/season_test.go
+++ b/backend/internal/vergabe/season_test.go
@@ -1,0 +1,56 @@
+package vergabe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Eine Aufgabe außerhalb ihrer Jahreszeit ruht (#78). Ruhen heißt: Niemand
+// wird gefragt und niemand bekommt eine Erinnerung — die Vergabe darf sie
+// nicht für überfällig halten, nur weil sie „nicht grün" ist.
+
+func TestRuhendeAufgabeWirdNichtVergeben(t *testing.T) {
+	start := berlin(t, 2026, time.November, 16, 9, 0)
+	d, e, _, s, task := aufbau(t, start)
+
+	// Jäten von April bis September — im November ist daran nichts zu tun.
+	task.Kind = model.TaskWeeding
+	task.SeasonStartMonth, task.SeasonEndMonth = 4, 9
+	if err := d.UpdateTask(&task); err != nil {
+		t.Fatal(err)
+	}
+	anmelden(t, d, task, "anna", start.AddDate(0, 0, -10))
+
+	durchlauf(t, e)
+
+	if v := vorgang(t, d, task.ID); v != nil {
+		t.Fatalf("Vorgang eröffnet, obwohl die Aufgabe ruht: %+v", v)
+	}
+	if empf := s.empfaenger(model.NotifyRequest); len(empf) != 0 {
+		t.Fatalf("Anfragen verschickt: %v", empf)
+	}
+}
+
+// Innerhalb ihrer Jahreszeit läuft die Vergabe wie immer.
+func TestAufgabeInDerJahreszeitWirdVergeben(t *testing.T) {
+	start := berlin(t, 2026, time.June, 16, 9, 0)
+	d, e, _, s, task := aufbau(t, start)
+
+	task.Kind = model.TaskWeeding
+	task.SeasonStartMonth, task.SeasonEndMonth = 4, 9
+	if err := d.UpdateTask(&task); err != nil {
+		t.Fatal(err)
+	}
+	anmelden(t, d, task, "anna", start.AddDate(0, 0, -10))
+
+	durchlauf(t, e)
+
+	if v := vorgang(t, d, task.ID); v == nil {
+		t.Fatal("kein Vorgang eröffnet, obwohl die Aufgabe fällig ist")
+	}
+	if empf := s.empfaenger(model.NotifyRequest); len(empf) != 1 || empf[0] != "anna" {
+		t.Fatalf("Anfragen = %v, erwartet [anna]", empf)
+	}
+}

--- a/backend/internal/vergabe/vergabe.go
+++ b/backend/internal/vergabe/vergabe.go
@@ -983,8 +983,11 @@ func (e *Engine) istFaellig(task model.CareTask, place *model.Place, now time.Ti
 		}
 		faktor = f
 	}
+	// NeedsWork statt „nicht grün": Eine Aufgabe außerhalb ihrer Jahreszeit
+	// ruht (StatusDormant) — sie ist nicht grün, aber es ist auch nichts zu
+	// tun, und dafür wird niemand gefragt (#78).
 	status, _, _ := model.ComputeStatus(task, letzte, now, faktor)
-	return status != model.StatusGreen, letzte, nil
+	return status.NeedsWork(), letzte, nil
 }
 
 func zeiger(t time.Time) *time.Time { return &t }


### PR DESCRIPTION
Das Beet vor dem Dorfgemeinschaftshaus soll alle acht Wochen **von April bis
September** gejätet werden. Das ließ sich nicht sagen: Eine Aufgabe kannte
nur ihr Intervall, zählte durch den Winter und wäre am 16.11. rot geworden —
ein roter Punkt auf der Dorfkarte für Arbeit, die es dort gerade nicht gibt.

Jetzt kann eine wiederkehrende Aufgabe sagen, in welchem Teil des Jahres sie
anfällt. Außerhalb davon ist sie **außer Dienst**.

## Entscheidungen

**Die Jahreszeit hängt an der Aufgabe, nicht am Ort.** Am selben Beet ist
Jäten saisonal und „Müll aufsammeln" ganzjährig. Am Ort wäre sie ein
zusätzlicher Ort-Aufgabe-Konflikt, ohne dass jemand etwas gewönne.

**Ganze Monate, keine Datumsangaben.** `seasonStartMonth`/`seasonEndMonth`,
beide einschließlich: 4 und 9 heißt vom 1. April 00:00 bis zum 30. September
23:59, gezogen in Ortszeit des Dorfes (`model.Location()`). Niemand sagt „ab
dem 12. April", und Monatsgrenzen kennen weder Schaltjahr- noch
Wochentagsprobleme. `0/0` heißt ganzjährig; „Januar bis Dezember" wird darauf
normalisiert, damit es für dieselbe Sache nicht zwei Schreibweisen gibt.

**Über den Jahreswechsel:** Steht der Anfang nach dem Ende, geht der Zeitraum
über den Jahreswechsel — `11/2` ist November bis einschließlich Februar. Das
kostet keine zusätzliche Angabe und ist die einzige sinnvolle Lesart von
„November bis Februar".

**Beim Übergang wird nichts zurückgesetzt.** Der Zähler läuft über den Winter
weiter, nur die Ampel schweigt. Damit ist eine Aufgabe, die am 30. September
rot war, am 1. Oktober nicht plötzlich grün — sie ruht —, und am 1. April ist
sie sofort wieder fällig, ohne dass jemand etwas angefasst hat. Es braucht
dafür keinen gespeicherten Zwischenstand und keinen Hintergrundlauf.
Angezeigt werden `dueAt`/`redAt` frühestens ab dem Beginn des Fensters: Vor
dem 1. April kann nichts fällig gewesen sein, und bei einer ruhenden Aufgabe
zeigen beide auf den Beginn der nächsten Jahreszeit — den Tag, ab dem wieder
etwas zu tun ist.

**Ein vierter Ampel-Wert statt eines zweiten Feldes:** `dormant`. „Außer
Dienst" ist ein Zustand der Ampel, kein Merkmal daneben; ein Boolean neben
`status` hätte jeden Ausgabeweg gezwungen, zwei Dinge zusammenzudenken.
Gerechnet wird er weiterhin ausschließlich in `model.ComputeStatus` — REST,
Web-Verwaltung, Karte, Vergabe, Chat und MCP fragen ihn.
`Status.NeedsWork()` kommt dazu, weil „ist sie nicht grün" jetzt die falsche
Frage ist: Die Vergabe hätte eine ruhende Aufgabe sonst für überfällig
gehalten und Leute gefragt.

**Ein Ort, dessen sämtliche aktiven Aufgaben ruhen, ruht mit**
(`model.PlaceStatus`). Steht eine ganzjährige daneben, entscheidet die. Ein
Ort ganz ohne aktive Aufgabe bleibt grün, wie bisher.

**Einmalige Aufgaben haben keine Jahreszeit.** Sie haben einen Termin; ein
Zeitraum daneben wären zwei Wahrheiten. Beides zusammen wird im Klartext
abgewiesen, und beim Umstellen auf „einmalig" fällt eine gespeicherte
Jahreszeit weg — genau wie das Intervall.

**Der Hitzefaktor staucht Schwellen, er verlängert keine Jahreszeit.**
Außerhalb des Fensters gewinnt die Jahreszeit, auch bei Faktor 0,1.

## Was mit dem Bestand passiert

Nichts. Die zwei Spalten kommen additiv über `ALTER TABLE … DEFAULT 0` dazu;
jede vorhandene Aufgabe steht damit auf ganzjährig und rechnet weiter wie
bisher. Der Migrationstest gegen das alte Schema prüft das mit.

Ältere App-Fassungen können weiterlaufen: `seasonStartMonth`/`seasonEndMonth`
sind in der Eingabe Zeiger — fehlen sie, bleibt die gespeicherte Jahreszeit
stehen. Eine geänderte Gießmenge nimmt einer Aufgabe also nicht nebenbei
ihren Zeitraum weg (dieselbe Vorsichtsmaßnahme wie bei `sichtbarkeit`).

## Wo es sich einstellen lässt

Überall, wo sich eine Aufgabe pflegen lässt — MCP ist der Verwaltungsweg
(#62):

- **MCP**: `aufgabe_anlegen` und `aufgabe_aendern` mit `seasonStartMonth` /
  `seasonEndMonth`; 0 nimmt die Jahreszeit weg.
- **Web-Verwaltung**: zwei Auswahlfelder „Von Monat" / „Bis Monat" im
  Aufgabenformular, Vorgabe „ganzjährig", ohne JavaScript bedienbar. Die
  Ortsseite zeigt die Jahreszeit im Klartext („April bis September") und den
  Zustand als graues Abzeichen „außer Dienst"; die Admin-Karte malt ruhende
  Orte grau (`#9e9e9e`).
- **REST**: `POST/PUT` auf Aufgaben.
- **Chat** (In-App-Assistent): `saisonVon` / `saisonBis`.

Kein neues CSS: Es werden nur Klassen verwendet, die schon im gebauten
`static/app.css` stehen — `npm run build:css` erzeugt unverändert dieselbe
Datei.

## Was in den Apps noch fehlt

**#85**: Android und iOS kennen `dormant` noch nicht. Beide fallen bei einem
unbekannten Status auf Grün zurück — es stürzt nichts ab, aber das Beet
meldet im Winter „Alles gut" statt „außer Dienst". Sie brauchen den Wert in
ihrer Statusaufzählung, einen grauen Farbton und einen Text dafür. Die Regel
bleibt dabei im Server: Ob eine Aufgabe ruht, entscheidet er und sagt es.

## Geprüft

`gofmt`, `go vet`, `go test ./...` (alles grün), `npm run build:css` ohne
Drift, `.github/scripts/pruefe_lokale_tests.py` sauber. Neue Proben in
`model` (Fenstergrenzen einschließlich, Jahreswechsel, Dezember als
Endmonat, Übergang am 30.09./01.10., Fälligkeit am 01.04., Hitzefaktor,
`PlaceStatus`), `db` (Speicherweg und Vorbelegung), `api` (REST, Prüfungen,
alte Clients), `mcp`, `admin` (Formular) und `vergabe` (eine ruhende Aufgabe
wird nicht vergeben).

Fixes #78
