### PR TITLE
Android holt im Maschinchenring auf: dieselben 19 Routen wie iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,16 @@ keine der beiden Apps noch einmal.
   belegte Zeiträume und Verfügbarkeit sind drüben öffentlich, so wie auf ihrer
   Webseite) — der Bereich ist deshalb auch vom Anmeldeschirm aus erreichbar.
   Mit der Rössing-ID kommen die eigenen Buchungen dazu: anfragen, ansehen,
-  stornieren. **Die App enthält keine Regeln des Verleihs**: Ob ein Zeitraum
+  stornieren. Dahinter liegen zwei weitere Seiten: **„Mein Profil im
+  Maschinchenring"** (Telefon und Adresse für die Übergabe, dazu „ich möchte
+  auch verleihen") und, wenn die Plattform `lenderStatus: "approved"` meldet,
+  **„Meine Vermietung"** — Anfragen auf den eigenen Geräten mit Name und
+  Nummer für die Übergabe, zusagen und absagen, die eigenen Geräte samt der
+  abgeschalteten, Zeiträume sperren und Sperren aufheben. **Sets** stehen zum
+  Ansehen daneben; gebucht werden sie drüben, weil der Server eine
+  Set-Buchung noch nicht bestätigen oder stornieren kann. Beide Fassungen
+  können das Gleiche — alle 19 Routen des Vertrags.
+  **Die App enthält keine Regeln des Verleihs**: Ob ein Zeitraum
   frei ist, sagt `GET /api/v1/availability`; ob storniert werden darf, sagt
   `canCancel`. Die Tarife stehen einzeln da und werden **nicht** zu einer
   Summe verrechnet — welcher bei welcher Dauer gilt, legt die Mietplattform

--- a/android/app/src/androidTest/java/de/roessing/app/RentalUiTest.kt
+++ b/android/app/src/androidTest/java/de/roessing/app/RentalUiTest.kt
@@ -17,28 +17,35 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import de.roessing.app.auth.RentalSignIn
+import de.roessing.app.data.BlockRequest
 import de.roessing.app.data.BookingRequest
 import de.roessing.app.data.BookingStatus
 import de.roessing.app.data.CompletionDto
 import de.roessing.app.data.LeaderboardDto
+import de.roessing.app.data.LenderRequest
 import de.roessing.app.data.LenderStatus
 import de.roessing.app.data.MeDto
 import de.roessing.app.data.MemberDto
 import de.roessing.app.data.OccupancyStatus
+import de.roessing.app.data.ProfilePatch
 import de.roessing.app.data.PlacesRepository
 import de.roessing.app.data.PlacesResponse
 import de.roessing.app.data.ProfileDto
 import de.roessing.app.data.ProfileInput
 import de.roessing.app.data.ProfileRepository
 import de.roessing.app.data.RentalAvailability
+import de.roessing.app.data.RentalBlock
 import de.roessing.app.data.RentalBooking
 import de.roessing.app.data.RentalDevice
 import de.roessing.app.data.RentalDeviceDetail
 import de.roessing.app.data.RentalOccupancy
+import de.roessing.app.data.RentalOwnerBooking
+import de.roessing.app.data.RentalOwnerDevice
 import de.roessing.app.data.RentalPeriod
 import de.roessing.app.data.RentalPickup
 import de.roessing.app.data.RentalProfile
 import de.roessing.app.data.RentalRepository
+import de.roessing.app.data.RentalSet
 import de.roessing.app.data.StatsRepository
 import de.roessing.app.ui.HomeScreen
 import de.roessing.app.ui.IdeenViewModel
