### PR TITLE
Außer Dienst sieht in beiden Apps auch so aus

### DIFF
--- a/android/app/src/main/java/de/roessing/app/data/Model.kt
+++ b/android/app/src/main/java/de/roessing/app/data/Model.kt
@@ -3,8 +3,19 @@ package de.roessing.app.data
 import kotlinx.serialization.Serializable
 
 /** Ampel-Status — Werte kommen 1:1 vom Backend. */
-enum class CareStatus { green, yellow, red }
+/**
+ * `dormant` heißt: außer Dienst. Die Aufgabe fällt zu dieser Jahreszeit nicht
+ * an — das Beet wird im Winter nicht gejätet. Sie ist dann weder fällig noch
+ * gelb noch rot, und es fragt auch niemand nach Helfern.
+ */
+enum class CareStatus { green, yellow, red, dormant }
 
+/**
+ * Ein unbekannter Zustand fällt auf grün zurück, statt die Antwort zu kosten.
+ * Das ist Absicht — ein neuer Wert vom Server darf eine ältere App nicht
+ * lahmlegen —, kostet aber Genauigkeit: Genau so hat diese App `dormant` eine
+ * Zeitlang als „Alles gut" angezeigt.
+ */
 private fun parseStatus(raw: String): CareStatus =
     runCatching { CareStatus.valueOf(raw) }.getOrDefault(CareStatus.green)
 

--- a/android/app/src/main/java/de/roessing/app/ui/PlaceList.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/PlaceList.kt
@@ -46,6 +46,7 @@ fun statusColor(status: CareStatus) = when (status) {
     CareStatus.green -> statusFarben.gruen
     CareStatus.yellow -> statusFarben.gelb
     CareStatus.red -> statusFarben.rot
+    CareStatus.dormant -> statusFarben.ruhend
 }
 
 /** Flächenfarbe hinter einem Status (Plaketten). */
@@ -54,6 +55,7 @@ fun statusFlaeche(status: CareStatus) = when (status) {
     CareStatus.green -> statusFarben.gruenFlaeche
     CareStatus.yellow -> statusFarben.gelbFlaeche
     CareStatus.red -> statusFarben.rotFlaeche
+    CareStatus.dormant -> statusFarben.ruhendFlaeche
 }
 
 /** Status als Plakette: Punkt plus Text, gut sichtbar und gut lesbar. */
@@ -85,6 +87,7 @@ fun statusLabel(status: CareStatus): String = when (status) {
     CareStatus.green -> stringResource(R.string.status_green)
     CareStatus.yellow -> stringResource(R.string.status_yellow)
     CareStatus.red -> stringResource(R.string.status_red)
+    CareStatus.dormant -> stringResource(R.string.status_dormant)
 }
 
 /** Statustext einer einzelnen Aufgabe — hier passt die Aufgabenart dazu. */
@@ -103,6 +106,13 @@ fun taskStatusLabel(kind: String, status: CareStatus): String = when (status) {
             "giessen" -> R.string.status_red_watering
             "jaeten" -> R.string.status_red_weeding
             else -> R.string.status_red
+        },
+    )
+    CareStatus.dormant -> stringResource(
+        when (kind) {
+            "giessen" -> R.string.status_dormant_watering
+            "jaeten" -> R.string.status_dormant_weeding
+            else -> R.string.status_dormant
         },
     )
 }

--- a/android/app/src/main/java/de/roessing/app/ui/theme/Theme.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/theme/Theme.kt
@@ -45,27 +45,34 @@ data class StatusFarben(
     val gruen: Color,
     val gelb: Color,
     val rot: Color,
+    /** Außer Dienst: grau. Was nicht ansteht, fordert zu nichts auf. */
+    val ruhend: Color,
     val gruenFlaeche: Color,
     val gelbFlaeche: Color,
     val rotFlaeche: Color,
+    val ruhendFlaeche: Color,
 )
 
 private val StatusHell = StatusFarben(
     gruen = Color(0xFF1B5E20),
     gelb = Color(0xFF7A5200),
     rot = Color(0xFFB3261E),
+    ruhend = Color(0xFF4A4E52),
     gruenFlaeche = Color(0xFFD7F0D3),
     gelbFlaeche = Color(0xFFFDECC8),
     rotFlaeche = Color(0xFFFCDAD6),
+    ruhendFlaeche = Color(0xFFE6E8EA),
 )
 
 private val StatusDunkel = StatusFarben(
     gruen = Color(0xFF9BE3A2),
     gelb = Color(0xFFFFD479),
     rot = Color(0xFFFFB4AB),
+    ruhend = Color(0xFFC4C8CC),
     gruenFlaeche = Color(0xFF23422A),
     gelbFlaeche = Color(0xFF4A3A12),
     rotFlaeche = Color(0xFF5C2420),
+    ruhendFlaeche = Color(0xFF34383C),
 )
 
 val LocalStatusFarben = staticCompositionLocalOf { StatusHell }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -64,6 +64,9 @@
     <string name="status_green">Alles gut</string>
     <string name="status_yellow">Bitte erledigen</string>
     <string name="status_red">Dringend!</string>
+    <string name="status_dormant">Außer Dienst</string>
+    <string name="status_dormant_watering">Wird jetzt nicht gegossen</string>
+    <string name="status_dormant_weeding">Wird jetzt nicht gejätet</string>
     <string name="status_yellow_watering">Bitte gießen</string>
     <string name="status_red_watering">Dringend gießen!</string>
     <string name="status_yellow_weeding">Bitte jäten</string>

--- a/android/app/src/test/java/de/roessing/app/AusserDienstTest.kt
+++ b/android/app/src/test/java/de/roessing/app/AusserDienstTest.kt
@@ -1,0 +1,34 @@
+package de.roessing.app
+
+import de.roessing.app.data.CareStatus
+import de.roessing.app.data.PlaceDto
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Eine Aufgabe, die zu dieser Jahreszeit nicht anfällt, ist nicht „grün".
+ * Grün hieße „alles gut" — eine Aussage über etwas, das gerade gar nicht
+ * ansteht. Das Beet vor dem Dorfgemeinschaftshaus wird im Winter nicht
+ * gejätet, und genau das soll dort stehen.
+ */
+class AusserDienstTest {
+    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+
+    @Test
+    fun `ruhender Status wird gelesen`() {
+        val ort = json.decodeFromString<PlaceDto>(
+            """{"id":3,"name":"Beet","lat":52.18,"lon":9.81,"status":"dormant"}""",
+        )
+        assertEquals(CareStatus.dormant, ort.careStatus)
+    }
+
+    /** Ein Wert, den diese Fassung nicht kennt, darf die Antwort nicht kosten. */
+    @Test
+    fun `unbekannter Status kostet nicht die Antwort`() {
+        val ort = json.decodeFromString<PlaceDto>(
+            """{"id":9,"name":"Neu","lat":52.18,"lon":9.81,"status":"irgendwas"}""",
+        )
+        assertEquals(CareStatus.green, ort.careStatus)
+    }
+}

--- a/ios/Dorf/Daten/Modelle.swift
+++ b/ios/Dorf/Daten/Modelle.swift
@@ -20,8 +20,15 @@ nonisolated extension KeyedDecodingContainer {
 
 /// Ampel-Status — die Werte kommen unverändert vom Backend.
 nonisolated enum Ampel: String, Codable, Sendable {
-    case green, yellow, red
+    /// `dormant` heißt: außer Dienst. Die Aufgabe fällt zu dieser Jahreszeit
+    /// nicht an — das Beet wird im Winter nicht gejätet. Sie ist dann weder
+    /// fällig noch gelb noch rot, und es fragt auch niemand nach Helfern.
+    case green, yellow, red, dormant
 
+    /// Ein unbekannter Zustand fällt auf grün zurück statt die Antwort zu
+    /// kosten. Das ist Absicht — ein neuer Wert vom Server darf eine ältere
+    /// App nicht lahmlegen —, kostet aber Genauigkeit: Genau so hat diese App
+    /// `dormant` eine Zeitlang als „Alles gut" angezeigt.
     init(roh: String) { self = Ampel(rawValue: roh) ?? .green }
 }
 

--- a/ios/Dorf/Design/Ampel+Anzeige.swift
+++ b/ios/Dorf/Design/Ampel+Anzeige.swift
@@ -12,6 +12,10 @@ extension Ampel {
         case .green: return Color(red: 0.18, green: 0.56, blue: 0.24)
         case .yellow: return Color(red: 0.92, green: 0.65, blue: 0.08)
         case .red: return Color(red: 0.78, green: 0.20, blue: 0.16)
+        // Außer Dienst ist kein Zustand, der zum Handeln auffordert —
+        // deshalb grau und nicht grün. Grün hieße „alles gut", und das ist
+        // eine Aussage über etwas, das gerade gar nicht ansteht.
+        case .dormant: return Color(red: 0.55, green: 0.56, blue: 0.58)
         }
     }
 
@@ -26,6 +30,9 @@ extension Ampel {
         case (.red, "giessen"): return "Dringend gießen!"
         case (.red, "jaeten"): return "Dringend jäten!"
         case (.red, _): return "Dringend!"
+        case (.dormant, "giessen"): return "Wird jetzt nicht gegossen"
+        case (.dormant, "jaeten"): return "Wird jetzt nicht gejätet"
+        case (.dormant, _): return "Außer Dienst"
         }
     }
 
@@ -35,6 +42,7 @@ extension Ampel {
         case .green: return "Status grün"
         case .yellow: return "Status gelb"
         case .red: return "Status rot"
+        case .dormant: return "Außer Dienst"
         }
     }
 