@@ -91,8 +98,18 @@ class RentalUiTest {
         private val bookings: List<RentalBooking> = emptyList(),
         private val available: Boolean = true,
         private val fehler: Boolean = false,
+        private val sets: List<RentalSet> = emptyList(),
+        /** Der Stand, den die Plattform zum Verleihen meldet. */
+        private val lenderStatus: LenderStatus = LenderStatus.NONE,
+        private val ownerBookings: List<RentalOwnerBooking> = emptyList(),
+        private val ownerDevices: List<RentalOwnerDevice> = emptyList(),
+        private val blocks: List<RentalBlock> = emptyList(),
     ) : RentalRepository {
         var letzteAnfrage: BookingRequest? = null
+        var letzteAenderung: ProfilePatch? = null
+        var letzteSperre: BlockRequest? = null
+        val zugesagt = mutableListOf<String>()
+        val abgesagt = mutableListOf<String>()
 
         override suspend fun devices(): List<RentalDevice> {
             if (fehler) throw IOException("kein Netz")
@@ -131,8 +148,8 @@ class RentalUiTest {
             addressStreet = "Kirchstraße 3",
             addressZip = "31171",
             addressCity = "Nordstemmen",
-            lender = false,
-            lenderStatus = LenderStatus.NONE,
+            lender = lenderStatus == LenderStatus.APPROVED,
+            lenderStatus = lenderStatus,
             profileComplete = true,
             missingFields = emptyList(),
         )
@@ -145,6 +162,43 @@ class RentalUiTest {
         }
 
         override suspend fun cancel(bookingId: String) = Unit
+
+        override suspend fun sets() = sets
+
+        override suspend fun updateProfile(patch: ProfilePatch): RentalProfile {
+            letzteAenderung = patch
+            return profile()
+        }
+
+        override suspend fun requestLender() =
+            LenderRequest(LenderStatus.PENDING, "Deine Anfrage wurde weitergeleitet.")
+
+        override suspend fun ownerBookings() = ownerBookings
+
+        override suspend fun approve(bookingId: String) {
+            zugesagt += bookingId
+        }
+
+        override suspend fun reject(bookingId: String) {
+            abgesagt += bookingId
+        }
+
+        override suspend fun ownerDevices() = ownerDevices
+
+        override suspend fun blocks() = blocks
+
+        override suspend fun addBlock(request: BlockRequest): RentalBlock {
+            letzteSperre = request
+            return RentalBlock(
+                id = "sperre-neu",
+                deviceId = request.deviceId,
+                deviceName = "AS 585 KM Kreiselmäher",
+                period = request.period,
+                reason = request.reason,
+            )
+        }
+
+        override suspend fun removeBlock(blockId: String) = Unit
     }
 
     private val maeher = RentalDevice(
@@ -173,6 +227,37 @@ class RentalUiTest {
         thumbnailUrl = null,
         productUrl = null,
         webUrl = null,
+    )
+
+    private val gartenset = RentalSet(
+        id = "gartenset",
+        name = "Gartenset",
+        description = "Vertikutierer, Rasenwalze und Streuwagen zusammen.",
+        pricePerDay = 30.0,
+        deposit = 150.0,
+        itemIds = listOf("rasenwalze", "vertikutierer"),
+    )
+
+    private val anfrage = RentalOwnerBooking(
+        id = "a-1",
+        deviceId = "as-585-km-kreiselmaeher",
+        deviceName = "AS 585 KM Kreiselmäher",
+        period = RentalPeriod(LocalDate.parse("2026-09-05"), LocalDate.parse("2026-09-07")),
+        status = BookingStatus.PENDING,
+        rawStatus = "pending",
+        renterName = "Erika Musterfrau",
+        renterPhone = "+49 5069 123456",
+        notes = null,
+        canDecide = true,
+        canCancel = true,
+    )
+
+    private val sperre = RentalBlock(
+        id = "s-1",
+        deviceId = "as-585-km-kreiselmaeher",
+        deviceName = "AS 585 KM Kreiselmäher",
+        period = RentalPeriod(LocalDate.parse("2026-10-01"), LocalDate.parse("2026-10-08")),
+        reason = "Eigener Einsatz",
     )
 
     private val buchung = RentalBooking(
@@ -243,6 +328,22 @@ class RentalUiTest {
         compose.onNodeWithTag("rental-list").performScrollToNode(hasTestTag("device-$id"))
         compose.onNodeWithTag("device-$id").performClick()
         compose.waitForIdle()
+    }
+
+    /** Öffnet „Mein Profil im Maschinchenring" aus dem Katalog heraus. */
+    private fun zumProfil() {
+        compose.onNodeWithTag("rental-list")
+            .performScrollToNode(hasTestTag("rental-profile-entry"))
+        compose.onNodeWithTag("rental-profile-entry").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithTag("rental-profile").assertIsDisplayed()
+    }
+
+    /** Und von dort weiter auf die Vermieterseite. */
+    private fun zurVermietung() {
+        compose.onNodeWithTag("rental-owner-entry").performScrollTo().performClick()
+        compose.waitForIdle()
+        compose.onNodeWithTag("rental-owner").assertIsDisplayed()
     }
 
     @Test
@@ -384,5 +485,125 @@ class RentalUiTest {
 
         compose.onNodeWithTag("rental-pick-period").performScrollTo().assertIsEnabled()
         compose.onNodeWithTag("rental-book").performScrollTo().assertIsNotEnabled()
+    }
+
+    /** Sets stehen unter den Geräten — angesehen, nicht gebucht. */
+    @Test
+    fun setsStehenUnterDenGeraeten() {
+        zeigeApp(FakeRental(devices = listOf(maeher), sets = listOf(gartenset)))
+        zumVerleih()
+
+        compose.onNodeWithTag("rental-list").performScrollToNode(hasTestTag("set-gartenset"))
+        compose.onNodeWithTag("set-gartenset").assertIsDisplayed()
+        compose.onNodeWithText("30 € pro Tag").assertIsDisplayed()
+    }
+
+    /** Der Weg zum eigenen Profil drüben — und wieder zurück. */
+    @Test
+    fun vomKatalogInsProfilUndZurueck() {
+        zeigeApp(FakeRental(devices = listOf(maeher)))
+        zumVerleih()
+
+        zumProfil()
+        compose.onNodeWithTag("rental-profile-phone").assertIsDisplayed()
+
+        compose.onNodeWithTag("rental-to-catalog").performClick()
+        compose.waitForIdle()
+        geraetIstDa(maeher.id)
+    }
+
+    /**
+     * Was im Formular steht, geht als Änderung hinaus — und ein leeres Feld
+     * bleibt weg, statt einen Wert drüben zu löschen.
+     */
+    @Test
+    fun dasProfilSpeichertWasImFormularSteht() {
+        val repo = FakeRental(devices = listOf(maeher))
+        zeigeApp(repo)
+        zumVerleih()
+        zumProfil()
+
+        compose.onNodeWithTag("rental-profile-save").performScrollTo().performClick()
+        compose.waitForIdle()
+
+        assertEquals("+49 5069 123456", repo.letzteAenderung?.phone)
+        assertEquals("Kirchstraße 3", repo.letzteAenderung?.addressStreet)
+    }
+
+    /**
+     * Die Vermieteransicht hängt an einer Auskunft des Servers. Ohne
+     * Freischaltung gibt es sie nicht — dafür den Weg, danach zu fragen.
+     */
+    @Test
+    fun ohneFreischaltungGibtEsKeineVermieteransicht() {
+        zeigeApp(FakeRental(devices = listOf(maeher)))
+        zumVerleih()
+        zumProfil()
+
+        compose.onNodeWithTag("rental-ask-to-lend").performScrollTo().assertIsEnabled()
+        compose.onNodeWithTag("rental-owner-entry").assertDoesNotExist()
+    }
+
+    @Test
+    fun mitFreischaltungFuehrtEinWegZurVermieteransicht() {
+        zeigeApp(
+            FakeRental(
+                devices = listOf(maeher),
+                lenderStatus = LenderStatus.APPROVED,
+                ownerBookings = listOf(anfrage),
+                ownerDevices = listOf(RentalOwnerDevice(maeher, active = false)),
+                blocks = listOf(sperre),
+            ),
+        )
+        zumVerleih()
+        zumProfil()
+
+        compose.onNodeWithTag("rental-owner-entry").performScrollTo().performClick()
+        compose.waitForIdle()
+
+        compose.onNodeWithTag("rental-owner").assertIsDisplayed()
+        // Name und Nummer stehen hier, weil die Übergabe verabredet werden
+        // muss — und nirgends sonst in der App.
+        compose.onNodeWithText("Mieter: Erika Musterfrau").assertIsDisplayed()
+        // Ein abgeschaltetes Gerät steht nur auf der eigenen Seite.
+        compose.onNodeWithTag("rental-owner")
+            .performScrollToNode(hasTestTag("owner-device-${maeher.id}"))
+        compose.onNodeWithText("Abgeschaltet — für andere unsichtbar.").assertIsDisplayed()
+    }
+
+    /** Die Knöpfe richten sich nach `canDecide` — die App prüft nichts nach. */
+    @Test
+    fun eineAnfrageLaesstSichZusagen() {
+        val repo = FakeRental(
+            devices = listOf(maeher),
+            lenderStatus = LenderStatus.APPROVED,
+            ownerBookings = listOf(anfrage),
+        )
+        zeigeApp(repo)
+        zumVerleih()
+        zumProfil()
+        zurVermietung()
+
+        compose.onNodeWithTag("rental-approve-a-1").performScrollTo().performClick()
+        compose.waitForIdle()
+
+        assertEquals(listOf("a-1"), repo.zugesagt)
+    }
+
+    @Test
+    fun eineSperreLaesstSichAufheben() {
+        zeigeApp(
+            FakeRental(
+                devices = listOf(maeher),
+                lenderStatus = LenderStatus.APPROVED,
+                blocks = listOf(sperre),
+            ),
+        )
+        zumVerleih()
+        zumProfil()
+        zurVermietung()
+
+        compose.onNodeWithTag("rental-owner").performScrollToNode(hasTestTag("block-s-1"))
+        compose.onNodeWithTag("rental-unblock-s-1").assertIsDisplayed()
     }
 }

--- a/android/app/src/main/java/de/roessing/app/data/Rental.kt
+++ b/android/app/src/main/java/de/roessing/app/data/Rental.kt
@@ -203,6 +203,107 @@ data class RentalProfile(
 )
 
 /**
+ * A set: several devices at one daily price (route 4).
+ *
+ * Unlike a device's description this one is **plain text**, not Markdown. A
+ * set has no picture of its own — it is shown with the names of its devices.
+ *
+ * Sets can be booked over there, but cancelling, confirming and turning one
+ * down is not implemented on the server yet. So the app shows them and does
+ * not offer a booking; that is the contract's own advice, not caution of ours.
+ */
+data class RentalSet(
+    val id: String,
+    val name: String,
+    val description: String?,
+    val pricePerDay: Double?,
+    val deposit: Double?,
+    /** The devices of the set, by their id in route 1. */
+    val itemIds: List<String>,
+)
+
+/**
+ * One of my own devices (route 16) — with the one field route 1 does not
+ * have: whether it is switched on at all.
+ *
+ * Creating and changing devices is **not** part of the contract, here or
+ * anywhere. That happens in the chat and the web version of the platform.
+ */
+data class RentalOwnerDevice(val device: RentalDevice, val active: Boolean)
+
+/**
+ * A request on one of my devices (route 13).
+ *
+ * [renterName] and [renterPhone] are here because the handover has to be
+ * arranged. They belong in no other view and in no cache that outlives this
+ * one — the same rule as for [RentalPickup], seen from the other side.
+ */
+data class RentalOwnerBooking(
+    val id: String,
+    val deviceId: String?,
+    val deviceName: String,
+    val period: RentalPeriod,
+    val status: BookingStatus,
+    /** What the server literally wrote, for a state we do not know. */
+    val rawStatus: String,
+    val renterName: String?,
+    val renterPhone: String?,
+    val notes: String?,
+    /** Whether confirming or turning down has a prospect. The server decides. */
+    val canDecide: Boolean,
+    val canCancel: Boolean,
+)
+
+/**
+ * A stretch the lender keeps for themselves (route 17).
+ *
+ * For everybody else it looks like any other taken period — without a reason
+ * and without a name.
+ */
+data class RentalBlock(
+    val id: String,
+    val deviceId: String?,
+    val deviceName: String,
+    val period: RentalPeriod,
+    val reason: String?,
+)
+
+/**
+ * What is to change in the own profile (route 8).
+ *
+ * Only fields that carry something go out: the platform changes exactly what
+ * it is given, and an empty value in a sent field is a `bad_request`, not a
+ * way to clear it. The e-mail address is missing on purpose — it comes from
+ * the Rössing-ID and is the link to the account over there.
+ */
+data class ProfilePatch(
+    val name: String? = null,
+    val phone: String? = null,
+    val addressStreet: String? = null,
+    val addressZip: String? = null,
+    val addressCity: String? = null,
+) {
+    /** Nothing to send is nothing to do. */
+    val empty: Boolean
+        get() = listOfNotNull(name, phone, addressStreet, addressZip, addressCity).isEmpty()
+}
+
+/**
+ * The receipt for „ich möchte auch verleihen" (route 9).
+ *
+ * It is a receipt, not a permission: somebody decides that by hand, in the
+ * web version. [message] is German and written over there.
+ */
+data class LenderRequest(val lenderStatus: LenderStatus, val message: String?)
+
+/** A new block on one of my devices (route 18). Sets cannot be blocked. */
+data class BlockRequest(
+    val deviceId: String,
+    val period: RentalPeriod,
+    val reason: String? = null,
+)
+
+/**
  * A booking request.
  *
  * The three personal fields are the exception, not the rule: normally the
@@ -272,9 +373,13 @@ class RentalApiException(
  * well, which is what lets the area work before anybody signs in. Only the
  * personal calls carry a token.
  *
- * The lender's side of the contract (routes 13 to 19) is deliberately absent:
- * creating and maintaining devices happens in the chat and the web version of
- * the rental platform, and it is meant to stay there.
+ * All nineteen routes of the contract are here, and the same nineteen are in
+ * the iOS app: the two are one product in two versions, and whoever holds the
+ * other telephone must not see something else.
+ *
+ * One thing is deliberately **not** here, on either side: creating and
+ * changing devices. That happens in the chat and the web version of the
+ * rental platform, and the contract has no route for it.
  */
 interface RentalRepository {
     /** All active devices, sorted by name. No sign-in. */
@@ -303,6 +408,43 @@ interface RentalRepository {
 
     /** Withdraw one of my bookings. Signed in. */
     suspend fun cancel(bookingId: String)
+
+    /** The sets. Shown, not booked — see [RentalSet]. No sign-in. */
+    suspend fun sets(): List<RentalSet>
+
+    /** Change telephone and address over there. Signed in. */
+    suspend fun updateProfile(patch: ProfilePatch): RentalProfile
+
+    /** Ask to become a lender. A receipt, not a permission. Signed in. */
+    suspend fun requestLender(): LenderRequest
+
+    // --- The lender's side. The platform decides who sees it ---------------
+    //
+    // Every one of these is shown only after route 7 answered
+    // `lenderStatus: "approved"`. That is an answer of the server, not a check
+    // of the app's own — and the calls themselves are refused over there with
+    // `not_a_lender` if somebody gets here anyway.
+
+    /** Requests on my devices, with name and number for the handover. */
+    suspend fun ownerBookings(): List<RentalOwnerBooking>
+
+    /** Confirm a request. From then on the renter sees the pickup address. */
+    suspend fun approve(bookingId: String)
+
+    /** Turn a request down. No reason is recorded. */
+    suspend fun reject(bookingId: String)
+
+    /** My own devices, including the switched-off ones. */
+    suspend fun ownerDevices(): List<RentalOwnerDevice>
+
+    /** The stretches I keep for myself. */
+    suspend fun blocks(): List<RentalBlock>
+
+    /** Keep a stretch. An existing booking is never pushed aside. */
+    suspend fun addBlock(request: BlockRequest): RentalBlock
+
+    /** Lift one of my blocks. */
+    suspend fun removeBlock(blockId: String)
 }
 
 /**
@@ -332,6 +474,32 @@ object NoRental : RentalRepository {
         throw RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
 
     override suspend fun cancel(bookingId: String) =
+        throw RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
+
+    override suspend fun sets(): List<RentalSet> = emptyList()
+
+    override suspend fun updateProfile(patch: ProfilePatch): RentalProfile =
+        throw RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
+
+    override suspend fun requestLender(): LenderRequest =
+        throw RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
+
+    override suspend fun ownerBookings(): List<RentalOwnerBooking> = emptyList()
+
+    override suspend fun approve(bookingId: String) =
+        throw RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
+
+    override suspend fun reject(bookingId: String) =
+        throw RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
+
+    override suspend fun ownerDevices(): List<RentalOwnerDevice> = emptyList()
+
+    override suspend fun blocks(): List<RentalBlock> = emptyList()
+
+    override suspend fun addBlock(request: BlockRequest): RentalBlock =
+        throw RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
+
+    override suspend fun removeBlock(blockId: String) =
         throw RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
 }
 

--- a/android/app/src/main/java/de/roessing/app/data/RentalApi.kt
+++ b/android/app/src/main/java/de/roessing/app/data/RentalApi.kt
@@ -12,8 +12,10 @@ import retrofit2.HttpException
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Headers
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -72,6 +74,12 @@ data class ItemDto(
     val score: Double? = null,
     /** Only in the detail route. */
     val images: List<ImageDto> = emptyList(),
+    /**
+     * Only in the lender's route 16: `false` means the device is switched off
+     * and invisible to everybody else. The public routes never send it, and
+     * what they do not send is on.
+     */
+    val active: Boolean = true,
 )
 
 @Serializable
@@ -166,6 +174,99 @@ data class BookingInputDto(
     val notes: String? = null,
 )
 
+/** Route 4. `description` is plain text here, not Markdown. */
+@Serializable
+data class SetDto(
+    val id: String = "",
+    val name: String = "",
+    val description: String? = null,
+    val pricePerDay: Double? = null,
+    val deposit: Double? = null,
+    val itemIds: List<String> = emptyList(),
+)
+
+@Serializable
+data class SetsDto(val sets: List<SetDto> = emptyList())
+
+/**
+ * The body of route 8. Null fields are left out, not sent as null — the
+ * platform changes exactly what it is given.
+ */
+@Serializable
+data class ProfilePatchDto(
+    val name: String? = null,
+    val phone: String? = null,
+    val addressStreet: String? = null,
+    val addressZip: String? = null,
+    val addressCity: String? = null,
+)
+
+/** Route 9. `message` is German and meant to be shown. */
+@Serializable
+data class LenderRequestDto(
+    val lenderStatus: String = "none",
+    val message: String = "",
+)
+
+/** Route 13. Carries the two fields no public route ever carries. */
+@Serializable
+data class OwnerBookingDto(
+    val id: String = "",
+    val deviceId: String? = null,
+    val deviceName: String = "",
+    val startDate: String = "",
+    val endDate: String = "",
+    val status: String = "",
+    val renterName: String? = null,
+    val renterPhone: String? = null,
+    val notes: String? = null,
+    val canDecide: Boolean = false,
+    val canCancel: Boolean = false,
+)
+
+@Serializable
+data class OwnerBookingsDto(val bookings: List<OwnerBookingDto> = emptyList())
+
+/**
+ * The answer of routes 12, 14 and 15: `{"status": "approved"}`.
+ *
+ * It is read rather than ignored for a plain reason — a call with no return
+ * type at all leaves the converter to guess what an empty answer is, and the
+ * platform does send a body.
+ */
+@Serializable
+data class StatusDto(val status: String = "")
+
+/** Route 19: `{"deleted": true}`. */
+@Serializable
+data class DeletedDto(val deleted: Boolean = false)
+
+/** Route 17 and 18. `reason` may be null. */
+@Serializable
+data class BlockDto(
+    val id: String = "",
+    val deviceId: String? = null,
+    val deviceName: String = "",
+    val startDate: String = "",
+    val endDate: String = "",
+    val reason: String? = null,
+)
+
+@Serializable
+data class BlocksDto(val blocks: List<BlockDto> = emptyList())
+
+@Serializable
+data class BlockEnvelopeDto(val block: BlockDto = BlockDto())
+
+/** The body of route 18. Sets cannot be blocked, only single devices. */
+@Serializable
+data class BlockInputDto(
+    val deviceId: String,
+    val startDate: String,
+    val endDate: String,
+    val reason: String? = null,
+)
+
 /** Every error of the platform has this shape. */
 @Serializable
 data class ApiErrorEnvelopeDto(val error: ApiErrorDataDto = ApiErrorDataDto())
@@ -216,7 +317,47 @@ interface MietenApi {
 
     @Headers("$AUTH_MARKER: required")
     @POST("api/v1/bookings/{id}/cancel")
-    suspend fun cancel(@Path("id") bookingId: String)
+    suspend fun cancel(@Path("id") bookingId: String): StatusDto
+
+    @GET("api/v1/sets")
+    suspend fun sets(): SetsDto
+
+    @Headers("$AUTH_MARKER: required")
+    @PATCH("api/v1/me")
+    suspend fun updateMe(@Body patch: ProfilePatchDto): ProfileEnvelopeDto
+
+    /** Route 9 takes no body; the receipt comes back. */
+    @Headers("$AUTH_MARKER: required")
+    @POST("api/v1/me/lender-request")
+    suspend fun requestLender(): LenderRequestDto
+
+    @Headers("$AUTH_MARKER: required")
+    @GET("api/v1/owner/bookings")
+    suspend fun ownerBookings(): OwnerBookingsDto
+
+    @Headers("$AUTH_MARKER: required")
+    @POST("api/v1/bookings/{id}/approve")
+    suspend fun approve(@Path("id") bookingId: String): StatusDto
+
+    @Headers("$AUTH_MARKER: required")
+    @POST("api/v1/bookings/{id}/reject")
+    suspend fun reject(@Path("id") bookingId: String): StatusDto
+
+    @Headers("$AUTH_MARKER: required")
+    @GET("api/v1/owner/items")
+    suspend fun ownerItems(): ItemsDto
+
+    @Headers("$AUTH_MARKER: required")
+    @GET("api/v1/owner/blocks")
+    suspend fun blocks(): BlocksDto
+
+    @Headers("$AUTH_MARKER: required")
+    @POST("api/v1/owner/blocks")
+    suspend fun addBlock(@Body input: BlockInputDto): BlockEnvelopeDto
+
+    @Headers("$AUTH_MARKER: required")
+    @DELETE("api/v1/owner/blocks/{id}")
+    suspend fun removeBlock(@Path("id") blockId: String): DeletedDto
 
     companion object {
         private val json = Json {
@@ -354,6 +495,72 @@ class MietenRentalRepository(
 
     override suspend fun cancel(bookingId: String) = personal {
         api.cancel(bookingId)
+        Unit
+    }
+
+    override suspend fun sets(): List<RentalSet> = translate {
+        api.sets().sets.mapNotNull { it.asSet() }
+    }
+
+    override suspend fun updateProfile(patch: ProfilePatch): RentalProfile = personal {
+        api.updateMe(
+            ProfilePatchDto(
+                // Only what carries something goes out: the platform changes
+                // exactly what it is given, and an empty value in a sent field
+                // is a refusal, not a way to clear it.
+                name = patch.name.orNullIfBlank(),
+                phone = patch.phone.orNullIfBlank(),
+                addressStreet = patch.addressStreet.orNullIfBlank(),
+                addressZip = patch.addressZip.orNullIfBlank(),
+                addressCity = patch.addressCity.orNullIfBlank(),
+            ),
+        ).profile.asProfile()
+    }
+
+    override suspend fun requestLender(): LenderRequest = personal {
+        val answer = api.requestLender()
+        LenderRequest(
+            lenderStatus = lenderStatusOf(answer.lenderStatus),
+            message = answer.message.orNullIfBlank(),
+        )
+    }
+
+    override suspend fun ownerBookings(): List<RentalOwnerBooking> = personal {
+        api.ownerBookings().bookings.mapNotNull { it.asOwnerBooking() }
+    }
+
+    override suspend fun approve(bookingId: String) = personal {
+        api.approve(bookingId)
+        Unit
+    }
+
+    override suspend fun reject(bookingId: String) = personal {
+        api.reject(bookingId)
+        Unit
+    }
+
+    override suspend fun ownerDevices(): List<RentalOwnerDevice> = personal {
+        api.ownerItems().items.map { RentalOwnerDevice(it.asDevice(), it.active) }
+    }
+
+    override suspend fun blocks(): List<RentalBlock> = personal {
+        api.blocks().blocks.mapNotNull { it.asBlock() }
+    }
+
+    override suspend fun addBlock(request: BlockRequest): RentalBlock = personal {
+        api.addBlock(
+            BlockInputDto(
+                deviceId = request.deviceId,
+                startDate = request.period.start.toString(),
+                endDate = request.period.end.toString(),
+                reason = request.reason.orNullIfBlank(),
+            ),
+        ).block.asBlock() ?: throw RentalApiException(RentalErrorCode.INTERNAL, null)
+    }
+
+    override suspend fun removeBlock(blockId: String) = personal {
+        api.removeBlock(blockId)
+        Unit
     }
 
     /**
@@ -495,13 +702,7 @@ internal fun MietenBookingDto.asBooking(): RentalBooking? {
         // Even a period the server wrote back to front must not turn into a
         // negative number of days on screen.
         period = RentalPeriod(from, if (to.isAfter(from)) to else from.plusDays(1)),
-        status = when (status) {
-            "pending" -> BookingStatus.PENDING
-            "approved" -> BookingStatus.APPROVED
-            "rejected" -> BookingStatus.REJECTED
-            "cancelled" -> BookingStatus.CANCELLED
-            else -> BookingStatus.UNKNOWN
-        },
+        status = bookingStatusOf(status),
         rawStatus = status,
         notes = notes.orNullIfBlank(),
         canCancel = canCancel,
@@ -513,6 +714,68 @@ internal fun MietenBookingDto.asBooking(): RentalBooking? {
     )
 }
 
+internal fun SetDto.asSet(): RentalSet? {
+    if (id.isBlank()) return null
+    return RentalSet(
+        id = id,
+        name = name,
+        // Plain text here, unlike a device's description — no conversion.
+        description = description.orNullIfBlank(),
+        pricePerDay = pricePerDay,
+        deposit = deposit,
+        itemIds = itemIds.filter { it.isNotBlank() },
+    )
+}
+
+internal fun OwnerBookingDto.asOwnerBooking(): RentalOwnerBooking? {
+    val from = date(startDate) ?: return null
+    val to = date(endDate) ?: return null
+    return RentalOwnerBooking(
+        id = id,
+        deviceId = deviceId.orNullIfBlank(),
+        deviceName = deviceName,
+        period = RentalPeriod(from, if (to.isAfter(from)) to else from.plusDays(1)),
+        status = bookingStatusOf(status),
+        rawStatus = status,
+        // The renter's name and number are here for the handover and are kept
+        // nowhere else — see `docs/mieten-api.md`, route 13.
+        renterName = renterName.orNullIfBlank(),
+        renterPhone = renterPhone.orNullIfBlank(),
+        notes = notes.orNullIfBlank(),
+        canDecide = canDecide,
+        canCancel = canCancel,
+    )
+}
+
+internal fun BlockDto.asBlock(): RentalBlock? {
+    val from = date(startDate) ?: return null
+    val to = date(endDate) ?: return null
+    if (!to.isAfter(from)) return null
+    return RentalBlock(
+        id = id,
+        deviceId = deviceId.orNullIfBlank(),
+        deviceName = deviceName,
+        period = RentalPeriod(from, to),
+        reason = reason.orNullIfBlank(),
+    )
+}
+
+/** The four states of the contract, and one bucket for a fifth. */
+internal fun bookingStatusOf(status: String): BookingStatus = when (status) {
+    "pending" -> BookingStatus.PENDING
+    "approved" -> BookingStatus.APPROVED
+    "rejected" -> BookingStatus.REJECTED
+    "cancelled" -> BookingStatus.CANCELLED
+    else -> BookingStatus.UNKNOWN
+}
+
+internal fun lenderStatusOf(status: String): LenderStatus = when (status) {
+    "none" -> LenderStatus.NONE
+    "pending" -> LenderStatus.PENDING
+    "approved" -> LenderStatus.APPROVED
+    else -> LenderStatus.UNKNOWN
+}
+
 internal fun ProfileDataDto.asProfile() = RentalProfile(
     name = name.orNullIfBlank(),
     email = email.orNullIfBlank(),
@@ -521,12 +784,7 @@ internal fun ProfileDataDto.asProfile() = RentalProfile(
     addressZip = addressZip.orNullIfBlank(),
     addressCity = addressCity.orNullIfBlank(),
     lender = lender,
-    lenderStatus = when (lenderStatus) {
-        "none" -> LenderStatus.NONE
-        "pending" -> LenderStatus.PENDING
-        "approved" -> LenderStatus.APPROVED
-        else -> LenderStatus.UNKNOWN
-    },
+    lenderStatus = lenderStatusOf(lenderStatus),
     profileComplete = profileComplete,
     missingFields = missingFields.filter { it.isNotBlank() },
 )

--- a/android/app/src/main/java/de/roessing/app/ui/HomeScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/HomeScreen.kt
@@ -306,15 +306,23 @@ fun HomeScreen(
     // Der Maschinchenring wird beim Öffnen geholt; die Anmeldung wird dabei
     // jedes Mal neu angesehen — sie kann sich zwischendurch geändert haben.
     LaunchedEffect(bereich) {
-        if (bereich == Bereich.VERLEIH) rentalViewModel.load()
+        // Wer den Bereich verlässt, kommt beim nächsten Mal wieder im Katalog
+        // an — die Unterseiten sind Wege dorthin, kein eigener Aufenthalt.
+        if (bereich == Bereich.VERLEIH) rentalViewModel.load() else rentalViewModel.showCatalog()
     }
     val gebuchtMsg = stringResource(R.string.rental_booked)
     val storniertMsg = stringResource(R.string.rental_cancelled)
+    val profilGespeichertMsg = stringResource(R.string.rental_profile_saved)
+    val zugesagtMsg = stringResource(R.string.rental_approved)
+    val abgesagtMsg = stringResource(R.string.rental_rejected)
     LaunchedEffect(Unit) {
         rentalViewModel.events.collect { event ->
             when (event) {
                 RentalEvent.Booked -> snackbar.showSnackbar(gebuchtMsg)
                 RentalEvent.Cancelled -> snackbar.showSnackbar(storniertMsg)
+                RentalEvent.ProfileSaved -> snackbar.showSnackbar(profilGespeichertMsg)
+                RentalEvent.Approved -> snackbar.showSnackbar(zugesagtMsg)
+                RentalEvent.Rejected -> snackbar.showSnackbar(abgesagtMsg)
             }
         }
     }
@@ -588,6 +596,23 @@ fun HomeScreen(
                     // eine neue Anmeldung.
                     onSignIn = null,
                     onSignInAgain = onReauthenticate,
+                    onShowCatalog = rentalViewModel::showCatalog,
+                    onShowProfile = rentalViewModel::showProfile,
+                    onShowOwner = rentalViewModel::showOwner,
+                    onSaveProfile = { name, telefon, strasse, plz, ort ->
+                        rentalViewModel.saveProfile(name, telefon, strasse, plz, ort)
+                    },
+                    onAskToLend = rentalViewModel::askToLend,
+                    onRefreshOwner = rentalViewModel::loadOwner,
+                    onApprove = rentalViewModel::approve,
+                    onReject = rentalViewModel::reject,
+                    onCancelOwnerBooking = rentalViewModel::cancelOwnerBooking,
+                    onOpenBlock = rentalViewModel::openBlock,
+                    onCloseBlock = rentalViewModel::closeBlock,
+                    onAddBlock = { zeitraum, grund ->
+                        rentalViewModel.addBlock(zeitraum, grund)
+                    },
+                    onRemoveBlock = rentalViewModel::removeBlock,
                 )
 
                 Bereich.IDEEN -> IdeenScreen(

--- a/android/app/src/main/java/de/roessing/app/ui/RentalScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/RentalScreen.kt
@@ -17,10 +17,14 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.EventBusy
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -29,6 +33,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.DateRangePicker
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -59,12 +64,17 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import de.roessing.app.R
 import de.roessing.app.data.BookingStatus
+import de.roessing.app.data.LenderStatus
 import de.roessing.app.data.OccupancyStatus
+import de.roessing.app.data.RentalBlock
 import de.roessing.app.data.RentalBooking
 import de.roessing.app.data.RentalDevice
 import de.roessing.app.data.RentalErrorCode
 import de.roessing.app.data.RentalOccupancy
+import de.roessing.app.data.RentalOwnerBooking
+import de.roessing.app.data.RentalOwnerDevice
 import de.roessing.app.data.RentalPeriod
+import de.roessing.app.data.RentalSet
 import de.roessing.app.data.euroText
 import de.roessing.app.data.markdownAsPlainText
 import java.time.Instant
@@ -74,17 +84,14 @@ import java.time.ZoneOffset
 /**
  * The area "Maschinchenring": what the village lends, and to whom.
  *
- * The order of the page follows what people come for. Searching sits at the
- * top, because whoever opens this area is usually after one particular thing.
- * Then whatever needs saying — no connection, sign in again, sign in at all.
- * Then my own bookings, because that is the second reason to look. Only then
- * the devices.
+ * One screen with two rooms behind it. The catalogue is what people come for;
+ * „Mein Profil im Maschinchenring" is reached from it, and „Meine Vermietung"
+ * from the profile — the latter only where the platform said `approved`.
  *
  * Not a single decision about renting is made here. "Free", "taken", "may be
- * cancelled" — every one of those comes from the rental platform; this file
- * puts it on screen.
+ * cancelled", "may be decided" — every one of those comes from the rental
+ * platform; this file puts it on screen.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RentalScreen(
     state: RentalUiState,
@@ -101,6 +108,96 @@ fun RentalScreen(
     onSignIn: (() -> Unit)? = null,
     /** Null when a fresh sign-in cannot be started from here. */
     onSignInAgain: (() -> Unit)? = null,
+    onShowCatalog: () -> Unit = {},
+    onShowProfile: () -> Unit = {},
+    onShowOwner: () -> Unit = {},
+    onSaveProfile: (
+        name: String,
+        phone: String,
+        addressStreet: String,
+        addressZip: String,
+        addressCity: String,
+    ) -> Unit = { _, _, _, _, _ -> },
+    onAskToLend: () -> Unit = {},
+    onRefreshOwner: () -> Unit = {},
+    onApprove: (String) -> Unit = {},
+    onReject: (String) -> Unit = {},
+    onCancelOwnerBooking: (String) -> Unit = {},
+    onOpenBlock: (String) -> Unit = {},
+    onCloseBlock: () -> Unit = {},
+    onAddBlock: (RentalPeriod, String) -> Unit = { _, _ -> },
+    onRemoveBlock: (String) -> Unit = {},
+) {
+    // Zurück führt zuerst in den Katalog und erst dann aus dem Bereich: Wer im
+    // Profil steht, will von dort zurück und nicht gleich auf die Startseite.
+    BackHandler(enabled = state.page != RentalPage.CATALOG, onBack = onShowCatalog)
+
+    when (state.page) {
+        RentalPage.CATALOG -> RentalCatalogPage(
+            state = state,
+            modifier = modifier,
+            onQuery = onQuery,
+            onRefresh = onRefresh,
+            onOpen = onOpen,
+            onClose = onClose,
+            onPeriod = onPeriod,
+            onBook = onBook,
+            onCancelBooking = onCancelBooking,
+            onSignIn = onSignIn,
+            onSignInAgain = onSignInAgain,
+            onShowProfile = onShowProfile,
+        )
+
+        RentalPage.PROFILE -> RentalProfilePage(
+            state = state,
+            modifier = modifier,
+            onBack = onShowCatalog,
+            onSave = onSaveProfile,
+            onAskToLend = onAskToLend,
+            onShowOwner = onShowOwner,
+        )
+
+        RentalPage.OWNER -> RentalOwnerPage(
+            state = state,
+            modifier = modifier,
+            onBack = onShowCatalog,
+            onRefresh = onRefreshOwner,
+            onApprove = onApprove,
+            onReject = onReject,
+            onCancelBooking = onCancelOwnerBooking,
+            onOpenBlock = onOpenBlock,
+            onCloseBlock = onCloseBlock,
+            onAddBlock = onAddBlock,
+            onRemoveBlock = onRemoveBlock,
+        )
+    }
+}
+
+/**
+ * The catalogue: what the village lends.
+ *
+ * The order of the page follows what people come for. Searching sits at the
+ * top, because whoever opens this area is usually after one particular thing.
+ * Then whatever needs saying — no connection, sign in again, sign in at all.
+ * Then my own bookings, because that is the second reason to look. Only then
+ * the devices, and the sets after them.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RentalCatalogPage(
+    state: RentalUiState,
+    modifier: Modifier = Modifier,
+    onQuery: (String) -> Unit = {},
+    onRefresh: () -> Unit = {},
+    onOpen: (RentalDevice) -> Unit = {},
+    onClose: () -> Unit = {},
+    onPeriod: (RentalPeriod) -> Unit = {},
+    onBook: (notes: String, firstName: String, lastName: String, phone: String) -> Unit =
+        { _, _, _, _ -> },
+    onCancelBooking: (String) -> Unit = {},
+    onSignIn: (() -> Unit)? = null,
+    onSignInAgain: (() -> Unit)? = null,
+    onShowProfile: () -> Unit = {},
 ) {
     // Der Weg nach draußen wird **hier** nachgeschlagen, im Fenster der App —
     // und nicht unten im Blatt. Ein ModalBottomSheet ist ein eigenes Fenster
@@ -167,6 +264,12 @@ fun RentalScreen(
                 item { SignInCard(onSignIn) }
             }
 
+            // Der Weg zum eigenen Profil drüben — und von dort weiter zur
+            // Vermieterseite, wenn die Plattform sie freigegeben hat.
+            if (state.signedIn) {
+                item { ProfileEntryCard(onShowProfile) }
+            }
+
             if (state.signedIn) {
                 item {
                     Text(
@@ -217,6 +320,28 @@ fun RentalScreen(
                         },
                         style = MaterialTheme.typography.bodyLarge,
                         modifier = Modifier.padding(top = 24.dp).testTag("rental-empty"),
+                    )
+                }
+            }
+
+            // Sets stehen unter den Geräten und nur in der ganzen Liste: Eine
+            // Suche fragt den Server nach Geräten, und ihre Antwort sagt über
+            // Sets nichts. Gebucht werden sie in der App nicht — Zusagen und
+            // Stornieren kann der Server dafür noch nicht.
+            if (state.sets.isNotEmpty() && state.query.isBlank()) {
+                item {
+                    Text(
+                        stringResource(R.string.rental_sets_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
+                items(state.sets, key = { "set-${it.id}" }) { SetCard(it) }
+                item {
+                    Text(
+                        stringResource(R.string.rental_sets_note),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
@@ -774,6 +899,765 @@ private fun Line(symbol: ImageVector, text: String) {
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+    }
+}
+
+// --- Der Weg zum eigenen Profil und zur Vermieterseite -----------------------
+
+/** The way into „Mein Profil im Maschinchenring". Only shown when signed in. */
+@Composable
+private fun ProfileEntryCard(onClick: () -> Unit) {
+    Card(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        modifier = Modifier.fillMaxWidth().testTag("rental-profile-entry"),
+    ) {
+        Row(
+            Modifier.padding(16.dp).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(Icons.Filled.Person, contentDescription = null, Modifier.size(20.dp))
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    stringResource(R.string.rental_profile_entry),
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                Text(
+                    stringResource(R.string.rental_profile_entry_body),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+        }
+    }
+}
+
+/** A set, as it stands over there: shown with its tariff, not bookable here. */
+@Composable
+private fun SetCard(set: RentalSet) {
+    Card(
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        modifier = Modifier.fillMaxWidth().testTag("set-${set.id}"),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(set.name, style = MaterialTheme.typography.titleMedium)
+            // Bei Sets ist die Beschreibung Klartext, kein Markdown — sie geht
+            // also unverändert auf den Schirm.
+            set.description?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            set.pricePerDay?.let {
+                Text(
+                    stringResource(R.string.rental_price_day, euroText(it)),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            set.deposit?.let { Text(stringResource(R.string.rental_deposit, euroText(it))) }
+            if (set.itemIds.isNotEmpty()) {
+                Text(
+                    pluralStringResource(
+                        R.plurals.rental_set_items,
+                        set.itemIds.size,
+                        set.itemIds.size,
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+/** The head of a page behind the catalogue: a way back and a title. */
+@Composable
+private fun PageHeader(title: String, onBack: () -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        IconButton(onClick = onBack, modifier = Modifier.testTag("rental-to-catalog")) {
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(R.string.back),
+            )
+        }
+        Text(title, style = MaterialTheme.typography.titleLarge)
+    }
+}
+
+// --- Mein Profil im Maschinchenring -----------------------------------------
+
+/**
+ * „Mein Profil im Maschinchenring" — telephone and address, so a handover can
+ * be arranged, plus the way to ask for permission to lend things out.
+ *
+ * The profile lives over there, not in the village backend: it is the one the
+ * lender sees. Whether it is complete enough is the platform's answer
+ * (`profileComplete`, `missingFields`), not a check of ours — and the e-mail
+ * address comes from the Rössing-ID and cannot be changed here at all.
+ */
+@Composable
+private fun RentalProfilePage(
+    state: RentalUiState,
+    modifier: Modifier = Modifier,
+    onBack: () -> Unit,
+    onSave: (
+        name: String,
+        phone: String,
+        addressStreet: String,
+        addressZip: String,
+        addressCity: String,
+    ) -> Unit,
+    onAskToLend: () -> Unit,
+    onShowOwner: () -> Unit,
+) {
+    val profile = state.profile
+    // Die Felder werden aus dem Profil vorbelegt und gehören danach dem, der
+    // tippt. Kommt drüben ein anderer Wert an, wechselt der Schlüssel und das
+    // Feld zeigt ihn — sonst bliebe ein alter Stand stehen.
+    var name by rememberSaveable(profile?.name) { mutableStateOf(profile?.name.orEmpty()) }
+    var phone by rememberSaveable(profile?.phone) { mutableStateOf(profile?.phone.orEmpty()) }
+    var street by rememberSaveable(profile?.addressStreet) {
+        mutableStateOf(profile?.addressStreet.orEmpty())
+    }
+    var zip by rememberSaveable(profile?.addressZip) {
+        mutableStateOf(profile?.addressZip.orEmpty())
+    }
+    var city by rememberSaveable(profile?.addressCity) {
+        mutableStateOf(profile?.addressCity.orEmpty())
+    }
+
+    Column(
+        modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp)
+            .padding(bottom = 32.dp)
+            .testTag("rental-profile"),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        PageHeader(stringResource(R.string.rental_profile_title), onBack)
+
+        if (profile == null) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                CircularProgressIndicator(Modifier.size(16.dp))
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.rental_profile_loading))
+            }
+        }
+
+        state.notice?.let { notice ->
+            Text(
+                notice.text ?: stringResource(fallbackFor(notice.code)),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("rental-profile-refusal"),
+            )
+        }
+
+        if (profile != null) {
+            profile.email?.let {
+                Text(
+                    stringResource(R.string.rental_profile_email, it),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                stringResource(R.string.rental_profile_section),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                singleLine = true,
+                label = { Text(stringResource(R.string.rental_field_name)) },
+                modifier = Modifier.fillMaxWidth().testTag("rental-profile-name"),
+            )
+            OutlinedTextField(
+                value = phone,
+                onValueChange = { phone = it },
+                singleLine = true,
+                label = { Text(stringResource(R.string.rental_field_phone)) },
+                modifier = Modifier.fillMaxWidth().testTag("rental-profile-phone"),
+            )
+            OutlinedTextField(
+                value = street,
+                onValueChange = { street = it },
+                singleLine = true,
+                label = { Text(stringResource(R.string.rental_field_street)) },
+                modifier = Modifier.fillMaxWidth().testTag("rental-profile-street"),
+            )
+            OutlinedTextField(
+                value = zip,
+                onValueChange = { zip = it },
+                singleLine = true,
+                label = { Text(stringResource(R.string.rental_field_zip)) },
+                modifier = Modifier.fillMaxWidth().testTag("rental-profile-zip"),
+            )
+            OutlinedTextField(
+                value = city,
+                onValueChange = { city = it },
+                singleLine = true,
+                label = { Text(stringResource(R.string.rental_field_city)) },
+                modifier = Modifier.fillMaxWidth().testTag("rental-profile-city"),
+            )
+
+            // Was fehlt, sagt der Server — die App führt keine eigene Liste.
+            if (profile.missingFields.isNotEmpty()) {
+                val missing = profile.missingFields.map { fieldLabel(it) }.joinToString(", ")
+                Text(
+                    stringResource(R.string.rental_profile_missing, missing),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.testTag("rental-profile-missing"),
+                )
+            }
+
+            Button(
+                onClick = { onSave(name, phone, street, zip, city) },
+                enabled = !state.savingProfile,
+                shape = MaterialTheme.shapes.large,
+                contentPadding = PaddingValues(vertical = 14.dp),
+                modifier = Modifier.fillMaxWidth().testTag("rental-profile-save"),
+            ) {
+                Text(
+                    if (state.savingProfile) {
+                        stringResource(R.string.rental_profile_saving)
+                    } else {
+                        stringResource(R.string.rental_profile_save)
+                    },
+                )
+            }
+            Text(
+                stringResource(R.string.rental_profile_note),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            HorizontalDivider(Modifier.padding(vertical = 8.dp))
+
+            Text(
+                stringResource(R.string.rental_lender_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Text(
+                lenderStatusText(profile.lenderStatus),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("rental-lender-status"),
+            )
+            // Der Satz der Plattform, so wie er kam.
+            state.lenderMessage?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("rental-lender-message"),
+                )
+            }
+            if (state.canAskToLend) {
+                OutlinedButton(
+                    onClick = onAskToLend,
+                    enabled = !state.askingToLend,
+                    shape = MaterialTheme.shapes.large,
+                    modifier = Modifier.fillMaxWidth().testTag("rental-ask-to-lend"),
+                ) {
+                    Text(
+                        if (state.askingToLend) {
+                            stringResource(R.string.rental_lender_asking)
+                        } else {
+                            stringResource(R.string.rental_lender_ask)
+                        },
+                    )
+                }
+            }
+            // Die Vermieterseite steht da, weil die Plattform „approved"
+            // gesagt hat — nie, weil die App etwas ausgerechnet hätte.
+            if (state.showsLenderArea) {
+                Button(
+                    onClick = onShowOwner,
+                    shape = MaterialTheme.shapes.large,
+                    modifier = Modifier.fillMaxWidth().testTag("rental-owner-entry"),
+                ) { Text(stringResource(R.string.rental_owner_entry)) }
+            }
+            Text(
+                stringResource(R.string.rental_lender_note),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/**
+ * The platform names its fields in English (`addressZip`); a person reads
+ * German. A name this version does not know is passed through rather than
+ * dropped — whoever reads „addressCountry" at least knows something is
+ * missing.
+ */
+@Composable
+private fun fieldLabel(field: String): String = when (field) {
+    "name" -> stringResource(R.string.rental_field_name)
+    "phone" -> stringResource(R.string.rental_field_phone)
+    "addressStreet" -> stringResource(R.string.rental_field_street)
+    "addressZip" -> stringResource(R.string.rental_field_zip)
+    "addressCity" -> stringResource(R.string.rental_field_city)
+    else -> field
+}
+
+/** The German wording of the lender's state. The three values are the contract's. */
+@Composable
+private fun lenderStatusText(status: LenderStatus): String = when (status) {
+    LenderStatus.NONE -> stringResource(R.string.rental_lender_none)
+    LenderStatus.PENDING -> stringResource(R.string.rental_lender_pending)
+    LenderStatus.APPROVED -> stringResource(R.string.rental_lender_approved)
+    LenderStatus.UNKNOWN -> stringResource(R.string.rental_lender_unknown)
+}
+
+// --- Meine Vermietung --------------------------------------------------------
+
+/**
+ * „Meine Vermietung" — who is asking for my devices, which devices are mine,
+ * and which stretches I keep for myself.
+ *
+ * Reachable only from the profile, and only where the platform has approved
+ * somebody as a lender. Adding or changing a device is **not** here: that
+ * happens in the chat and the web version of the Maschinchenring, and it
+ * stays there.
+ */
+@Composable
+private fun RentalOwnerPage(
+    state: RentalUiState,
+    modifier: Modifier = Modifier,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onApprove: (String) -> Unit,
+    onReject: (String) -> Unit,
+    onCancelBooking: (String) -> Unit,
+    onOpenBlock: (String) -> Unit,
+    onCloseBlock: () -> Unit,
+    onAddBlock: (RentalPeriod, String) -> Unit,
+    onRemoveBlock: (String) -> Unit,
+) {
+    LazyColumn(
+        modifier.fillMaxWidth().testTag("rental-owner"),
+        contentPadding = PaddingValues(start = 20.dp, end = 20.dp, bottom = 28.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item { PageHeader(stringResource(R.string.rental_owner_title), onBack) }
+
+        // Ein missglückter Abruf leert keine Liste — der Hinweis steht über
+        // dem, was zuletzt da war.
+        if (state.ownerOffline) {
+            item {
+                Notice(
+                    text = stringResource(R.string.rental_owner_offline),
+                    actionText = stringResource(R.string.rental_retry),
+                    testTag = "rental-owner-offline",
+                    actionTestTag = "rental-owner-retry",
+                    onAction = onRefresh,
+                )
+            }
+        }
+
+        state.notice?.let { notice ->
+            item {
+                Text(
+                    notice.text ?: stringResource(fallbackFor(notice.code)),
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.testTag("rental-owner-refusal"),
+                )
+            }
+        }
+
+        item {
+            Text(
+                if (state.waitingRequests > 0) {
+                    stringResource(R.string.rental_owner_requests_open, state.waitingRequests)
+                } else {
+                    stringResource(R.string.rental_owner_requests)
+                },
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+        if (state.ownerLoading && state.ownerBookings.isEmpty()) {
+            item {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(Modifier.size(16.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text(stringResource(R.string.rental_owner_loading))
+                }
+            }
+        }
+        items(state.ownerBookings, key = { "owner-${it.id}" }) { booking ->
+            OwnerBookingCard(
+                booking = booking,
+                busy = booking.id in state.deciding,
+                onApprove = { onApprove(booking.id) },
+                onReject = { onReject(booking.id) },
+                onCancel = { onCancelBooking(booking.id) },
+            )
+        }
+        if (state.ownerBookings.isEmpty() && !state.ownerLoading) {
+            item {
+                Text(
+                    stringResource(R.string.rental_owner_no_bookings),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("rental-owner-no-bookings"),
+                )
+            }
+        }
+        item {
+            Text(
+                stringResource(R.string.rental_owner_requests_note),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        item {
+            Text(
+                stringResource(R.string.rental_owner_devices),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+        items(state.ownerDevices, key = { "owner-device-${it.device.id}" }) { own ->
+            OwnerDeviceCard(own) { onOpenBlock(own.device.id) }
+        }
+        if (state.ownerDevices.isEmpty() && !state.ownerLoading) {
+            item {
+                Text(
+                    stringResource(R.string.rental_owner_no_devices),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("rental-owner-no-devices"),
+                )
+            }
+        }
+        item {
+            Text(
+                stringResource(R.string.rental_owner_devices_note),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        item {
+            Text(
+                stringResource(R.string.rental_owner_blocks),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+        items(state.blocks, key = { "block-${it.id}" }) { block ->
+            BlockCard(
+                block = block,
+                busy = block.id in state.deciding,
+                onRemove = { onRemoveBlock(block.id) },
+            )
+        }
+        if (state.blocks.isEmpty() && !state.ownerLoading) {
+            item {
+                Text(
+                    stringResource(R.string.rental_owner_no_blocks),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("rental-owner-no-blocks"),
+                )
+            }
+        }
+    }
+
+    state.blockDeviceId?.let { deviceId ->
+        BlockDialog(
+            deviceName = state.ownerDevices
+                .firstOrNull { it.device.id == deviceId }?.device?.name.orEmpty(),
+            state = state,
+            onDismiss = onCloseBlock,
+            onSave = onAddBlock,
+        )
+    }
+}
+
+/**
+ * One request on one of my devices — with the decisions the platform says are
+ * possible right now.
+ *
+ * Name and telephone stand here because the handover has to be arranged, and
+ * they stand nowhere else in the app.
+ */
+@Composable
+private fun OwnerBookingCard(
+    booking: RentalOwnerBooking,
+    busy: Boolean,
+    onApprove: () -> Unit,
+    onReject: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Card(
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        ),
+        modifier = Modifier.fillMaxWidth().testTag("owner-booking-${booking.id}"),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(booking.deviceName, style = MaterialTheme.typography.titleMedium)
+            Text(booking.period.text, style = MaterialTheme.typography.bodyMedium)
+            Text(
+                stringResource(R.string.rental_return_day, dayText(booking.period.end)),
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Text(ownerStatusText(booking), style = MaterialTheme.typography.labelLarge)
+            booking.renterName?.let {
+                Line(Icons.Filled.Person, stringResource(R.string.rental_owner_renter, it))
+            }
+            booking.renterPhone?.let {
+                Line(Icons.Filled.Phone, stringResource(R.string.rental_owner_phone, it))
+            }
+            booking.notes?.let {
+                Text(
+                    stringResource(R.string.rental_owner_note, it),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            // Die Knöpfe richten sich nach canDecide und canCancel. Ob eine
+            // Entscheidung noch offen ist, sagt die Plattform.
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (booking.canDecide) {
+                    Button(
+                        onClick = onApprove,
+                        enabled = !busy,
+                        shape = MaterialTheme.shapes.large,
+                        modifier = Modifier.testTag("rental-approve-${booking.id}"),
+                    ) { Text(stringResource(R.string.rental_approve)) }
+                    OutlinedButton(
+                        onClick = onReject,
+                        enabled = !busy,
+                        shape = MaterialTheme.shapes.large,
+                        modifier = Modifier.testTag("rental-reject-${booking.id}"),
+                    ) { Text(stringResource(R.string.rental_reject)) }
+                } else if (booking.canCancel) {
+                    OutlinedButton(
+                        onClick = onCancel,
+                        enabled = !busy,
+                        shape = MaterialTheme.shapes.large,
+                        modifier = Modifier.testTag("owner-cancel-${booking.id}"),
+                    ) { Text(stringResource(R.string.rental_owner_cancel)) }
+                }
+            }
+        }
+    }
+}
+
+/** The German wording of a request's state, seen from the lender's side. */
+@Composable
+private fun ownerStatusText(booking: RentalOwnerBooking): String = when (booking.status) {
+    BookingStatus.PENDING -> stringResource(R.string.rental_status_pending)
+    BookingStatus.APPROVED -> stringResource(R.string.rental_status_approved)
+    BookingStatus.REJECTED -> stringResource(R.string.rental_status_rejected)
+    BookingStatus.CANCELLED -> stringResource(R.string.rental_status_cancelled)
+    BookingStatus.UNKNOWN -> booking.rawStatus
+}
+
+/** One of my devices, with the way to keep a stretch for myself. */
+@Composable
+private fun OwnerDeviceCard(own: RentalOwnerDevice, onBlock: () -> Unit) {
+    Card(
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        modifier = Modifier.fillMaxWidth().testTag("owner-device-${own.device.id}"),
+    ) {
+        Row(
+            Modifier.padding(16.dp).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(own.device.name, style = MaterialTheme.typography.titleSmall)
+                // Abgeschaltete Geräte stehen nur hier — in der öffentlichen
+                // Liste tauchen sie nicht auf.
+                if (!own.active) {
+                    Text(
+                        stringResource(R.string.rental_owner_inactive),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            OutlinedButton(
+                onClick = onBlock,
+                shape = MaterialTheme.shapes.large,
+                modifier = Modifier.testTag("rental-block-${own.device.id}"),
+            ) { Text(stringResource(R.string.rental_block)) }
+        }
+    }
+}
+
+/** One of my blocks, with the way to lift it. */
+@Composable
+private fun BlockCard(block: RentalBlock, busy: Boolean, onRemove: () -> Unit) {
+    Card(
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        modifier = Modifier.fillMaxWidth().testTag("block-${block.id}"),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(block.deviceName, style = MaterialTheme.typography.titleSmall)
+            Line(Icons.Filled.EventBusy, block.period.text)
+            block.reason?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            OutlinedButton(
+                onClick = onRemove,
+                enabled = !busy,
+                shape = MaterialTheme.shapes.large,
+                modifier = Modifier.testTag("rental-unblock-${block.id}"),
+            ) { Text(stringResource(R.string.rental_unblock)) }
+        }
+    }
+}
+
+/**
+ * „Zeitraum sperren" — the lender keeps a stretch for themselves.
+ *
+ * The same conversion as everywhere in this area: the calendar hands out the
+ * days somebody needs the device, the contract wants the day it comes back
+ * ([periodOfPicked]). A refusal stays in the sheet, because closing it would
+ * throw away what was just typed.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BlockDialog(
+    deviceName: String,
+    state: RentalUiState,
+    onDismiss: () -> Unit,
+    onSave: (RentalPeriod, String) -> Unit,
+) {
+    var period by remember { mutableStateOf<RentalPeriod?>(null) }
+    var reason by rememberSaveable { mutableStateOf("") }
+    var picking by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.rental_block_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(deviceName, style = MaterialTheme.typography.titleSmall)
+                OutlinedButton(
+                    onClick = { picking = true },
+                    shape = MaterialTheme.shapes.large,
+                    modifier = Modifier.fillMaxWidth().testTag("rental-block-period"),
+                ) {
+                    Text(
+                        if (period == null) {
+                            stringResource(R.string.rental_choose_period)
+                        } else {
+                            stringResource(R.string.rental_change_period)
+                        },
+                    )
+                }
+                period?.let {
+                    Text(it.text, style = MaterialTheme.typography.titleSmall)
+                    Text(
+                        stringResource(R.string.rental_return_day, dayText(it.end)),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                OutlinedTextField(
+                    value = reason,
+                    onValueChange = { reason = it },
+                    singleLine = true,
+                    label = { Text(stringResource(R.string.rental_block_reason)) },
+                    modifier = Modifier.fillMaxWidth().testTag("rental-block-reason"),
+                )
+                Text(
+                    stringResource(R.string.rental_block_note),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                state.notice?.let { notice ->
+                    Text(
+                        notice.text ?: stringResource(fallbackFor(notice.code)),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.testTag("rental-block-refusal"),
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { period?.let { onSave(it, reason) } },
+                enabled = period != null && !state.blocking,
+                modifier = Modifier.testTag("rental-block-save"),
+            ) {
+                Text(
+                    if (state.blocking) {
+                        stringResource(R.string.rental_block_saving)
+                    } else {
+                        stringResource(R.string.rental_block)
+                    },
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, modifier = Modifier.testTag("rental-block-abort")) {
+                Text(stringResource(R.string.rental_period_abort))
+            }
+        },
+    )
+
+    if (picking) {
+        val picker = rememberDateRangePickerState()
+        DatePickerDialog(
+            onDismissRequest = { picking = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val chosen = periodOfPicked(
+                            picker.selectedStartDateMillis,
+                            picker.selectedEndDateMillis,
+                        )
+                        picking = false
+                        chosen?.let { period = it }
+                    },
+                    modifier = Modifier.testTag("rental-block-period-ok"),
+                ) { Text(stringResource(R.string.rental_period_ok)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { picking = false }) {
+                    Text(stringResource(R.string.rental_period_abort))
+                }
+            },
+        ) {
+            DateRangePicker(picker, modifier = Modifier.testTag("rental-block-period-picker"))
+        }
     }
 }
 

--- a/android/app/src/main/java/de/roessing/app/ui/RentalViewModel.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/RentalViewModel.kt
@@ -3,17 +3,24 @@ package de.roessing.app.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import de.roessing.app.auth.RentalSignIn
+import de.roessing.app.data.BlockRequest
 import de.roessing.app.data.BookingRequest
+import de.roessing.app.data.LenderStatus
+import de.roessing.app.data.ProfilePatch
 import de.roessing.app.data.RentalApiException
 import de.roessing.app.data.RentalAvailability
+import de.roessing.app.data.RentalBlock
 import de.roessing.app.data.RentalBooking
 import de.roessing.app.data.RentalDevice
 import de.roessing.app.data.RentalErrorCode
 import de.roessing.app.data.RentalImage
 import de.roessing.app.data.RentalOccupancy
+import de.roessing.app.data.RentalOwnerBooking
+import de.roessing.app.data.RentalOwnerDevice
 import de.roessing.app.data.RentalPeriod
 import de.roessing.app.data.RentalProfile
 import de.roessing.app.data.RentalRepository
+import de.roessing.app.data.RentalSet
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.delay
@@ -34,6 +41,16 @@ import kotlinx.coroutines.launch
 data class RentalNotice(val code: RentalErrorCode, val text: String?)
 
 /**
+ * Which page of the area is on screen.
+ *
+ * The area is one screen with two rooms behind it, not three areas: the
+ * catalogue is what people come for, the profile is reached from it, and the
+ * lender's side from the profile — and only when the platform said
+ * `lenderStatus: "approved"`.
+ */
+enum class RentalPage { CATALOG, PROFILE, OWNER }
+
+/**
  * State of the area "Maschinchenring".
  *
  * [offline] does not mean "nothing there", it means "not reachable right
@@ -49,6 +66,9 @@ data class RentalNotice(val code: RentalErrorCode, val text: String?)
 data class RentalUiState(
     val query: String = "",
     val devices: List<RentalDevice> = emptyList(),
+    /** Shown, not booked — the server cannot yet decide a set booking. */
+    val sets: List<RentalSet> = emptyList(),
+    val page: RentalPage = RentalPage.CATALOG,
     val loading: Boolean = false,
     val offline: Boolean = false,
     /** Somebody is signed in and the token counts for the rental platform. */
@@ -75,6 +95,22 @@ data class RentalUiState(
      * normal case — it takes name and telephone from the profile itself.
      */
     val missingFields: List<String> = emptyList(),
+    // --- The own profile over there ---------------------------------------
+    val savingProfile: Boolean = false,
+    val askingToLend: Boolean = false,
+    /** What the platform answered to "I would like to lend, too". Its words. */
+    val lenderMessage: String? = null,
+    // --- The lender's side ------------------------------------------------
+    val ownerBookings: List<RentalOwnerBooking> = emptyList(),
+    val ownerDevices: List<RentalOwnerDevice> = emptyList(),
+    val blocks: List<RentalBlock> = emptyList(),
+    val ownerLoading: Boolean = false,
+    val ownerOffline: Boolean = false,
+    /** Which requests are being decided right now. */
+    val deciding: Set<String> = emptySet(),
+    val blocking: Boolean = false,
+    /** The device a new block is being drawn for, or null. */
+    val blockDeviceId: String? = null,
 ) {
     /** Nothing there, nothing on its way, nothing broken — then it is empty. */
     val empty: Boolean get() = devices.isEmpty() && !loading && !offline
@@ -90,6 +126,21 @@ data class RentalUiState(
             period?.isValid == true &&
             availability?.available == true &&
             !booking
+
+    /**
+     * Whether the lender's side is shown at all.
+     *
+     * **The platform's answer**, nothing else: `approved`. The app does not
+     * work this out, and it does not fall back to [RentalProfile.lender] —
+     * the contract names one field for this question.
+     */
+    val showsLenderArea: Boolean get() = profile?.lenderStatus == LenderStatus.APPROVED
+
+    /** Whether asking to become a lender is worth offering at all. */
+    val canAskToLend: Boolean get() = profile?.lenderStatus == LenderStatus.NONE
+
+    /** How many requests wait for a yes or a no. */
+    val waitingRequests: Int get() = ownerBookings.count { it.canDecide }
 }
 
 /** One-off events of the area. */
@@ -98,6 +149,15 @@ sealed interface RentalEvent {
     data object Booked : RentalEvent
 
     data object Cancelled : RentalEvent
+
+    /** Telephone and address are stored over there. */
+    data object ProfileSaved : RentalEvent
+
+    /** A request on one of my devices was confirmed. */
+    data object Approved : RentalEvent
+
+    /** A request on one of my devices was turned down. */
+    data object Rejected : RentalEvent
 }
 
 /**
@@ -162,6 +222,10 @@ class RentalViewModel(
     }
 
     private fun fetch(query: String) {
+        // Sets are shown next to the devices, so they are fetched with them —
+        // but only for the whole catalogue: a search asks the server about
+        // devices, and its answer says nothing about sets.
+        if (query.isBlank()) loadSets()
         viewModelScope.launch {
             _state.update { it.copy(loading = true) }
             runCatching {
@@ -180,6 +244,20 @@ class RentalViewModel(
         }
     }
 
+    /**
+     * The sets — an addition, not the point of the screen.
+     *
+     * If they cannot be had, the devices are still there and nothing is said
+     * about it: a missing section is better than a hint nobody can act on.
+     */
+    private fun loadSets() {
+        viewModelScope.launch {
+            runCatching { repo.sets() }.onSuccess { list ->
+                _state.update { it.copy(sets = list) }
+            }
+        }
+    }
+
     /** Looks at the sign-in and, if it counts, fetches profile and bookings. */
     private suspend fun refreshSignIn() {
         val signedIn = runCatching { signIn() }.getOrDefault(RentalSignIn.UNREACHABLE)
@@ -191,6 +269,12 @@ class RentalViewModel(
                 // keep on screen either.
                 bookings = if (signedIn == RentalSignIn.VALID) it.bookings else emptyList(),
                 profile = if (signedIn == RentalSignIn.VALID) it.profile else null,
+                // The lender's side carries other people's names and numbers.
+                // Whoever is not signed in must not still see them.
+                ownerBookings = if (signedIn == RentalSignIn.VALID) it.ownerBookings else emptyList(),
+                ownerDevices = if (signedIn == RentalSignIn.VALID) it.ownerDevices else emptyList(),
+                blocks = if (signedIn == RentalSignIn.VALID) it.blocks else emptyList(),
+                page = if (signedIn == RentalSignIn.VALID) it.page else RentalPage.CATALOG,
             )
         }
         if (signedIn == RentalSignIn.VALID) {
@@ -241,6 +325,247 @@ class RentalViewModel(
                     }
                 }
         }
+    }
+
+    // --- The pages of the area -----------------------------------------------
+
+    /** Back to the devices. */
+    fun showCatalog() = _state.update {
+        it.copy(page = RentalPage.CATALOG, notice = null, blockDeviceId = null)
+    }
+
+    /**
+     * „Mein Profil im Maschinchenring".
+     *
+     * The profile is fetched again on opening: it lives over there, somebody
+     * may have changed it in the web version, and a stale form is worse than
+     * a moment's wait.
+     */
+    fun showProfile() {
+        _state.update { it.copy(page = RentalPage.PROFILE, notice = null, lenderMessage = null) }
+        loadProfile()
+    }
+
+    /**
+     * „Meine Vermietung".
+     *
+     * Reached only where the platform said `approved`
+     * ([RentalUiState.showsLenderArea]). That is the server's answer, and the
+     * calls behind this page are refused over there with `not_a_lender`
+     * anyway — the app checks nothing of its own.
+     */
+    fun showOwner() {
+        _state.update { it.copy(page = RentalPage.OWNER, notice = null) }
+        loadOwner()
+    }
+
+    // --- The own profile over there -------------------------------------------
+
+    /**
+     * Stores telephone and address in the rental platform.
+     *
+     * Only fields that carry something go out. An empty field is **not** a way
+     * to clear a value — the platform answers `bad_request` to that — so a
+     * blank one is left out and whatever stands over there stays.
+     */
+    fun saveProfile(
+        name: String,
+        phone: String,
+        addressStreet: String,
+        addressZip: String,
+        addressCity: String,
+    ) {
+        if (_state.value.savingProfile) return
+        val patch = ProfilePatch(
+            name = name.trim().takeIf { it.isNotEmpty() },
+            phone = phone.trim().takeIf { it.isNotEmpty() },
+            addressStreet = addressStreet.trim().takeIf { it.isNotEmpty() },
+            addressZip = addressZip.trim().takeIf { it.isNotEmpty() },
+            addressCity = addressCity.trim().takeIf { it.isNotEmpty() },
+        )
+        // An empty form is nothing to send. Saying so would be a rule of the
+        // app about a request the platform never sees.
+        if (patch.empty) return
+        _state.update { it.copy(savingProfile = true, notice = null) }
+        viewModelScope.launch {
+            runCatching { repo.updateProfile(patch) }
+                .onSuccess { fresh ->
+                    _state.update {
+                        it.copy(
+                            savingProfile = false,
+                            profile = fresh,
+                            // What a booking was missing is the server's list.
+                            // If it now says the profile is complete, the old
+                            // refusal has nothing left to ask for.
+                            missingFields = if (fresh.profileComplete) {
+                                emptyList()
+                            } else {
+                                fresh.missingFields
+                            },
+                        )
+                    }
+                    _events.emit(RentalEvent.ProfileSaved)
+                }
+                .onFailure { failure ->
+                    // What was typed stays on screen; nobody fills in an
+                    // address twice because the connection hiccuped.
+                    _state.update { it.copy(savingProfile = false).after(failure) }
+                }
+        }
+    }
+
+    /**
+     * „Ich möchte auch verleihen".
+     *
+     * The answer is a receipt, not a permission: somebody decides that by hand
+     * in the web version. Its sentence is German and is shown as it stands.
+     */
+    fun askToLend() {
+        if (_state.value.askingToLend) return
+        _state.update { it.copy(askingToLend = true, notice = null, lenderMessage = null) }
+        viewModelScope.launch {
+            runCatching { repo.requestLender() }
+                .onSuccess { receipt ->
+                    _state.update { it.copy(askingToLend = false, lenderMessage = receipt.message) }
+                    // The status moved. What counts is the platform's own
+                    // answer, so it is fetched rather than patched together.
+                    loadProfile()
+                }
+                .onFailure { failure ->
+                    _state.update { it.copy(askingToLend = false).after(failure) }
+                }
+        }
+    }
+
+    // --- The lender's side ----------------------------------------------------
+
+    /** Requests, own devices and own blocks — the three lists of that page. */
+    fun loadOwner() {
+        viewModelScope.launch {
+            _state.update { it.copy(ownerLoading = true) }
+            runCatching {
+                Triple(repo.ownerBookings(), repo.ownerDevices(), repo.blocks())
+            }
+                .onSuccess { (bookings, devices, blocks) ->
+                    _state.update {
+                        it.copy(
+                            ownerLoading = false,
+                            ownerOffline = false,
+                            ownerBookings = bookings,
+                            ownerDevices = devices,
+                            blocks = blocks,
+                        )
+                    }
+                }
+                .onFailure { failure ->
+                    _state.update { state ->
+                        val quiet = state.copy(ownerLoading = false)
+                        when (failure.rentalCode()) {
+                            RentalErrorCode.TOKEN_AUDIENCE -> quiet.asStale()
+                            RentalErrorCode.UNAUTHORIZED -> quiet.asSignedOut()
+                            // A failed call never quietly empties a list.
+                            else -> quiet.copy(ownerOffline = true)
+                        }
+                    }
+                }
+        }
+    }
+
+    /** Confirms a request. From then on the renter sees the pickup address. */
+    fun approve(bookingId: String) = decide(bookingId, RentalEvent.Approved) {
+        repo.approve(bookingId)
+    }
+
+    /** Turns a request down. No reason is recorded. */
+    fun reject(bookingId: String) = decide(bookingId, RentalEvent.Rejected) {
+        repo.reject(bookingId)
+    }
+
+    /**
+     * Withdraws a booking on one of my own devices — allowed for both sides
+     * while it is `pending` or `approved`. The button follows `canCancel`.
+     */
+    fun cancelOwnerBooking(bookingId: String) = decide(bookingId, RentalEvent.Cancelled) {
+        repo.cancel(bookingId)
+    }
+
+    private fun decide(bookingId: String, done: RentalEvent, step: suspend () -> Unit) {
+        if (bookingId in _state.value.deciding) return
+        // As with booking: note it first, then send — otherwise a second tap
+        // gets past the same check.
+        _state.update { it.copy(deciding = it.deciding + bookingId, notice = null) }
+        viewModelScope.launch {
+            runCatching { step() }
+                .onSuccess {
+                    _state.update { it.copy(deciding = it.deciding - bookingId) }
+                    _events.emit(done)
+                }
+                .onFailure { failure ->
+                    _state.update { it.copy(deciding = it.deciding - bookingId).after(failure) }
+                }
+            // The platform's list is the truth about what just happened — and
+            // after a refusal it knows better than the screen does.
+            reloadOwnerBookings()
+        }
+    }
+
+    /** Opens the sheet for a new block on one of my devices. */
+    fun openBlock(deviceId: String) = _state.update {
+        it.copy(blockDeviceId = deviceId, notice = null)
+    }
+
+    fun closeBlock() = _state.update { it.copy(blockDeviceId = null, notice = null) }
+
+    /**
+     * Keeps a stretch on the open device.
+     *
+     * An existing booking is never pushed aside: the platform answers
+     * `occupied`, and whoever wants the days anyway cancels the booking first.
+     * The sheet closes only when the platform took the block.
+     */
+    fun addBlock(period: RentalPeriod, reason: String? = null) {
+        val deviceId = _state.value.blockDeviceId ?: return
+        if (_state.value.blocking) return
+        if (!period.isValid) return
+        _state.update { it.copy(blocking = true, notice = null) }
+        viewModelScope.launch {
+            runCatching { repo.addBlock(BlockRequest(deviceId, period, reason)) }
+                .onSuccess {
+                    _state.update { it.copy(blocking = false, blockDeviceId = null) }
+                    reloadBlocks()
+                }
+                .onFailure { failure ->
+                    // The sheet stays open with the refusal in it — closing it
+                    // would throw away what somebody just typed.
+                    _state.update { it.copy(blocking = false).after(failure) }
+                }
+        }
+    }
+
+    /** Lifts one of my blocks. */
+    fun removeBlock(blockId: String) {
+        if (blockId in _state.value.deciding) return
+        _state.update { it.copy(deciding = it.deciding + blockId, notice = null) }
+        viewModelScope.launch {
+            runCatching { repo.removeBlock(blockId) }
+                .onSuccess { _state.update { it.copy(deciding = it.deciding - blockId) } }
+                .onFailure { failure ->
+                    _state.update { it.copy(deciding = it.deciding - blockId).after(failure) }
+                }
+            reloadBlocks()
+        }
+    }
+
+    private suspend fun reloadOwnerBookings() {
+        runCatching { repo.ownerBookings() }
+            .onSuccess { list -> _state.update { it.copy(ownerBookings = list) } }
+            .onFailure { _state.update { it.copy(ownerOffline = true) } }
+    }
+
+    private suspend fun reloadBlocks() {
+        runCatching { repo.blocks() }
+            .onSuccess { list -> _state.update { it.copy(blocks = list) } }
+            .onFailure { _state.update { it.copy(ownerOffline = true) } }
     }
 
     // --- Detail sheet --------------------------------------------------------
@@ -454,12 +779,36 @@ class RentalViewModel(
 }
 
 /** Signed in, but with a token from before the changeover. */
-private fun RentalUiState.asStale() =
-    copy(staleSignIn = true, signedIn = false, bookings = emptyList(), profile = null)
+private fun RentalUiState.asStale() = copy(
+    staleSignIn = true,
+    signedIn = false,
+    bookings = emptyList(),
+    profile = null,
+).withoutLenderSide()
 
 /** The sign-in is gone — the ordinary way back is the login screen. */
-private fun RentalUiState.asSignedOut() =
-    copy(signedIn = false, staleSignIn = false, bookings = emptyList(), profile = null)
+private fun RentalUiState.asSignedOut() = copy(
+    signedIn = false,
+    staleSignIn = false,
+    bookings = emptyList(),
+    profile = null,
+).withoutLenderSide()
+
+/**
+ * Everything the lender's side holds, gone.
+ *
+ * Not tidiness: those lists carry other people's names and telephone numbers,
+ * and they have no business standing on a screen that nobody is signed in to.
+ * The page goes back to the catalogue for the same reason.
+ */
+private fun RentalUiState.withoutLenderSide() = copy(
+    page = RentalPage.CATALOG,
+    ownerBookings = emptyList(),
+    ownerDevices = emptyList(),
+    blocks = emptyList(),
+    blockDeviceId = null,
+    lenderMessage = null,
+)
 
 /** The platform's code, or null when the failure was not one of its answers. */
 private fun Throwable.rentalCode(): RentalErrorCode? = (this as? RentalApiException)?.code

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -334,4 +334,77 @@
         <item quantity="one">%1$d Tag</item>
         <item quantity="other">%1$d Tage</item>
     </plurals>
+
+    <!-- Sets: mehrere Geraete zu einem eigenen Tagespreis. Gebucht werden sie
+         drueben; in der App stehen sie zum Ansehen. -->
+    <string name="rental_sets_title">Sets</string>
+    <string name="rental_sets_note">Sets werden im Maschinchenring selbst gebucht — in der App stehen sie zum Ansehen.</string>
+    <plurals name="rental_set_items">
+        <item quantity="one">%1$d Gerät</item>
+        <item quantity="other">%1$d Geräte</item>
+    </plurals>
+
+    <!-- Das eigene Profil im Maschinchenring. Es liegt drueben, nicht im
+         Dorf-Backend: Es ist das, was der Verleiher bei der Uebergabe sieht. -->
+    <string name="rental_profile_entry">Mein Profil im Maschinchenring</string>
+    <string name="rental_profile_entry_body">Telefon und Adresse für die Übergabe — und der Weg zum Verleihen.</string>
+    <string name="rental_profile_title">Mein Profil im Maschinchenring</string>
+    <string name="rental_profile_loading">Profil wird geholt …</string>
+    <string name="rental_profile_section">Deine Angaben</string>
+    <string name="rental_profile_email">E-Mail: %1$s</string>
+    <string name="rental_profile_save">Speichern</string>
+    <string name="rental_profile_saving">Wird gespeichert …</string>
+    <string name="rental_profile_saved">Gespeichert.</string>
+    <string name="rental_profile_note">Deine E-Mail-Adresse kommt aus der Rössing-ID und lässt sich hier nicht ändern. Telefon und Adresse braucht der Verleiher für die Übergabe.</string>
+    <string name="rental_profile_missing">Zum Buchen fehlt dem Maschinchenring noch: %1$s.</string>
+
+    <!-- Die Feldnamen der Mietplattform heissen englisch; gelesen wird deutsch. -->
+    <string name="rental_field_name">Name</string>
+    <string name="rental_field_phone">Telefonnummer</string>
+    <string name="rental_field_street">Straße und Hausnummer</string>
+    <string name="rental_field_zip">Postleitzahl</string>
+    <string name="rental_field_city">Ort</string>
+
+    <!-- Verleihen: ueber die Freischaltung entscheidet die Verwaltung des
+         Maschinchenrings von Hand, in der Webfassung. -->
+    <string name="rental_lender_title">Verleihen</string>
+    <string name="rental_lender_none">Du verleihst noch nichts.</string>
+    <string name="rental_lender_pending">Deine Anfrage als Verleiher liegt vor.</string>
+    <string name="rental_lender_approved">Du bist als Verleiher freigeschaltet.</string>
+    <string name="rental_lender_unknown">Unbekannter Stand.</string>
+    <string name="rental_lender_ask">Ich möchte auch verleihen</string>
+    <string name="rental_lender_asking">Wird gesendet …</string>
+    <string name="rental_lender_note">Über die Freischaltung entscheidet die Verwaltung des Maschinchenrings von Hand. Du bekommst eine E-Mail, sobald es so weit ist.</string>
+
+    <!-- Meine Vermietung: Anfragen entscheiden, eigene Geraete, eigene Sperren. -->
+    <string name="rental_owner_entry">Meine Vermietung</string>
+    <string name="rental_owner_title">Meine Vermietung</string>
+    <string name="rental_owner_loading">Anfragen werden geholt …</string>
+    <string name="rental_owner_offline">Gerade keine Verbindung zum Maschinchenring — die Listen sind möglicherweise nicht mehr aktuell.</string>
+    <string name="rental_owner_requests">Anfragen</string>
+    <string name="rental_owner_requests_open">Anfragen (%1$d offen)</string>
+    <string name="rental_owner_requests_note">Sobald du zusagst, bekommt der Mieter deine Abholadresse per E-Mail — vorher nicht.</string>
+    <string name="rental_owner_no_bookings">Für deine Geräte liegt gerade nichts vor.</string>
+    <string name="rental_owner_renter">Mieter: %1$s</string>
+    <string name="rental_owner_phone">Telefon: %1$s</string>
+    <string name="rental_owner_note">Nachricht: %1$s</string>
+    <string name="rental_approve">Zusagen</string>
+    <string name="rental_reject">Absagen</string>
+    <string name="rental_owner_cancel">Stornieren</string>
+    <string name="rental_approved">Zugesagt — der Mieter bekommt deine Abholadresse.</string>
+    <string name="rental_rejected">Abgesagt.</string>
+    <string name="rental_owner_devices">Meine Geräte</string>
+    <string name="rental_owner_no_devices">Du hast noch kein Gerät eingestellt.</string>
+    <string name="rental_owner_devices_note">Geräte anlegen und ändern geht im Maschinchenring selbst — in der App bewusst nicht.</string>
+    <string name="rental_owner_inactive">Abgeschaltet — für andere unsichtbar.</string>
+    <string name="rental_owner_blocks">Meine Sperren</string>
+    <string name="rental_owner_no_blocks">Keine Sperre eingetragen.</string>
+    <string name="rental_unblock">Sperre aufheben</string>
+
+    <!-- Zeitraum sperren: der Verleiher braucht sein Geraet selbst. -->
+    <string name="rental_block">Sperren</string>
+    <string name="rental_block_title">Zeitraum sperren</string>
+    <string name="rental_block_reason">Grund (freiwillig)</string>
+    <string name="rental_block_note">Für andere sieht die Sperre aus wie jeder belegte Zeitraum — ohne Grund und ohne Namen. Eine bestehende Buchung verdrängt sie nicht.</string>
+    <string name="rental_block_saving">Wird gesperrt …</string>
 </resources>

--- a/android/app/src/test/java/de/roessing/app/RentalApiTest.kt
+++ b/android/app/src/test/java/de/roessing/app/RentalApiTest.kt
@@ -2,12 +2,14 @@ package de.roessing.app
 
 import de.roessing.app.auth.RentalSignIn
 import de.roessing.app.auth.TokenResult
+import de.roessing.app.data.BlockRequest
 import de.roessing.app.data.BookingRequest
 import de.roessing.app.data.BookingStatus
 import de.roessing.app.data.LenderStatus
 import de.roessing.app.data.MietenApi
 import de.roessing.app.data.MietenRentalRepository
 import de.roessing.app.data.OccupancyStatus
+import de.roessing.app.data.ProfilePatch
 import de.roessing.app.data.RentalApiException
 import de.roessing.app.data.RentalErrorCode
 import de.roessing.app.data.RentalPeriod
@@ -334,6 +336,256 @@ class RentalApiTest {
         val hinaus = MietenApi.authorized(anfrage, TokenResult.Token("abc"))
 
         assertNull(hinaus.header("Authorization"))
+    }
+
+    // --- Sets (Route 4) ------------------------------------------------------
+
+    /**
+     * Sets stehen im Vertrag als eigene Hülle. Sie werden angezeigt und in der
+     * App nicht gebucht — Zusagen und Stornieren kann der Server dafür noch
+     * nicht, und was er nicht kann, baut die App nicht nach.
+     */
+    @Test
+    fun `die Sets kommen ohne Anmeldung und mit ihren Geraeten`() = runTest {
+        server.enqueue(antwort("sets.json"))
+
+        val sets = repo(token = TokenResult.Token("streng-geheim")).sets()
+
+        assertEquals(listOf("gartenset", "malerset"), sets.map { it.id })
+        assertEquals("Gartenset", sets.first().name)
+        assertEquals(30.0, sets.first().pricePerDay!!, 0.001)
+        assertEquals(3, sets.first().itemIds.size)
+        // Kein Preis für ein Wochenende, keine Kaution — das bleibt leer.
+        assertNull(sets[1].description)
+        assertNull(sets[1].deposit)
+
+        val anfrage = server.takeRequest()
+        assertEquals("/api/v1/sets", anfrage.path)
+        assertNull(anfrage.getHeader("Authorization"))
+    }
+
+    // --- Profil (Routen 8 und 9) ---------------------------------------------
+
+    /**
+     * Der Server ändert genau, was er bekommt. Ein leeres Feld ist deshalb
+     * kein Weg, einen Wert zu löschen — es bleibt weg.
+     */
+    @Test
+    fun `das Profil aendert nur, was mitgeschickt wird`() = runTest {
+        server.enqueue(antwort("me-updated.json"))
+
+        val profil = repo().updateProfile(ProfilePatch(phone = "+49 5069 987654", addressCity = "  "))
+
+        assertEquals("+49 5069 987654", profil.phone)
+        val anfrage = server.takeRequest()
+        assertEquals("PATCH", anfrage.method)
+        assertEquals("/api/v1/me", anfrage.path)
+        val koerper = anfrage.body.readUtf8()
+        assertTrue(koerper, koerper.contains("\"phone\":\"+49 5069 987654\""))
+        assertFalse(koerper, koerper.contains("addressCity"))
+        // Die E-Mail-Adresse kommt aus der Rössing-ID und geht nie hinaus.
+        assertFalse(koerper, koerper.contains("email"))
+    }
+
+    @Test
+    fun `die Anfrage als Verleiher ist eine Eingangsbestaetigung`() = runTest {
+        server.enqueue(antwort("lender-request.json"))
+
+        val antwort = repo().requestLender()
+
+        assertEquals(LenderStatus.PENDING, antwort.lenderStatus)
+        assertTrue(antwort.message!!.startsWith("Deine Anfrage wurde weitergeleitet"))
+        val anfrage = server.takeRequest()
+        assertEquals("POST", anfrage.method)
+        assertEquals("/api/v1/me/lender-request", anfrage.path)
+    }
+
+    /** Zu schnell hintereinander gefragt: eine Auskunft, kein Absturz. */
+    @Test
+    fun `eine zu schnelle Verleiher-Anfrage kommt als Kennung zurueck`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(429)
+                .setHeader("Content-Type", "application/json; charset=utf-8")
+                .setBody("""{"error":{"code":"rate_limited","message":"Bitte später noch einmal"}}"""),
+        )
+
+        val fehler = fehlerVon { repo().requestLender() }
+
+        assertEquals(RentalErrorCode.RATE_LIMITED, fehler.code)
+    }
+
+    @Test
+    fun `ein freigeschaltetes Profil sagt es selbst`() = runTest {
+        server.enqueue(antwort("me-lender.json"))
+
+        val profil = repo().profile()
+
+        // Daran — und an nichts anderem — hängt die Vermieteransicht.
+        assertEquals(LenderStatus.APPROVED, profil.lenderStatus)
+        assertTrue(profil.lender)
+    }
+
+    // --- Die Vermieterseite (Routen 13 bis 19) -------------------------------
+
+    /**
+     * Name und Nummer des Mieters stehen hier, weil die Übergabe verabredet
+     * werden muss. Sie stehen in keiner anderen Antwort des Vertrags.
+     */
+    @Test
+    fun `die Anfragen auf meinen Geraeten tragen Name und Nummer`() = runTest {
+        server.enqueue(antwort("owner-bookings.json"))
+
+        val anfragen = repo(token = TokenResult.Token("abc123")).ownerBookings()
+
+        assertEquals(2, anfragen.size)
+        val offen = anfragen.first()
+        assertEquals("Erika Musterfrau", offen.renterName)
+        assertEquals("+49 5069 123456", offen.renterPhone)
+        assertEquals(BookingStatus.PENDING, offen.status)
+        // Ob entschieden werden kann, sagt der Server — nicht die App.
+        assertTrue(offen.canDecide)
+        assertFalse(anfragen[1].canDecide)
+        assertTrue(anfragen[1].canCancel)
+        assertNull(anfragen[1].renterPhone)
+
+        val anfrage = server.takeRequest()
+        assertEquals("/api/v1/owner/bookings", anfrage.path)
+        assertEquals("Bearer abc123", anfrage.getHeader("Authorization"))
+    }
+
+    /** Wer keine Geräte hat, bekommt eine leere Liste — kein Fehler. */
+    @Test
+    fun `wer nicht freigeschaltet ist, bekommt eine Kennung dafuer`() = runTest {
+        server.enqueue(antwort("error-not-a-lender.json", code = 403))
+
+        val fehler = fehlerVon { repo().ownerBookings() }
+
+        assertEquals(RentalErrorCode.NOT_A_LENDER, fehler.code)
+    }
+
+    @Test
+    fun `zusagen und absagen gehen an die Buchung`() = runTest {
+        server.enqueue(antwort("status-approved.json"))
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json; charset=utf-8")
+                .setBody("""{"status":"rejected"}"""),
+        )
+
+        repo().approve("8f14c2b0")
+        repo().reject("1c9e77a3")
+
+        val zusage = server.takeRequest()
+        assertEquals("POST", zusage.method)
+        assertEquals("/api/v1/bookings/8f14c2b0/approve", zusage.path)
+        assertEquals("/api/v1/bookings/1c9e77a3/reject", server.takeRequest().path)
+    }
+
+    /**
+     * Eine Buchung, die nicht mehr offen ist, ist kein Absturz: Der Server
+     * sagt `conflict`, und die Ansicht holt danach seine Liste.
+     */
+    @Test
+    fun `eine schon entschiedene Buchung meldet conflict`() = runTest {
+        server.enqueue(antwort("error-conflict.json", code = 409))
+
+        val fehler = fehlerVon { repo().approve("8f14c2b0") }
+
+        assertEquals(RentalErrorCode.CONFLICT, fehler.code)
+    }
+
+    /** Stornieren liefert einen Körper — der wird gelesen und nicht geraten. */
+    @Test
+    fun `das Stornieren liest die Antwort des Servers`() = runTest {
+        server.enqueue(antwort("status-cancelled.json"))
+
+        repo().cancel("8f14c2b0")
+
+        assertEquals("/api/v1/bookings/8f14c2b0/cancel", server.takeRequest().path)
+    }
+
+    @Test
+    fun `meine Geraete stehen mit den abgeschalteten da`() = runTest {
+        server.enqueue(antwort("owner-items.json"))
+
+        val meine = repo().ownerDevices()
+
+        assertEquals(2, meine.size)
+        assertTrue(meine.first().active)
+        // Das eine Feld, das die öffentliche Liste nicht hat.
+        assertFalse(meine[1].active)
+        assertEquals("Rasenwalze", meine[1].device.name)
+        assertEquals("/api/v1/owner/items", server.takeRequest().path)
+    }
+
+    @Test
+    fun `eine Sperre wird angelegt und wieder aufgehoben`() = runTest {
+        server.enqueue(antwort("block-created.json", code = 201))
+        server.enqueue(antwort("block-deleted.json"))
+
+        val sperre = repo().addBlock(
+            BlockRequest(
+                deviceId = "as-585-km-kreiselmaeher",
+                period = RentalPeriod(
+                    LocalDate.parse("2026-10-01"),
+                    LocalDate.parse("2026-10-08"),
+                ),
+                reason = "Eigener Einsatz",
+            ),
+        )
+
+        assertEquals("b1f0c9a2-33aa-4d10-8e77-5c2b1a9f0e33", sperre.id)
+        // Der 7. ist der letzte Tag, der 8. der Rückgabetag.
+        assertEquals(LocalDate.parse("2026-10-07"), sperre.period.lastDay)
+
+        val anlegen = server.takeRequest()
+        assertEquals("/api/v1/owner/blocks", anlegen.path)
+        val koerper = anlegen.body.readUtf8()
+        assertTrue(koerper, koerper.contains("\"startDate\":\"2026-10-01\""))
+        assertTrue(koerper, koerper.contains("\"endDate\":\"2026-10-08\""))
+        assertTrue(koerper, koerper.contains("\"reason\":\"Eigener Einsatz\""))
+
+        repo().removeBlock(sperre.id)
+        val aufheben = server.takeRequest()
+        assertEquals("DELETE", aufheben.method)
+        assertEquals("/api/v1/owner/blocks/${sperre.id}", aufheben.path)
+    }
+
+    @Test
+    fun `meine Sperren kommen mit Geraet und Grund`() = runTest {
+        server.enqueue(antwort("blocks.json"))
+
+        val sperren = repo().blocks()
+
+        assertEquals(1, sperren.size)
+        assertEquals("AS 585 KM Kreiselmäher", sperren.first().deviceName)
+        assertEquals("Eigener Einsatz", sperren.first().reason)
+        assertEquals("/api/v1/owner/blocks", server.takeRequest().path)
+    }
+
+    /**
+     * Eine bestehende Buchung wird von einer Sperre nicht verdrängt. Der
+     * Server sagt `occupied`; wer die Tage trotzdem will, storniert zuerst.
+     */
+    @Test
+    fun `eine Sperre verdraengt keine Buchung`() = runTest {
+        server.enqueue(antwort("error-block-occupied.json", code = 409))
+
+        val fehler = fehlerVon {
+            repo().addBlock(
+                BlockRequest(
+                    deviceId = "as-585-km-kreiselmaeher",
+                    period = RentalPeriod(
+                        LocalDate.parse("2026-10-01"),
+                        LocalDate.parse("2026-10-08"),
+                    ),
+                ),
+            )
+        }
+
+        assertEquals(RentalErrorCode.OCCUPIED, fehler.code)
     }
 
     /**

--- a/android/app/src/test/java/de/roessing/app/RentalViewModelTest.kt
+++ b/android/app/src/test/java/de/roessing/app/RentalViewModelTest.kt
@@ -1,11 +1,15 @@
 package de.roessing.app
 
 import de.roessing.app.auth.RentalSignIn
+import de.roessing.app.data.BlockRequest
 import de.roessing.app.data.BookingRequest
 import de.roessing.app.data.BookingStatus
 import de.roessing.app.data.LenderStatus
+import de.roessing.app.data.LenderRequest
 import de.roessing.app.data.OccupancyStatus
+import de.roessing.app.data.ProfilePatch
 import de.roessing.app.data.RentalApiException
+import de.roessing.app.data.RentalBlock
 import de.roessing.app.data.RentalAvailability
 import de.roessing.app.data.RentalBooking
 import de.roessing.app.data.RentalDevice
@@ -13,10 +17,14 @@ import de.roessing.app.data.RentalDeviceDetail
 import de.roessing.app.data.RentalErrorCode
 import de.roessing.app.data.RentalImage
 import de.roessing.app.data.RentalOccupancy
+import de.roessing.app.data.RentalOwnerBooking
+import de.roessing.app.data.RentalOwnerDevice
 import de.roessing.app.data.RentalPeriod
 import de.roessing.app.data.RentalProfile
 import de.roessing.app.data.RentalRepository
+import de.roessing.app.data.RentalSet
 import de.roessing.app.ui.RentalEvent
+import de.roessing.app.ui.RentalPage
 import de.roessing.app.ui.RentalViewModel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -133,7 +141,128 @@ private class FakeRental : RentalRepository {
         cancelFailure?.let { throw it }
         cancelled += bookingId
     }
+
+    // --- Sets, Profil und die Vermieterseite --------------------------------
+
+    var sets: List<RentalSet> = emptyList()
+    var setsFailure: Throwable? = null
+    var lenderReceipt = LenderRequest(LenderStatus.PENDING, "Deine Anfrage wurde weitergeleitet.")
+    var ownerBookings: List<RentalOwnerBooking> = emptyList()
+    var ownerDevices: List<RentalOwnerDevice> = emptyList()
+    var blocks: List<RentalBlock> = emptyList()
+
+    var updateFailure: Throwable? = null
+    var lenderFailure: Throwable? = null
+    var ownerFailure: Throwable? = null
+    var decideFailure: Throwable? = null
+    var blockFailure: Throwable? = null
+
+    var setsCalls = 0
+    var ownerCalls = 0
+    var lastPatch: ProfilePatch? = null
+    var lastBlock: BlockRequest? = null
+    var approved = mutableListOf<String>()
+    var rejected = mutableListOf<String>()
+    var removedBlocks = mutableListOf<String>()
+
+    override suspend fun sets(): List<RentalSet> {
+        setsCalls++
+        setsFailure?.let { throw it }
+        return sets
+    }
+
+    override suspend fun updateProfile(patch: ProfilePatch): RentalProfile {
+        lastPatch = patch
+        updateFailure?.let { throw it }
+        // Die Plattform antwortet mit dem geänderten Profil — hier: das, was
+        // sie behalten hat.
+        profile = profile.copy(
+            name = patch.name ?: profile.name,
+            phone = patch.phone ?: profile.phone,
+            addressStreet = patch.addressStreet ?: profile.addressStreet,
+            addressZip = patch.addressZip ?: profile.addressZip,
+            addressCity = patch.addressCity ?: profile.addressCity,
+        )
+        return profile
+    }
+
+    override suspend fun requestLender(): LenderRequest {
+        lenderFailure?.let { throw it }
+        return lenderReceipt
+    }
+
+    override suspend fun ownerBookings(): List<RentalOwnerBooking> {
+        ownerCalls++
+        ownerFailure?.let { throw it }
+        return ownerBookings
+    }
+
+    override suspend fun approve(bookingId: String) {
+        decideFailure?.let { throw it }
+        approved += bookingId
+    }
+
+    override suspend fun reject(bookingId: String) {
+        decideFailure?.let { throw it }
+        rejected += bookingId
+    }
+
+    override suspend fun ownerDevices(): List<RentalOwnerDevice> {
+        ownerFailure?.let { throw it }
+        return ownerDevices
+    }
+
+    override suspend fun blocks(): List<RentalBlock> {
+        ownerFailure?.let { throw it }
+        return blocks
+    }
+
+    override suspend fun addBlock(request: BlockRequest): RentalBlock {
+        lastBlock = request
+        blockFailure?.let { throw it }
+        val neu = RentalBlock(
+            id = "sperre-neu",
+            deviceId = request.deviceId,
+            deviceName = "Kreiselmäher",
+            period = request.period,
+            reason = request.reason,
+        )
+        blocks = blocks + neu
+        return neu
+    }
+
+    override suspend fun removeBlock(blockId: String) {
+        blockFailure?.let { throw it }
+        removedBlocks += blockId
+        blocks = blocks.filterNot { it.id == blockId }
+    }
 }
+
+private fun anfrage(
+    id: String,
+    canDecide: Boolean = true,
+    canCancel: Boolean = true,
+) = RentalOwnerBooking(
+    id = id,
+    deviceId = "maeher",
+    deviceName = "Kreiselmäher",
+    period = zeitraum(),
+    status = if (canDecide) BookingStatus.PENDING else BookingStatus.APPROVED,
+    rawStatus = if (canDecide) "pending" else "approved",
+    renterName = "Erika Musterfrau",
+    renterPhone = "+49 5069 123456",
+    notes = null,
+    canDecide = canDecide,
+    canCancel = canCancel,
+)
+
+private fun sperre(id: String) = RentalBlock(
+    id = id,
+    deviceId = "maeher",
+    deviceName = "Kreiselmäher",
+    period = RentalPeriod(LocalDate.parse("2026-10-01"), LocalDate.parse("2026-10-08")),
+    reason = "Eigener Einsatz",
+)
 
 private fun geraet(id: String, name: String = "Kreiselmäher") = RentalDevice(
     id = id,
@@ -147,6 +276,15 @@ private fun geraet(id: String, name: String = "Kreiselmäher") = RentalDevice(
     thumbnailUrl = null,
     productUrl = null,
     webUrl = "https://mieten.example.invalid/geraete/$id/",
+)
+
+private fun satz(id: String, name: String = "Gartenset") = RentalSet(
+    id = id,
+    name = name,
+    description = "Vertikutierer, Rasenwalze und Streuwagen zusammen.",
+    pricePerDay = 30.0,
+    deposit = 150.0,
+    itemIds = listOf("walze", "vertikutierer"),
 )
 
 private fun zeitraum(von: String = "2026-09-05", bis: String = "2026-09-07") =
@@ -169,15 +307,18 @@ private fun buchung(
     pickup = null,
 )
 
-private fun profil(missing: List<String> = emptyList()) = RentalProfile(
+private fun profil(
+    missing: List<String> = emptyList(),
+    lenderStatus: LenderStatus = LenderStatus.NONE,
+) = RentalProfile(
     name = "Erika Musterfrau",
     email = "erika@example.invalid",
     phone = "+49 5069 123456",
     addressStreet = "Hauptstraße 1",
     addressZip = "31171",
     addressCity = "Nordstemmen",
-    lender = false,
-    lenderStatus = LenderStatus.NONE,
+    lender = lenderStatus == LenderStatus.APPROVED,
+    lenderStatus = lenderStatus,
     profileComplete = missing.isEmpty(),
     missingFields = missing,
 )
@@ -742,5 +883,438 @@ class RentalViewModelTest {
         advanceUntilIdle()
 
         assertEquals(listOf("b-1"), repo.cancelled)
+    }
+
+    // --- Sets ---------------------------------------------------------------
+
+    @Test
+    fun `die Sets stehen neben den Geraeten`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            devices = listOf(geraet("maeher"))
+            sets = listOf(satz("gartenset"))
+        }
+        val vm = vm(repo)
+
+        vm.load()
+        advanceUntilIdle()
+
+        assertEquals(listOf("gartenset"), vm.state.value.sets.map { it.id })
+    }
+
+    /**
+     * Eine Suche fragt den Server nach Geräten; über Sets sagt ihre Antwort
+     * nichts. Sie werden deshalb nur zur ganzen Liste geholt.
+     */
+    @Test
+    fun `eine Suche holt keine Sets`() = runTest(dispatcher) {
+        val repo = FakeRental().apply { sets = listOf(satz("gartenset")) }
+        val vm = vm(repo)
+        vm.load()
+        advanceUntilIdle()
+        val vorher = repo.setsCalls
+
+        vm.setQuery("rasen")
+        advanceUntilIdle()
+
+        assertEquals(vorher, repo.setsCalls)
+    }
+
+    /** Fehlen die Sets, stehen die Geräte trotzdem da — ohne Hinweis. */
+    @Test
+    fun `ein Ausfall der Sets laesst die Geraete stehen`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            devices = listOf(geraet("maeher"))
+            setsFailure = IOException("kein Netz")
+        }
+        val vm = vm(repo)
+
+        vm.load()
+        advanceUntilIdle()
+
+        assertEquals(1, vm.state.value.devices.size)
+        assertTrue(vm.state.value.sets.isEmpty())
+        assertFalse(vm.state.value.offline)
+    }
+
+    // --- Mein Profil im Maschinchenring -------------------------------------
+
+    @Test
+    fun `das Profil schickt nur, was ausgefuellt ist`() = runTest(dispatcher) {
+        val repo = FakeRental()
+        val vm = vm(repo, RentalSignIn.VALID)
+        val ereignisse = mutableListOf<RentalEvent>()
+        val lauscher = launch { ereignisse += vm.events.first() }
+        vm.load()
+        advanceUntilIdle()
+
+        vm.saveProfile(name = "Erika Musterfrau", phone = "  ", addressStreet = "Hauptstraße 1", addressZip = "", addressCity = "Nordstemmen")
+        advanceUntilIdle()
+        lauscher.join()
+
+        // Ein leeres Feld ist kein Weg, einen Wert zu löschen — es bleibt weg.
+        assertEquals("Erika Musterfrau", repo.lastPatch?.name)
+        assertNull(repo.lastPatch?.phone)
+        assertNull(repo.lastPatch?.addressZip)
+        assertEquals(listOf(RentalEvent.ProfileSaved), ereignisse)
+        assertFalse(vm.state.value.savingProfile)
+    }
+
+    @Test
+    fun `ein leeres Formular geht gar nicht erst hinaus`() = runTest(dispatcher) {
+        val repo = FakeRental()
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.saveProfile("", " ", "", "", "")
+        advanceUntilIdle()
+
+        assertNull(repo.lastPatch)
+    }
+
+    @Test
+    fun `misslingt das Speichern, sagt es der Server und nicht die App`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            updateFailure = RentalApiException(RentalErrorCode.BAD_REQUEST, "Leerer Wert")
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.saveProfile("Erika", "", "", "", "")
+        advanceUntilIdle()
+
+        assertEquals(RentalErrorCode.BAD_REQUEST, vm.state.value.notice?.code)
+        assertEquals("Leerer Wert", vm.state.value.notice?.text)
+        assertFalse(vm.state.value.savingProfile)
+    }
+
+    /**
+     * „Ich möchte auch verleihen" ist eine Eingangsbestätigung, keine
+     * Freischaltung — entschieden wird drüben, von Hand.
+     */
+    @Test
+    fun `die Anfrage als Verleiher zeigt den Satz der Plattform`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            lenderReceipt = LenderRequest(LenderStatus.PENDING, "Deine Anfrage liegt vor.")
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.askToLend()
+        advanceUntilIdle()
+
+        assertEquals("Deine Anfrage liegt vor.", vm.state.value.lenderMessage)
+        assertFalse(vm.state.value.askingToLend)
+    }
+
+    @Test
+    fun `eine zu schnelle Verleiher-Anfrage bleibt eine Auskunft`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            lenderFailure = RentalApiException(RentalErrorCode.RATE_LIMITED, "Später noch einmal")
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.askToLend()
+        advanceUntilIdle()
+
+        assertEquals(RentalErrorCode.RATE_LIMITED, vm.state.value.notice?.code)
+        assertNull(vm.state.value.lenderMessage)
+    }
+
+    // --- Meine Vermietung ---------------------------------------------------
+
+    /**
+     * Die Vermieteransicht hängt an genau einem Feld der Plattform. Die App
+     * rechnet daran nichts nach — auch nicht an der Zahl eigener Geräte.
+     */
+    @Test
+    fun `die Vermieteransicht erscheint nur bei approved`() = runTest(dispatcher) {
+        val repo = FakeRental().apply { profile = profil() }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+        assertFalse(vm.state.value.showsLenderArea)
+        assertTrue(vm.state.value.canAskToLend)
+
+        repo.profile = profil(lenderStatus = LenderStatus.APPROVED)
+        vm.loadProfile()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.showsLenderArea)
+        // Wer freigeschaltet ist, wird nicht mehr gefragt, ob er möchte.
+        assertFalse(vm.state.value.canAskToLend)
+    }
+
+    @Test
+    fun `die Vermieterseite holt Anfragen, Geraete und Sperren`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            profile = profil(lenderStatus = LenderStatus.APPROVED)
+            ownerBookings = listOf(anfrage("a-1"), anfrage("a-2", canDecide = false))
+            ownerDevices = listOf(RentalOwnerDevice(geraet("maeher"), active = false))
+            blocks = listOf(sperre("s-1"))
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.showOwner()
+        advanceUntilIdle()
+
+        assertEquals(RentalPage.OWNER, vm.state.value.page)
+        assertEquals(2, vm.state.value.ownerBookings.size)
+        // Offen ist, was der Server für entscheidbar hält.
+        assertEquals(1, vm.state.value.waitingRequests)
+        assertEquals(1, vm.state.value.ownerDevices.size)
+        assertFalse(vm.state.value.ownerDevices.first().active)
+        assertEquals(1, vm.state.value.blocks.size)
+        assertFalse(vm.state.value.ownerOffline)
+    }
+
+    /** Ein missglückter Abruf leert keine Liste. */
+    @Test
+    fun `ohne Netz bleiben die Anfragen stehen`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            profile = profil(lenderStatus = LenderStatus.APPROVED)
+            ownerBookings = listOf(anfrage("a-1"))
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+        vm.showOwner()
+        advanceUntilIdle()
+
+        repo.ownerFailure = IOException("kein Netz")
+        vm.loadOwner()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.ownerOffline)
+        assertEquals(1, vm.state.value.ownerBookings.size)
+    }
+
+    @Test
+    fun `zusagen holt danach die Liste des Servers`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            profile = profil(lenderStatus = LenderStatus.APPROVED)
+            ownerBookings = listOf(anfrage("a-1"))
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        val ereignisse = mutableListOf<RentalEvent>()
+        val lauscher = launch { ereignisse += vm.events.first() }
+        vm.load()
+        advanceUntilIdle()
+        vm.showOwner()
+        advanceUntilIdle()
+        val vorher = repo.ownerCalls
+
+        vm.approve("a-1")
+        advanceUntilIdle()
+        lauscher.join()
+
+        assertEquals(listOf("a-1"), repo.approved)
+        assertEquals(listOf(RentalEvent.Approved), ereignisse)
+        // Was gerade geschehen ist, weiß die Plattform besser als der Schirm.
+        assertEquals(vorher + 1, repo.ownerCalls)
+        assertTrue(vm.state.value.deciding.isEmpty())
+    }
+
+    @Test
+    fun `absagen meldet es und holt die Liste ebenso`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            profile = profil(lenderStatus = LenderStatus.APPROVED)
+            ownerBookings = listOf(anfrage("a-1"))
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.reject("a-1")
+        advanceUntilIdle()
+
+        assertEquals(listOf("a-1"), repo.rejected)
+        assertTrue(vm.state.value.deciding.isEmpty())
+    }
+
+    @Test
+    fun `zweimal auf Zusagen tippen sagt nicht zweimal zu`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            profile = profil(lenderStatus = LenderStatus.APPROVED)
+            ownerBookings = listOf(anfrage("a-1"))
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.approve("a-1")
+        vm.approve("a-1")
+        advanceUntilIdle()
+
+        assertEquals(listOf("a-1"), repo.approved)
+    }
+
+    @Test
+    fun `eine nicht mehr offene Anfrage meldet den Grund des Servers`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            profile = profil(lenderStatus = LenderStatus.APPROVED)
+            ownerBookings = listOf(anfrage("a-1"))
+            decideFailure = RentalApiException(RentalErrorCode.CONFLICT, "Nicht mehr offen")
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.approve("a-1")
+        advanceUntilIdle()
+
+        assertEquals(RentalErrorCode.CONFLICT, vm.state.value.notice?.code)
+        assertEquals("Nicht mehr offen", vm.state.value.notice?.text)
+        assertTrue(vm.state.value.deciding.isEmpty())
+    }
+
+    // --- Sperren ------------------------------------------------------------
+
+    /**
+     * Der Kalender gibt die Tage her, an denen jemand sein Gerät braucht; der
+     * Vertrag will den Rückgabetag. Umgerechnet wird an einer Stelle.
+     */
+    @Test
+    fun `eine Sperre geht mit dem Rueckgabetag hinaus`() = runTest(dispatcher) {
+        val repo = FakeRental().apply { profile = profil(lenderStatus = LenderStatus.APPROVED) }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.openBlock("maeher")
+        vm.addBlock(
+            RentalPeriod.ofPickedDays(LocalDate.parse("2026-10-01"), LocalDate.parse("2026-10-07")),
+            "Eigener Einsatz",
+        )
+        advanceUntilIdle()
+
+        assertEquals("maeher", repo.lastBlock?.deviceId)
+        assertEquals(LocalDate.parse("2026-10-08"), repo.lastBlock?.period?.end)
+        assertEquals("Eigener Einsatz", repo.lastBlock?.reason)
+        // Erst wenn die Plattform die Sperre genommen hat, schließt das Blatt.
+        assertNull(vm.state.value.blockDeviceId)
+        assertEquals(1, vm.state.value.blocks.size)
+    }
+
+    @Test
+    fun `eine abgelehnte Sperre laesst das Blatt offen`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            profile = profil(lenderStatus = LenderStatus.APPROVED)
+            blockFailure = RentalApiException(RentalErrorCode.OCCUPIED, "Da liegt schon etwas")
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.openBlock("maeher")
+        vm.addBlock(zeitraum("2026-10-01", "2026-10-08"))
+        advanceUntilIdle()
+
+        assertEquals("maeher", vm.state.value.blockDeviceId)
+        assertEquals(RentalErrorCode.OCCUPIED, vm.state.value.notice?.code)
+        assertFalse(vm.state.value.blocking)
+    }
+
+    @Test
+    fun `ohne geoeffnetes Blatt wird nichts gesperrt`() = runTest(dispatcher) {
+        val repo = FakeRental().apply { profile = profil(lenderStatus = LenderStatus.APPROVED) }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.addBlock(zeitraum("2026-10-01", "2026-10-08"))
+        advanceUntilIdle()
+
+        assertNull(repo.lastBlock)
+    }
+
+    @Test
+    fun `eine Sperre laesst sich wieder aufheben`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            profile = profil(lenderStatus = LenderStatus.APPROVED)
+            blocks = listOf(sperre("s-1"))
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+        vm.showOwner()
+        advanceUntilIdle()
+
+        vm.removeBlock("s-1")
+        advanceUntilIdle()
+
+        assertEquals(listOf("s-1"), repo.removedBlocks)
+        assertTrue(vm.state.value.blocks.isEmpty())
+        assertTrue(vm.state.value.deciding.isEmpty())
+    }
+
+    // --- Die Seiten des Bereichs --------------------------------------------
+
+    @Test
+    fun `das Profil wird beim Aufschlagen frisch geholt`() = runTest(dispatcher) {
+        val repo = FakeRental()
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        repo.profile = profil(lenderStatus = LenderStatus.APPROVED)
+        vm.showProfile()
+        advanceUntilIdle()
+
+        assertEquals(RentalPage.PROFILE, vm.state.value.page)
+        assertEquals(LenderStatus.APPROVED, vm.state.value.profile?.lenderStatus)
+    }
+
+    /**
+     * Die Anfragen tragen Namen und Nummern anderer Menschen. Wer nicht
+     * angemeldet ist, darf sie nicht weiter auf dem Schirm haben — und steht
+     * wieder im Katalog.
+     */
+    @Test
+    fun `eine verlorene Anmeldung raeumt die Vermieterseite ab`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            profile = profil(lenderStatus = LenderStatus.APPROVED)
+            ownerBookings = listOf(anfrage("a-1"))
+            blocks = listOf(sperre("s-1"))
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+        vm.showOwner()
+        advanceUntilIdle()
+        assertEquals(1, vm.state.value.ownerBookings.size)
+
+        repo.ownerFailure = RentalApiException(RentalErrorCode.UNAUTHORIZED, null)
+        vm.loadOwner()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.ownerBookings.isEmpty())
+        assertTrue(vm.state.value.blocks.isEmpty())
+        assertEquals(RentalPage.CATALOG, vm.state.value.page)
+        assertFalse(vm.state.value.signedIn)
+    }
+
+    /** Ein Token von vor der Umstellung heißt „neu anmelden", nicht „leer". */
+    @Test
+    fun `ein veraltetes Token auf der Vermieterseite bittet um Anmeldung`() = runTest(dispatcher) {
+        val repo = FakeRental().apply {
+            profile = profil(lenderStatus = LenderStatus.APPROVED)
+            ownerFailure = RentalApiException(RentalErrorCode.TOKEN_AUDIENCE, null)
+        }
+        val vm = vm(repo, RentalSignIn.VALID)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.showOwner()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.staleSignIn)
+        assertEquals(RentalPage.CATALOG, vm.state.value.page)
     }
 }

--- a/android/e2e/fixtures/mieten/README.md
+++ b/android/e2e/fixtures/mieten/README.md
@@ -14,14 +14,30 @@ Testdatei wäre eine Einladung dazu.
 | `items.json` | 1 — `GET /api/v1/items` |
 | `item-detail.json` | 2 — `GET /api/v1/items/{id}` |
 | `search.json` | 3 — `GET /api/v1/search` |
+| `sets.json` | 4 — `GET /api/v1/sets` |
 | `availability-free.json`, `availability-taken.json` | 5 — `GET /api/v1/availability` |
 | `occupancy.json` | 6 — `GET /api/v1/occupancy` |
-| `me.json` | 7 — `GET /api/v1/me` |
+| `me.json`, `me-lender.json` | 7 — `GET /api/v1/me` |
+| `me-updated.json` | 8 — `PATCH /api/v1/me` |
+| `lender-request.json` | 9 — `POST /api/v1/me/lender-request` |
 | `my-bookings.json` | 10 — `GET /api/v1/bookings/mine` |
 | `booking-created.json` | 11 — `POST /api/v1/bookings` |
+| `status-cancelled.json` | 12 — `POST /api/v1/bookings/{id}/cancel` |
+| `owner-bookings.json` | 13 — `GET /api/v1/owner/bookings` |
+| `status-approved.json` | 14 — `POST /api/v1/bookings/{id}/approve` |
+| `owner-items.json` | 16 — `GET /api/v1/owner/items` |
+| `blocks.json` | 17 — `GET /api/v1/owner/blocks` |
+| `block-created.json` | 18 — `POST /api/v1/owner/blocks` |
+| `block-deleted.json` | 19 — `DELETE /api/v1/owner/blocks/{id}` |
 | `error-occupied.json` | 409 auf Route 11 |
+| `error-block-occupied.json` | 409 auf Route 18 |
 | `error-profile-incomplete.json` | 400 auf Route 11 |
+| `error-not-a-lender.json` | 403 auf den Routen 13 bis 19 |
+| `error-conflict.json` | 409 auf den Routen 12, 14 und 15 |
 | `error-token-audience.json` | 401 auf jeder angemeldeten Route |
 
-Sets (Route 4) und die Vermieterseite (Routen 13 bis 19) hat der Bereich
-bewusst nicht — deshalb liegen dafür auch keine Beispiele hier.
+Route 15 (`reject`) antwortet in derselben Form wie Route 14, nur mit
+`"rejected"`; dafür liegt keine eigene Datei hier, sondern der Test setzt den
+einen Wert selbst. `me-lender.json` ist dasselbe Profil wie `me.json`, nur mit
+`lenderStatus: "approved"` — daran entscheidet sich, ob die Vermieteransicht
+überhaupt erscheint.

--- a/android/e2e/fixtures/mieten/block-created.json
+++ b/android/e2e/fixtures/mieten/block-created.json
@@ -1,0 +1,10 @@
+{
+  "block": {
+    "id": "b1f0c9a2-33aa-4d10-8e77-5c2b1a9f0e33",
+    "deviceId": "as-585-km-kreiselmaeher",
+    "deviceName": "AS 585 KM Kreiselmäher",
+    "startDate": "2026-10-01",
+    "endDate": "2026-10-08",
+    "reason": "Eigener Einsatz"
+  }
+}

--- a/android/e2e/fixtures/mieten/block-deleted.json
+++ b/android/e2e/fixtures/mieten/block-deleted.json
@@ -1,0 +1,1 @@
+{ "deleted": true }

--- a/android/e2e/fixtures/mieten/blocks.json
+++ b/android/e2e/fixtures/mieten/blocks.json
@@ -1,0 +1,12 @@
+{
+  "blocks": [
+    {
+      "id": "b1f0c9a2-33aa-4d10-8e77-5c2b1a9f0e33",
+      "deviceId": "as-585-km-kreiselmaeher",
+      "deviceName": "AS 585 KM Kreiselmäher",
+      "startDate": "2026-10-01",
+      "endDate": "2026-10-08",
+      "reason": "Eigener Einsatz"
+    }
+  ]
+}

--- a/android/e2e/fixtures/mieten/error-block-occupied.json
+++ b/android/e2e/fixtures/mieten/error-block-occupied.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": "occupied",
+    "message": "In diesem Zeitraum liegt schon eine Buchung oder eine Sperre"
+  }
+}

--- a/android/e2e/fixtures/mieten/error-conflict.json
+++ b/android/e2e/fixtures/mieten/error-conflict.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": "conflict",
+    "message": "Die Buchung ist nicht mehr offen"
+  }
+}

--- a/android/e2e/fixtures/mieten/error-not-a-lender.json
+++ b/android/e2e/fixtures/mieten/error-not-a-lender.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": "not_a_lender",
+    "message": "Diese Handlung ist nur für freigeschaltete Vermieter"
+  }
+}

--- a/android/e2e/fixtures/mieten/lender-request.json
+++ b/android/e2e/fixtures/mieten/lender-request.json
@@ -1,0 +1,4 @@
+{
+  "lenderStatus": "pending",
+  "message": "Deine Anfrage wurde weitergeleitet. Du bekommst eine E-Mail, sobald dein Zugang freigeschaltet ist."
+}

--- a/android/e2e/fixtures/mieten/me-lender.json
+++ b/android/e2e/fixtures/mieten/me-lender.json
@@ -1,0 +1,14 @@
+{
+  "profile": {
+    "name": "Erika Musterfrau",
+    "email": "erika@example.invalid",
+    "phone": "+49 5069 123456",
+    "addressStreet": "Hauptstraße 1",
+    "addressZip": "31171",
+    "addressCity": "Nordstemmen",
+    "lender": true,
+    "lenderStatus": "approved",
+    "profileComplete": true,
+    "missingFields": []
+  }
+}

--- a/android/e2e/fixtures/mieten/me-updated.json
+++ b/android/e2e/fixtures/mieten/me-updated.json
@@ -1,0 +1,14 @@
+{
+  "profile": {
+    "name": "Erika Musterfrau",
+    "email": "erika@example.invalid",
+    "phone": "+49 5069 987654",
+    "addressStreet": "Hauptstraße 1",
+    "addressZip": "31171",
+    "addressCity": "Nordstemmen",
+    "lender": false,
+    "lenderStatus": "none",
+    "profileComplete": true,
+    "missingFields": []
+  }
+}