@@ -44,6 +52,8 @@ extension Ampel {
         case .red: return 0
         case .yellow: return 1
         case .green: return 2
+        // Ganz nach hinten: Was gerade nicht ansteht, steht auch nicht oben.
+        case .dormant: return 3
         }
     }
 }

--- a/ios/DorfTests/ModelleTests.swift
+++ b/ios/DorfTests/ModelleTests.swift
@@ -113,3 +113,43 @@ struct TraegerAmOrtTests {
         #expect(ort.traegerName.isEmpty)
     }
 }
+
+// MARK: - Außer Dienst
+
+/// Eine Aufgabe, die zu dieser Jahreszeit nicht anfällt, ist nicht „grün".
+/// Grün hieße „alles gut" — eine Aussage über etwas, das gerade gar nicht
+/// ansteht. Das Beet vor dem Dorfgemeinschaftshaus wird im Winter nicht
+/// gejätet, und genau das soll dort stehen.
+struct AusserDienstTests {
+    @Test func ruhenderStatusWirdGelesen() throws {
+        let roh = """
+        {"id":3,"name":"Beet","lat":52.18,"lon":9.81,"status":"dormant"}
+        """.data(using: .utf8)!
+        let ort = try JSONDecoder().decode(Ort.self, from: roh)
+        #expect(ort.ampel == .dormant)
+    }
+
+    @Test func ruhendSagtWasSacheIst() {
+        #expect(Ampel.dormant.text(fuer: "jaeten") == "Wird jetzt nicht gejätet")
+        #expect(Ampel.dormant.text(fuer: "giessen") == "Wird jetzt nicht gegossen")
+        #expect(Ampel.dormant.text() == "Außer Dienst")
+        // Die Farbe allein ist keine Information.
+        #expect(Ampel.dormant.vorlesetext == "Außer Dienst")
+    }
+
+    /// Was nicht ansteht, steht auch nicht oben in der Liste.
+    @Test func ruhendSortiertGanzNachHinten() {
+        let sortiert = [Ampel.dormant, .green, .red, .yellow]
+            .sorted { $0.dringlichkeit < $1.dringlichkeit }
+        #expect(sortiert == [.red, .yellow, .green, .dormant])
+    }
+
+    /// Ein Wert, den diese Fassung nicht kennt, darf die Antwort nicht kosten.
+    @Test func unbekannterStatusKostetNichtDieAntwort() throws {
+        let roh = """
+        {"id":9,"name":"Neu","lat":52.18,"lon":9.81,"status":"irgendwas"}
+        """.data(using: .utf8)!
+        let ort = try JSONDecoder().decode(Ort.self, from: roh)
+        #expect(ort.ampel == .green)
+    }
+}


### PR DESCRIPTION
Behebt #85, die Folgelücke aus #86.

## Warum

Seit #86 kennt das Backend einen vierten Ampel-Wert: `dormant` — außer Dienst. Das Beet vor dem Dorfgemeinschaftshaus wird von Oktober bis März nicht gejätet, und dann ist es weder fällig noch gelb noch rot.

Beide Apps kannten den Wert nicht. **Abgestürzt wäre nichts** — beide fallen bei unbekanntem Status auf Grün zurück —, aber genau das war das Problem: Das ruhende Beet hätte „Alles gut" gemeldet. Grün ist eine Aussage über etwas, das gerade gar nicht ansteht.

## Was jetzt da steht

| | vorher | jetzt |
| --- | --- | --- |
| Farbe | grün | grau |
| Text (Jäten) | „Alles gut" | „Wird jetzt nicht gejätet" |
| Text (Gießen) | „Alles gut" | „Wird jetzt nicht gegossen" |
| Text (sonst) | „Alles gut" | „Außer Dienst" |
| Sortierung | wie grün | ganz nach hinten |

Grau und nicht grün, weil außer Dienst kein Zustand ist, der zum Handeln auffordert. Ganz nach hinten, weil was nicht ansteht auch nicht oben steht. Für VoiceOver und TalkBack ein eigener Text — die Farbe allein ist keine Information. Auf Android gibt es die Grautöne für hell und dunkel getrennt, wie bei den anderen drei auch: Die kräftigen Kartenfarben wären auf dunklem Grund kaum lesbar.

## Der Rückfall auf Grün bleibt

Ein neuer Wert vom Server darf eine ältere App nicht lahmlegen. Er steht jetzt aber als Kommentar da, zusammen mit dem Fall, der ihn gekostet hat — damit beim nächsten neuen Statuswert jemand daran denkt, dass „stürzt nicht ab" und „sagt die Wahrheit" zwei verschiedene Dinge sind.

## Geprüft

- iOS: `xcodebuild test` — **245 Tests in 18 Suiten grün** (4 neu).
- Android: `./gradlew testDebugUnitTest assembleDebug` grün (2 neu).
- `pruefe_lokale_tests.py` grün.

Beide Fassungen, gleicher Umfang — nach `CLAUDE.md` ist ein Stand sonst nicht fertig.