--- a/android/e2e/fixtures/mieten/owner-bookings.json
+++ b/android/e2e/fixtures/mieten/owner-bookings.json
@@ -1,0 +1,30 @@
+{
+  "bookings": [
+    {
+      "id": "8f14c2b0-91ae-4c77-b1b2-0a3d5e7c9f01",
+      "deviceId": "as-585-km-kreiselmaeher",
+      "deviceName": "AS 585 KM Kreiselmäher",
+      "startDate": "2026-09-05",
+      "endDate": "2026-09-07",
+      "status": "pending",
+      "renterName": "Erika Musterfrau",
+      "renterPhone": "+49 5069 123456",
+      "notes": "Hole ich Samstag früh ab.",
+      "canDecide": true,
+      "canCancel": true
+    },
+    {
+      "id": "1c9e77a3-1234-4bb8-9a0e-77ce31d2a456",
+      "deviceId": "018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11",
+      "deviceName": "Rasenwalze",
+      "startDate": "2026-10-01",
+      "endDate": "2026-10-03",
+      "status": "approved",
+      "renterName": "Heinz Beispiel",
+      "renterPhone": null,
+      "notes": null,
+      "canDecide": false,
+      "canCancel": true
+    }
+  ]
+}

--- a/android/e2e/fixtures/mieten/owner-items.json
+++ b/android/e2e/fixtures/mieten/owner-items.json
@@ -1,0 +1,32 @@
+{
+  "items": [
+    {
+      "id": "as-585-km-kreiselmaeher",
+      "name": "AS 585 KM Kreiselmäher",
+      "description": "Kreiselmäher für hohes Gras und Böschungen.",
+      "pricePerDay": 25,
+      "pricePerWeekend": 40,
+      "pricePerWeek": 120,
+      "deposit": 100,
+      "tags": ["garten", "motorgeraet"],
+      "thumbnailUrl": "https://cdn.example.invalid/sIgn/resize:fill:600:450/plain/local:///items/as-585-km-kreiselmaeher/front.jpg",
+      "productUrl": null,
+      "webUrl": "https://mieten.example.invalid/geraete/as-585-km-kreiselmaeher/",
+      "active": true
+    },
+    {
+      "id": "018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11",
+      "name": "Rasenwalze",
+      "description": null,
+      "pricePerDay": 8,
+      "pricePerWeekend": null,
+      "pricePerWeek": null,
+      "deposit": null,
+      "tags": ["garten"],
+      "thumbnailUrl": null,
+      "productUrl": null,
+      "webUrl": "https://mieten.example.invalid/geraete/018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11/",
+      "active": false
+    }
+  ]
+}

--- a/android/e2e/fixtures/mieten/sets.json
+++ b/android/e2e/fixtures/mieten/sets.json
@@ -1,0 +1,24 @@
+{
+  "sets": [
+    {
+      "id": "gartenset",
+      "name": "Gartenset",
+      "description": "Vertikutierer, Rasenwalze und Streuwagen zusammen.",
+      "pricePerDay": 30,
+      "deposit": 150,
+      "itemIds": [
+        "018f2c1a-7b3d-4e91-9a0c-2f5d8e6b4a11",
+        "vertikutierer",
+        "streuwagen"
+      ]
+    },
+    {
+      "id": "malerset",
+      "name": "Malerset",
+      "description": null,
+      "pricePerDay": 12,
+      "deposit": null,
+      "itemIds": ["leiter", "farbrolle"]
+    }
+  ]
+}

--- a/android/e2e/fixtures/mieten/status-approved.json
+++ b/android/e2e/fixtures/mieten/status-approved.json
@@ -1,0 +1,1 @@
+{ "status": "approved" }

--- a/android/e2e/fixtures/mieten/status-cancelled.json
+++ b/android/e2e/fixtures/mieten/status-cancelled.json
@@ -1,0 +1,1 @@
+{ "status": "cancelled" }


### PR DESCRIPTION
Der Maschinchenring lag seit gestern in beiden Apps — aber nicht gleich weit:
iOS bediente alle 19 Routen des Vertrags, Android neun. Wer das falsche
Telefon hatte, sah etwas anderes als der Nachbar. Dieser Zweig holt Android
nach.

## Was jetzt beide Fassungen können

| Route | | vorher iOS | vorher Android | jetzt |
| --- | --- | --- | --- | --- |
| 1, 2, 3, 5, 6 | ansehen, suchen, Verfügbarkeit, Belegung | ✓ | ✓ | ✓ |
| 4 | Sets ansehen | ✓ | — | ✓ |
| 7 | Profil lesen | ✓ | ✓ | ✓ |
| 8 | Profil ändern | ✓ | — | ✓ |
| 9 | „Ich möchte auch verleihen" | ✓ | — | ✓ |
| 10, 11, 12 | eigene Buchungen, buchen, stornieren | ✓ | ✓ | ✓ |
| 13, 14, 15 | Anfragen auf meinen Geräten, zusagen, absagen | ✓ | — | ✓ |
| 16 | meine Geräte, samt der abgeschalteten | ✓ | — | ✓ |
| 17, 18, 19 | Sperren ansehen, anlegen, aufheben | ✓ | — | ✓ |

Der Bereich ist auf Android jetzt ein Katalog mit zwei Räumen dahinter:
**„Mein Profil im Maschinchenring"** führt aus dem Katalog, **„Meine
Vermietung"** aus dem Profil. Zurück geht erst in den Katalog und dann aus dem
Bereich. Die Bedienelemente sind die des Systems (Karten, ein Blatt für die
Sperre, der Material-Datumsbereich) — der Funktionsumfang ist derselbe wie
drüben.

## Was die App weiterhin nicht entscheidet

- Die Vermieteransicht erscheint **allein**, weil die Plattform
  `lenderStatus: "approved"` meldet. Keine zweite Prüfung daneben, auch nicht
  über die Zahl eigener Geräte.
- Zusagen und absagen richten sich nach `canDecide`, stornieren nach
  `canCancel`.
- Eine Sperre verdrängt keine Buchung: Der Server antwortet `occupied`, das
  Blatt bleibt mit seiner Meldung offen, damit das Getippte nicht verloren
  geht.
- Beim Profil gehen nur ausgefüllte Felder hinaus. Ein leeres Feld ist beim
  Server kein Weg, einen Wert zu löschen, sondern ein `bad_request`.
- Geht die Anmeldung verloren oder gilt das Token drüben nicht mehr, werden
  Anfragen, Geräte und Sperren geräumt und der Bereich steht wieder im
  Katalog — dort stehen Namen und Telefonnummern anderer Menschen.

## Was bewusst weiterhin fehlt — auf beiden Seiten

- **Geräte anlegen und ändern.** Der Vertrag hat dafür keine Route; das läuft
  im Chat und in der Webfassung der Mietplattform und soll dort bleiben.
- **Sets buchen.** Angezeigt ja, gebucht nein: Stornieren, Bestätigen und
  Ablehnen einer Set-Buchung ist serverseitig nicht umgesetzt und antwortet
  mit `409 conflict`.
- **Bilder hochladen, eine Preisberechnung, Push für den Verleih.** Steht so
  in `docs/mieten-api.md`, Abschnitt 3.
- **Die `/api/v1/…`-Routen sind drüben noch nicht ausgerollt.** Bis dahin
  zeigt der Bereich seinen „nicht erreichbar"-Hinweis über der (womöglich
  älteren) Liste statt einer leeren Seite — geprüft ist das als eigener Fall.

## Wie geprüft wurde

- `cd android && ./gradlew testDebugUnitTest assembleDebug assembleDebugAndroidTest`
  — 238 Unit-Tests grün, die Instrumentierung übersetzt. Hier läuft kein
  Emulator; ausgeführt wird sie in der CI.
- `python3 .github/scripts/pruefe_lokale_tests.py` — 109 Dateien, kein Zugriff
  nach draußen.
- Neue Beispielantworten unter `android/e2e/fixtures/mieten/` (Sets, Profil
  ändern, Verleiher-Anfrage, Vermieterseite, Sperren, `not_a_lender`,
  `conflict`, `occupied` auf einer Sperre), **wörtlich aus dem Vertrag**, mit
  Adressen auf `example.invalid`. `RentalApiTest` liest sie und prüft
  Methode, Pfad und Körper — ein geänderter Vertrag fällt dort auf und nicht
  erst als leere Liste auf dem Telefon.
- Neue Unit-Tests am ViewModel: Sets neben den Geräten (und keine Sets bei
  einer Suche), das Profil schickt nur Ausgefülltes, die Verleiher-Anfrage als
  Eingangsbestätigung, die Vermieteransicht nur bei `approved`, zusagen holt
  danach die Liste des Servers, ein Doppeltipp sagt nicht zweimal zu, die
  Sperre geht mit dem Rückgabetag hinaus, eine abgelehnte Sperre lässt das
  Blatt offen, eine verlorene Anmeldung räumt die Vermieterseite ab.
- Neue Oberflächen-Tests: Sets in der Liste, der Weg ins Profil und zurück,
  Speichern, kein Weg zur Vermietung ohne Freischaltung, mit Freischaltung
  Anfragen mit Name und abgeschaltete Geräte, zusagen, Sperre aufheben.

Keine neue Abhängigkeit, kein DI-Framework, alle sichtbaren Texte in
`strings.xml`.

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfZ9C5s2meH45APq947FXT
