### PR TITLE
Träger: Beitritt beantragen und freigeben, statt in Zitadel einzutragen

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,19 @@ keine der beiden Apps noch einmal.
   Betreiber-Rolle steckt im Token und bleibt davon unberührt — der Betreiber
   bleibt handlungsfähig. Kurz: Ein Ausfall macht die App vorsichtiger, nie
   großzügiger.
+- **Beitreten kann man in der App.** Wer einen offenen Träger im Verzeichnis
+  sieht, stellt dort einen Antrag; der Träger-Admin gibt frei oder lehnt ab
+  (`POST /api/v1/traeger/{id}/beitritt`, `POST /api/v1/beitritte/{id}`, in der
+  Verwaltung auf der Trägerseite, über MCP `beitritte_liste` und
+  `beitritt_entscheiden`). Die Freigabe **schreibt die Rolle `mitglied` nach
+  Zitadel zurück** — niemand muss mehr in die Konsole steigen, und die neue
+  Mitgliedschaft wirkt sofort. Ein erteilter Antrag ist dabei *nicht* die
+  Mitgliedschaft (anders als beim Befähigungsantrag): Die steht in der
+  Rössing-ID, hier steht nur der Vorgang. Klappt das Zurückschreiben nicht,
+  bleibt der Antrag offen und die Meldung nennt den Grund.
+  Eine **geschlossene** Gruppe nimmt keine Anträge entgegen — sie steht nicht
+  im Verzeichnis und holt sich ihre Leute selbst (`POST
+  /api/v1/traeger/{id}/mitglieder`, MCP `mitglied_aufnehmen`).
 - **Sichtbarkeit einer Aufgabe**: `oeffentlich` oder `nur_mitglieder`. Eine
   **geschlossene Gruppe kann sehr wohl öffentlich ausschreiben** — die
   Sichtbarkeit des Trägers betrifft nur das Verzeichnis. Umgekehrt gilt für
@@ -522,7 +535,7 @@ auf die Produktion.
 | `MCP_CLIENT_ID` | PKCE-Client für die MCP-Anbindung |
 | `SEED` | `1` → Beispieldaten anlegen, falls die DB leer ist |
 | `AUTH_AUDIENCE` | kommaseparierte Liste erlaubter Token-Empfänger — die Client-IDs der Anwendungen, die dieses Backend nutzen dürfen. **Im OIDC-Modus Pflicht:** ohne sie prüft das Backend nur Aussteller und Signatur, und ein Token für ein anderes Projekt derselben Rössing-ID käme durch. Der Server verweigert deshalb ohne diesen Wert den Start |
-| `ZITADEL_SERVICE_USER_KEY_FILE` | JSON-Schlüssel des Dienst-Nutzers, mit dem die Träger-Mitgliedschaften über die Management-API abgefragt werden. **Fehlt er, gibt es keine Träger-Rollen**: Dann verwaltet nur der Betreiber, und alle anderen sehen die öffentlichen Aufgaben. Der Betrieb läuft dabei unverändert weiter |
+| `ZITADEL_SERVICE_USER_KEY_FILE` | JSON-Schlüssel des Dienst-Nutzers, mit dem die Träger-Mitgliedschaften über die Management-API abgefragt **und bei einer Beitritts-Freigabe zurückgeschrieben** werden (dafür braucht er `user.grant.read` **und** `user.grant.write`, in Zitadel die Manager-Rolle `ORG_USER_PERMISSION_EDITOR`). **Fehlt er, gibt es keine Träger-Rollen**: Dann verwaltet nur der Betreiber, alle anderen sehen die öffentlichen Aufgaben, und eine Aufnahme scheitert mit einem Hinweis, statt still ins Leere zu laufen. Der Betrieb läuft dabei unverändert weiter |
 | `ZITADEL_ROLLEN_TTL` | Wie lange eine Mitgliedschafts-Auskunft als frisch gilt (Vorgabe `45s`) |
 | `RATE_LIMIT` | `off` schaltet die Zugriffsbegrenzung ab |
 | `RATE_LIMIT_BURST` / `RATE_LIMIT_PER_MINUTE` | Eimergröße (60) und Nachfüllrate pro Minute (120) |

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -164,7 +164,13 @@ func main() {
 		// MCP_CLIENT_ID: PKCE-Client, den Dynamic Client Registration
 		// (claude.ai) zurückbekommt.
 		mcpClientID := envOr("MCP_CLIENT_ID", "385946294599876803")
-		mcp.New(database, verifier, issuer, publicURL, mcpClientID).Register(mux)
+		mcpSrv := mcp.New(database, verifier, issuer, publicURL, mcpClientID)
+		// Damit MCP jemanden in einen Träger aufnehmen kann: Das schreibt
+		// die Rollenzuweisung in die Rössing-ID zurück (siehe
+		// internal/mitglied). Ohne Quelle sagen die Werkzeuge das und tun
+		// nichts, statt still ins Leere zu laufen.
+		mcpSrv.Mitglieder = mitglieder
+		mcpSrv.Register(mux)
 		slog.Info("MCP-Server aktiv unter /mcp (OAuth + DCR)", "issuer", issuer)
 		// Chat: dieselben Daten in normalem Deutsch, in der Sicht der
 		// fragenden Person. Ohne ANTHROPIC_API_KEY schaltet er sich ab.

--- a/backend/e2e/e2e_test.go
+++ b/backend/e2e/e2e_test.go
@@ -1313,6 +1313,124 @@ func TestEndToEnd(t *testing.T) {
 			t.Error("die Aufgabe eines gesperrten Trägers ist noch sichtbar")
 		}
 	})
+
+	// --- Beitritt: beantragen, freigeben, wirklich Mitglied sein -----------
+	//
+	// Der Punkt, an dem sich entscheidet, ob das Verfahren etwas taugt: Die
+	// Freigabe muss die Rollenzuweisung in Zitadel ZURÜCKSCHREIBEN. Geprüft
+	// wird deshalb nicht die eigene Datenbank, sondern die Management-API —
+	// und danach die Wirkung mit demselben Token, ohne neue Anmeldung.
+	t.Run("Träger: Beitritt beantragen und freigeben schreibt nach Zitadel zurück", func(t *testing.T) {
+		beitrittProjekt := zapi(t, iamToken, "POST", "/management/v1/projects",
+			map[string]any{"name": fmt.Sprintf("ak2-e2e-%d", time.Now().UnixNano())})
+		beitrittProjektID := beitrittProjekt["id"].(string)
+		for _, rolle := range []map[string]any{
+			{"roleKey": "admin", "displayName": "Verwaltung"},
+			{"roleKey": "mitglied", "displayName": "Mitglied"},
+		} {
+			zapi(t, iamToken, "POST", "/management/v1/projects/"+beitrittProjektID+"/roles", rolle)
+		}
+
+		resp, traeger := request(t, "POST", "/api/v1/traeger", adminToken, map[string]any{
+			"name": "AK 2 Umwelt und Natur", "projektId": beitrittProjektID,
+			"status": "zugelassen", "sichtbarkeit": "offen",
+		})
+		if resp.StatusCode != 201 {
+			t.Fatalf("Träger anlegen: HTTP %d: %v", resp.StatusCode, traeger)
+		}
+		traegerID := traeger["id"].(float64)
+
+		// Ein Vorstand mit der admin-Rolle des Arbeitskreises und jemand aus
+		// dem Dorf, der noch nirgends dabei ist.
+		vorstandUser := newMachine("AK2-Vorstand", nil)
+		zapi(t, iamToken, "POST", "/management/v1/users/"+vorstandUser.UserID+"/grants",
+			map[string]any{"projectId": beitrittProjektID, "roleKeys": []string{"admin"}})
+		vorstandToken := fetchToken(t, vorstandUser, scope)
+		neulingUser := newMachine("Dorf-Neuling", nil)
+		neulingToken := fetchToken(t, neulingUser, scope)
+
+		// „Ich will mitjäten.“
+		resp, antrag := request(t, "POST", fmt.Sprintf("/api/v1/traeger/%.0f/beitritt", traegerID),
+			neulingToken, map[string]any{"begruendung": "Ich wohne neben dem Beet"})
+		if resp.StatusCode != 201 {
+			t.Fatalf("Beitrittsantrag: HTTP %d: %v", resp.StatusCode, antrag)
+		}
+		antragID := antrag["id"].(float64)
+
+		// Niemand entscheidet über sich selbst.
+		resp, _ = request(t, "POST", fmt.Sprintf("/api/v1/beitritte/%.0f", antragID),
+			neulingToken, map[string]any{"status": "erteilt"})
+		if resp.StatusCode != 403 {
+			t.Errorf("Selbstaufnahme: HTTP %d, erwartet 403", resp.StatusCode)
+		}
+
+		resp, out := request(t, "POST", fmt.Sprintf("/api/v1/beitritte/%.0f", antragID),
+			vorstandToken, map[string]any{"status": "erteilt", "notiz": "willkommen"})
+		if resp.StatusCode != 200 {
+			t.Fatalf("Freigabe: HTTP %d: %v", resp.StatusCode, out)
+		}
+
+		// Der eigentliche Beweis: In Zitadel steht die Rolle.
+		grants := zapi(t, iamToken, "POST", "/management/v1/users/grants/_search", map[string]any{
+			"queries": []any{map[string]any{"userIdQuery": map[string]any{"userId": neulingUser.UserID}}},
+		})
+		eingetragen := false
+		for _, roh := range grants["result"].([]any) {
+			g := roh.(map[string]any)
+			if g["projectId"] != beitrittProjektID {
+				continue
+			}
+			for _, rolle := range g["roleKeys"].([]any) {
+				if rolle == "mitglied" {
+					eingetragen = true
+				}
+			}
+		}
+		if !eingetragen {
+			t.Fatalf("die Mitgliedschaft steht nicht in Zitadel: %v", grants["result"])
+		}
+
+		// Und sie wirkt sofort — derselbe Token, keine neue Anmeldung.
+		sichtbar := false
+		for i := 0; i < 20; i++ {
+			_, liste := request(t, "GET", "/api/v1/traeger", neulingToken, nil)
+			for _, roh := range liste["traeger"].([]any) {
+				tr := roh.(map[string]any)
+				if tr["id"] == traegerID && tr["istMitglied"] == true {
+					sichtbar = true
+				}
+			}
+			if sichtbar {
+				break
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+		if !sichtbar {
+			t.Fatal("die frisch erteilte Mitgliedschaft wirkt nicht ohne erneute Anmeldung")
+		}
+
+		// Ein zweites Mal beitreten gibt es nicht — man ist ja schon dabei.
+		resp, _ = request(t, "POST", fmt.Sprintf("/api/v1/traeger/%.0f/beitritt", traegerID),
+			neulingToken, map[string]any{})
+		if resp.StatusCode != 409 {
+			t.Errorf("zweiter Antrag: HTTP %d, erwartet 409", resp.StatusCode)
+		}
+
+		// Und der kurze Weg: aufnehmen ohne Antrag (so nimmt eine
+		// geschlossene Gruppe ihre Leute auf).
+		zweiterUser := newMachine("Dorf-Nachbarin", nil)
+		resp, out = request(t, "POST", fmt.Sprintf("/api/v1/traeger/%.0f/mitglieder", traegerID),
+			vorstandToken, map[string]any{"userSub": zweiterUser.UserID, "notiz": "auf der Versammlung gefragt"})
+		if resp.StatusCode != 200 {
+			t.Fatalf("Aufnehmen ohne Antrag: HTTP %d: %v", resp.StatusCode, out)
+		}
+		grants = zapi(t, iamToken, "POST", "/management/v1/users/grants/_search", map[string]any{
+			"queries": []any{map[string]any{"userIdQuery": map[string]any{"userId": zweiterUser.UserID}}},
+		})
+		if len(grants["result"].([]any)) == 0 {
+			t.Fatal("die Aufnahme ohne Antrag steht nicht in Zitadel")
+		}
+	})
 }
 
 // befaehigungErteilen stellt einen Antrag und gibt ihn gleich frei. Der

--- a/backend/internal/admin/beitritt.go
+++ b/backend/internal/admin/beitritt.go
@@ -1,0 +1,114 @@
+package admin
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/api"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Beitritte in der Web-Verwaltung: Wer mitmachen will, steht auf der Seite
+// seines Trägers — und wird dort aufgenommen oder abgelehnt.
+//
+// Der Knopf tut mehr, als es aussieht: Die Freigabe schreibt die
+// Rollenzuweisung in die Rössing-ID zurück (siehe api.Aufnehmen). Erst wenn
+// das geklappt hat, gilt der Antrag als erteilt. Scheitert es, bleibt er
+// offen und die Meldung sagt, woran es lag — nichts wäre schlimmer als eine
+// Verwaltung, die „aufgenommen“ meldet, während die Tür zu bleibt.
+
+func (a *App) beitrittEntscheiden(w http.ResponseWriter, r *http.Request, s session) {
+	t, z, ok := a.traegerAusPfad(w, r, s)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseInt(r.PathValue("bid"), 10, 64)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	b, err := a.db.GetBeitritt(id)
+	// Der Antrag muss zu genau diesem Träger gehören — sonst ließe sich über
+	// eine fremde Kennung an den Mitgliedern eines anderen Vereins drehen.
+	if err != nil || b.TraegerID != t.ID {
+		http.NotFound(w, r)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		a.fail(w, r, http.StatusBadRequest, err)
+		return
+	}
+	status := model.AntragStatus(r.FormValue("status"))
+	if status != model.AntragErteilt && status != model.AntragAbgelehnt {
+		a.setFlash(w, "error", "Unbekannte Entscheidung.")
+		a.zurueckZumTraeger(w, r, t.ID)
+		return
+	}
+	notiz := strings.TrimSpace(r.FormValue("notiz"))
+	if _, err := api.BeitrittEntscheiden(r.Context(), a.db, a.mitglieder, t, *b,
+		status, z.Sub, notiz, a.now()); err != nil {
+		a.setFlash(w, "error", fehlertext(err))
+		a.zurueckZumTraeger(w, r, t.ID)
+		return
+	}
+	name := b.UserName
+	if name == "" {
+		name = b.UserSub
+	}
+	if status == model.AntragErteilt {
+		a.setFlash(w, "success", zitat(name)+" ist jetzt Mitglied von "+zitat(t.Name)+
+			" — die Rolle steht in der Rössing-ID.")
+	} else {
+		a.setFlash(w, "success", "Der Beitrittsantrag von "+zitat(name)+" wurde abgelehnt.")
+	}
+	a.zurueckZumTraeger(w, r, t.ID)
+}
+
+// mitgliedAufnehmen trägt jemanden ohne vorherigen Antrag ein. Für die
+// geschlossene Gruppe, die keine Anträge entgegennimmt, ist das der einzige
+// Weg — und für die offene der kurze, wenn am Gartenzaun gefragt wurde.
+func (a *App) mitgliedAufnehmen(w http.ResponseWriter, r *http.Request, s session) {
+	t, z, ok := a.traegerAusPfad(w, r, s)
+	if !ok {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		a.fail(w, r, http.StatusBadRequest, err)
+		return
+	}
+	userSub := strings.TrimSpace(r.FormValue("userSub"))
+	notiz := strings.TrimSpace(r.FormValue("notiz"))
+	b, err := api.Aufnehmen(r.Context(), a.db, a.mitglieder, t, userSub, z.Sub, notiz, a.now())
+	if err != nil {
+		a.setFlash(w, "error", fehlertext(err))
+		a.zurueckZumTraeger(w, r, t.ID)
+		return
+	}
+	namen, nerr := a.db.NameResolver()
+	name := userSub
+	if nerr == nil {
+		if n := namen.Resolve(b.UserSub, ""); n != "" {
+			name = n
+		}
+	}
+	a.setFlash(w, "success", zitat(name)+" ist jetzt Mitglied von "+zitat(t.Name)+".")
+	a.zurueckZumTraeger(w, r, t.ID)
+}
+
+func (a *App) zurueckZumTraeger(w http.ResponseWriter, r *http.Request, id int64) {
+	http.Redirect(w, r, fmt.Sprintf("%s/%d", traegerBasis, id), http.StatusSeeOther)
+}
+
+// fehlertext holt die Meldung heraus, die für Menschen gedacht ist. Alles
+// andere kommt als allgemeiner Satz — eine rohe Fehlermeldung auf einer
+// Verwaltungsseite hilft niemandem weiter.
+func fehlertext(err error) string {
+	var ce *api.CompletionError
+	if errors.As(err, &ce) {
+		return ce.Message
+	}
+	return "Das hat nicht geklappt: " + err.Error()
+}

--- a/backend/internal/admin/beitritt_test.go
+++ b/backend/internal/admin/beitritt_test.go
@@ -1,0 +1,213 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/db"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/mitglied"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Beitritte in der Web-Verwaltung — server-gerendert, echte Formulare, kein
+// Modal. Geprüft wird, was wirklich im HTML steht und was danach in der
+// Rössing-ID steht.
+
+// roessingID spielt die Rössing-ID: lesen wie die Dev-Quelle, schreiben wie
+// der Dienst-Nutzer im Betrieb.
+type roessingID struct {
+	mu          sync.Mutex
+	aufgenommen map[string]string // "sub@projekt" → Rolle
+	fehler      error
+}
+
+func (q *roessingID) Fuer(ctx context.Context, u auth.User) mitglied.Stand {
+	stand := mitglied.DevQuelle{}.Fuer(ctx, u)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for schluessel, rolle := range q.aufgenommen {
+		sub, projekt, _ := strings.Cut(schluessel, "@")
+		if sub != u.Sub {
+			continue
+		}
+		if stand.Rollen[projekt] == nil {
+			stand.Rollen[projekt] = map[string]bool{}
+		}
+		stand.Rollen[projekt][rolle] = true
+	}
+	return stand
+}
+
+func (q *roessingID) Aufnehmen(_ context.Context, projektID, userSub, rolle string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.fehler != nil {
+		return q.fehler
+	}
+	q.aufgenommen[userSub+"@"+projektID] = rolle
+	return nil
+}
+
+func (q *roessingID) hat(sub, projektID string) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.aufgenommen[sub+"@"+projektID] == model.RolleMitglied
+}
+
+// beitrittsAufbau ist traegerAufbau mit einer Rössing-ID, in die
+// zurückgeschrieben werden kann.
+func beitrittsAufbau(t *testing.T) (*App, http.Handler, *db.DB, *roessingID) {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.sqlite"))
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	q := &roessingID{aufgenommen: map[string]string{}}
+	a := newApp(Config{
+		DB: d, Issuer: "https://id.invalid", ClientID: "test-client",
+		PublicURL: "http://localhost:8080", SessionKey: []byte("test-schluessel"),
+		Mitglieder: q,
+		// Dieselbe gestellte Uhr wie in traegerAufbau: Die Sitzung im Test
+		// läuft ab echter Zeit, eine vorgestellte Uhr ließe sie ablaufen.
+		Now: func() time.Time { return time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC) },
+	})
+	mux := http.NewServeMux()
+	a.register(mux)
+	return a, mux, d, q
+}
+
+func offenerBeitritt(t *testing.T, d *db.DB, traegerID int64, sub string) model.Beitritt {
+	t.Helper()
+	b := model.Beitritt{TraegerID: traegerID, UserSub: sub, Status: model.AntragBeantragt,
+		Begruendung: "Ich wohne neben dem Beet", CreatedAt: time.Now().UTC()}
+	if err := d.InsertBeitritt(&b); err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// Der Durchstich in der Verwaltung: Der offene Antrag steht auf der Seite,
+// ein Klick nimmt auf — und die Rolle steht danach in der Rössing-ID.
+func TestBeitrittInDerVerwaltungFreigeben(t *testing.T) {
+	a, h, d, roessing := beitrittsAufbau(t)
+	tr := traegerAnlegen(t, d, "AK 2 Umwelt und Natur", "388", model.TraegerZugelassen)
+	vorstand := sitzung(t, a, "vorstand", false, "388@admin")
+	b := offenerBeitritt(t, d, tr.ID, "erna")
+
+	w := hole(t, h, fmt.Sprintf("/admin/traeger/%d", tr.ID), vorstand)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Trägerseite: HTTP %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), fmt.Sprintf(`id="beitritt-%d"`, b.ID)) {
+		t.Fatal("der offene Beitrittsantrag steht nicht auf der Seite")
+	}
+	if strings.Contains(w.Body.String(), `id="keine-aufnahme"`) {
+		t.Error("die Seite behauptet, es könne niemand aufgenommen werden")
+	}
+
+	w = sende(t, h, fmt.Sprintf("/admin/traeger/%d/beitritte/%d", tr.ID, b.ID),
+		url.Values{"status": {"erteilt"}, "notiz": {"willkommen"}}, vorstand)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("Aufnehmen: HTTP %d — %s", w.Code, w.Body.String())
+	}
+	nachher, err := d.GetBeitritt(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nachher.Status != model.AntragErteilt || nachher.Notiz != "willkommen" {
+		t.Fatalf("Entscheidung nicht festgehalten: %+v", nachher)
+	}
+	if !roessing.hat("erna", "388") {
+		t.Fatal("die Mitgliedschaft steht nicht in der Rössing-ID")
+	}
+}
+
+// Scheitert das Eintragen, bleibt der Antrag offen — und auf dem Schirm steht,
+// woran es lag. Nichts wäre schlimmer als eine Verwaltung, die „aufgenommen“
+// meldet, während die Tür zu bleibt.
+func TestGescheiterteAufnahmeMeldetSichUndAendertNichts(t *testing.T) {
+	a, h, d, roessing := beitrittsAufbau(t)
+	roessing.fehler = fmt.Errorf("Rössing-ID antwortet nicht")
+	tr := traegerAnlegen(t, d, "AK 2 Umwelt und Natur", "388", model.TraegerZugelassen)
+	vorstand := sitzung(t, a, "vorstand", false, "388@admin")
+	b := offenerBeitritt(t, d, tr.ID, "erna")
+
+	w := sende(t, h, fmt.Sprintf("/admin/traeger/%d/beitritte/%d", tr.ID, b.ID),
+		url.Values{"status": {"erteilt"}}, vorstand)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("HTTP %d", w.Code)
+	}
+	nachher, _ := d.GetBeitritt(b.ID)
+	if nachher.Status != model.AntragBeantragt {
+		t.Fatalf("der Antrag wurde abgehakt, obwohl nichts eingetragen wurde: %+v", nachher)
+	}
+	// Die Meldung steht im Flash-Cookie und danach auf der Seite.
+	if !strings.Contains(strings.Join(w.Header().Values("Set-Cookie"), " "), "flash") {
+		t.Error("es gibt keine Rückmeldung an die Verwaltung")
+	}
+}
+
+// Ohne schreibenden Dienst-Nutzer sagt die Seite das, statt einen Knopf
+// anzubieten, der nichts tut.
+func TestOhneDienstNutzerStehtDerHinweisAufDerSeite(t *testing.T) {
+	a, h, d := traegerAufbau(t) // Dev-Quelle: liest aus dem Token, schreibt nicht
+	tr := traegerAnlegen(t, d, "AK 2 Umwelt und Natur", "388", model.TraegerZugelassen)
+	vorstand := sitzung(t, a, "vorstand", false, "388@admin")
+
+	w := hole(t, h, fmt.Sprintf("/admin/traeger/%d", tr.ID), vorstand)
+	if !strings.Contains(w.Body.String(), `id="keine-aufnahme"`) {
+		t.Fatal("der Hinweis auf den fehlenden Dienst-Nutzer fehlt")
+	}
+}
+
+// Jemanden ohne vorherigen Antrag aufnehmen — der Weg der geschlossenen
+// Gruppe und die Abkürzung nach dem Gespräch am Gartenzaun.
+func TestJemandenDirektAufnehmen(t *testing.T) {
+	a, h, d, roessing := beitrittsAufbau(t)
+	tr := traegerAnlegen(t, d, "AK 2 Umwelt und Natur", "388", model.TraegerZugelassen)
+	vorstand := sitzung(t, a, "vorstand", false, "388@admin")
+
+	w := sende(t, h, fmt.Sprintf("/admin/traeger/%d/mitglieder", tr.ID),
+		url.Values{"userSub": {"erna"}, "notiz": {"auf der Versammlung gefragt"}}, vorstand)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("Aufnehmen: HTTP %d — %s", w.Code, w.Body.String())
+	}
+	if !roessing.hat("erna", "388") {
+		t.Fatal("die Mitgliedschaft steht nicht in der Rössing-ID")
+	}
+	vorgang, err := d.BeitrittVon(tr.ID, "erna")
+	if err != nil || vorgang == nil || vorgang.Status != model.AntragErteilt {
+		t.Fatalf("der Vorgang wurde nicht festgehalten: %v %+v", err, vorgang)
+	}
+	if vorgang.EntschiedenVon != "vorstand" {
+		t.Errorf("es steht nicht dabei, wer aufgenommen hat: %+v", vorgang)
+	}
+}
+
+// Ein fremder Antrag geht die Verwaltung eines anderen Vereins nichts an.
+func TestFremderAntragBleibtUnerreichbar(t *testing.T) {
+	a, h, d, _ := beitrittsAufbau(t)
+	meiner := traegerAnlegen(t, d, "AK 2 Umwelt und Natur", "388", model.TraegerZugelassen)
+	fremder := traegerAnlegen(t, d, "Schützenverein", "999", model.TraegerZugelassen)
+	vorstand := sitzung(t, a, "vorstand", false, "388@admin")
+	fremd := offenerBeitritt(t, d, fremder.ID, "erna")
+
+	w := sende(t, h, fmt.Sprintf("/admin/traeger/%d/beitritte/%d", meiner.ID, fremd.ID),
+		url.Values{"status": {"erteilt"}}, vorstand)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("HTTP %d, erwartet 404", w.Code)
+	}
+	nachher, _ := d.GetBeitritt(fremd.ID)
+	if nachher.Status != model.AntragBeantragt {
+		t.Fatal("ein fremder Antrag wurde entschieden")
+	}
+}

--- a/backend/internal/admin/templates/traeger.html
+++ b/backend/internal/admin/templates/traeger.html
@@ -178,6 +178,101 @@
   </div>
 </div>
 
+{{/* --- Beitritte --- */}}
+<div class="card mt-6 bg-base-100 shadow-sm">
+  <div class="card-body">
+    <h2 class="card-title text-lg">
+      Mitmachen
+      {{if .Data.OffeneBeitritte}}
+        <span class="badge badge-warning" id="beitritte-offen">{{len .Data.OffeneBeitritte}}</span>
+      {{else}}
+        <span class="badge badge-ghost" id="beitritte-offen">0</span>
+      {{end}}
+    </h2>
+    <p class="text-base-content/70">
+      Wer diesem Träger beitreten möchte, fragt hier an. Eine Freigabe trägt die Rolle
+      <code>mitglied</code> unmittelbar in der Rössing-ID ein — niemand muss dafür in die
+      Zitadel-Konsole. Wer eine geschlossene Gruppe verwaltet, nimmt unten selbst auf:
+      Anträge nimmt sie nicht entgegen.
+    </p>
+
+    {{if not .Data.AufnahmeMoeglich}}
+      <div class="alert alert-warning mt-2" id="keine-aufnahme">
+        <span>{{.Data.KeineAufnahme}}</span>
+      </div>
+    {{end}}
+
+    {{if .Data.OffeneBeitritte}}
+      <div class="mt-2 overflow-x-auto">
+        <table class="table" id="offene-beitritte">
+          <thead><tr><th>Person</th><th>Begründung</th><th>Gefragt</th><th></th></tr></thead>
+          <tbody>
+            {{range .Data.OffeneBeitritte}}
+              <tr id="beitritt-{{.ID}}">
+                <td>{{.UserName}}</td>
+                <td class="max-w-xs">{{.Begruendung}}</td>
+                <td class="whitespace-nowrap">{{datum .CreatedAt}}</td>
+                <td class="whitespace-nowrap text-right">
+                  <form method="post" action="/admin/traeger/{{.TraegerID}}/beitritte/{{.ID}}"
+                        class="flex flex-wrap items-center justify-end gap-1">
+                    <input class="input input-sm" type="text" name="notiz"
+                           placeholder="Notiz (optional)" maxlength="500">
+                    <button class="btn btn-success btn-sm" type="submit" name="status" value="erteilt">Aufnehmen</button>
+                    <button class="btn btn-ghost btn-sm" type="submit" name="status" value="abgelehnt">Ablehnen</button>
+                  </form>
+                </td>
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </div>
+    {{else}}
+      <div class="alert mt-2" id="keine-beitritte"><span>Keine offenen Beitrittsanträge.</span></div>
+    {{end}}
+
+    <form method="post" action="/admin/traeger/{{.Data.Traeger.ID}}/mitglieder"
+          class="mt-4 flex flex-wrap items-end gap-2">
+      <fieldset class="fieldset grow">
+        <legend class="fieldset-legend">Jemanden aufnehmen</legend>
+        <input class="input w-full" type="text" name="userSub" id="aufnehmen-usersub"
+               placeholder="Kennung aus der Rössing-ID" required maxlength="200">
+      </fieldset>
+      <fieldset class="fieldset grow">
+        <legend class="fieldset-legend">Notiz</legend>
+        <input class="input w-full" type="text" name="notiz" id="aufnehmen-notiz"
+               placeholder="z.B. „hat auf der Versammlung zugesagt“" maxlength="500">
+      </fieldset>
+      <button class="btn btn-primary" type="submit" id="aufnehmen">Aufnehmen</button>
+    </form>
+    <p class="text-sm text-base-content/60">
+      Die Kennung steht in der Rangliste und an jeder Erledigung.
+    </p>
+
+    {{if .Data.Mitglieder}}
+      <h3 class="mt-4 font-medium">Bereits entschieden</h3>
+      <div class="overflow-x-auto">
+        <table class="table table-sm" id="entschiedene-beitritte">
+          <thead><tr><th>Person</th><th>Stand</th><th>Am</th><th>Notiz</th></tr></thead>
+          <tbody>
+            {{range .Data.Mitglieder}}
+              <tr>
+                <td>{{.UserName}}</td>
+                <td><span class="badge {{antragBadge .Status}}">{{antragStatus .Status}}</span></td>
+                <td class="whitespace-nowrap">{{datumOpt .EntschiedenAm}}</td>
+                <td>{{.Notiz}}</td>
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </div>
+      <p class="text-sm text-base-content/60">
+        Wer hier steht, wurde über die Dorf-App aufgenommen. Wer außerhalb der App
+        eingetragen wurde, taucht hier nicht auf — maßgeblich ist die Rössing-ID.
+      </p>
+    {{end}}
+  </div>
+</div>
+
 {{/* --- Orte --- */}}
 <div class="card mt-6 bg-base-100 shadow-sm">
   <div class="card-body">

--- a/backend/internal/admin/templates/traeger_liste.html
+++ b/backend/internal/admin/templates/traeger_liste.html
@@ -34,6 +34,7 @@
           <th>Zitadel-Projekt</th>
           <th class="text-right">Orte</th>
           <th class="text-right">Offene Anträge</th>
+          <th class="text-right">Beitritte</th>
         </tr>
       </thead>
       <tbody>
@@ -52,6 +53,10 @@
             <td class="text-right">{{.Orte}}</td>
             <td class="text-right">
               {{if .OffeneAntraege}}<span class="badge badge-warning">{{.OffeneAntraege}}</span>
+              {{else}}0{{end}}
+            </td>
+            <td class="text-right" id="beitritte-offen-{{.ID}}">
+              {{if .OffeneBeitritte}}<span class="badge badge-warning">{{.OffeneBeitritte}}</span>
               {{else}}0{{end}}
             </td>
           </tr>

--- a/backend/internal/admin/traeger.go
+++ b/backend/internal/admin/traeger.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/api"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/mitglied"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
@@ -42,6 +43,9 @@ func (a *App) registerTraeger(mux *http.ServeMux) {
 	post("/{id}/befaehigungen/{bid}/loeschen", a.befaehigungLoeschen)
 
 	post("/{id}/antraege/{aid}", a.antragEntscheiden)
+
+	post("/{id}/beitritte/{bid}", a.beitrittEntscheiden)
+	post("/{id}/mitglieder", a.mitgliedAufnehmen)
 }
 
 // requireVerwaltung lässt herein, wer irgendetwas zu verwalten hat: den
@@ -107,9 +111,10 @@ type traegerListeDaten struct {
 
 type traegerZeile struct {
 	model.Traeger
-	OffeneAntraege int
-	Orte           int
-	DarfVerwalten  bool
+	OffeneAntraege  int
+	OffeneBeitritte int
+	Orte            int
+	DarfVerwalten   bool
 }
 
 func (a *App) traegerListe(w http.ResponseWriter, r *http.Request, s session) {
@@ -128,6 +133,11 @@ func (a *App) traegerListe(w http.ResponseWriter, r *http.Request, s session) {
 	for _, o := range orte {
 		orteJe[o.TraegerID]++
 	}
+	offeneBeitritte, err := a.db.OffeneBeitritte()
+	if err != nil {
+		a.fail(w, r, http.StatusInternalServerError, err)
+		return
+	}
 
 	daten := traegerListeDaten{Betreiber: z.Betreiber, Veraltet: z.Veraltet}
 	for _, t := range alle {
@@ -139,6 +149,7 @@ func (a *App) traegerListe(w http.ResponseWriter, r *http.Request, s session) {
 		if offen, err := a.db.ListAntraege(t.ID, model.AntragBeantragt); err == nil {
 			zeile.OffeneAntraege = len(offen)
 		}
+		zeile.OffeneBeitritte = offeneBeitritte[t.ID]
 		daten.Traeger = append(daten.Traeger, zeile)
 	}
 	a.render(w, r, http.StatusOK, "traeger_liste", view{
@@ -207,6 +218,15 @@ type traegerDetailDaten struct {
 	Entschieden    []model.BefaehigungsAntrag
 	Orte           []model.Place
 	Betreiber      bool
+	// Beitritte: wer mitmachen will, und wer schon aufgenommen ist.
+	OffeneBeitritte []model.Beitritt
+	Mitglieder      []model.Beitritt
+	// AufnahmeMoeglich sagt, ob eine Freigabe überhaupt etwas bewirken kann.
+	// Ohne schreibenden Dienst-Nutzer bliebe sie wirkungslos, und dann soll
+	// hier ein Hinweis stehen statt eines Knopfes, der nichts tut.
+	AufnahmeMoeglich bool
+	// KeineAufnahme ist der Hinweistext für genau diesen Fall.
+	KeineAufnahme string
 }
 
 // traegerAusPfad lädt den Träger und prüft, ob er gepflegt werden darf.
@@ -289,6 +309,26 @@ func (a *App) zeigeTraeger(w http.ResponseWriter, r *http.Request, status int,
 		}
 	}
 
+	alleBeitritte, err := a.db.ListBeitritte(t.ID, "")
+	if err != nil {
+		a.fail(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	offeneBeitritte := []model.Beitritt{}
+	mitglieder := []model.Beitritt{}
+	for _, b := range alleBeitritte {
+		b.UserName = namen.Resolve(b.UserSub, "")
+		if b.UserName == "" {
+			b.UserName = b.UserSub
+		}
+		if b.Status == model.AntragBeantragt {
+			offeneBeitritte = append(offeneBeitritte, b)
+		} else {
+			mitglieder = append(mitglieder, b)
+		}
+	}
+	_, kannAufnehmen := mitglied.AufnehmerVon(a.mitglieder)
+
 	formular := t
 	if entwurf != nil {
 		formular = *entwurf
@@ -305,6 +345,11 @@ func (a *App) zeigeTraeger(w http.ResponseWriter, r *http.Request, status int,
 			Entschieden:    entschieden,
 			Orte:           seine,
 			Betreiber:      z.Betreiber,
+
+			OffeneBeitritte:  offeneBeitritte,
+			Mitglieder:       mitglieder,
+			AufnahmeMoeglich: kannAufnehmen && t.ProjektID != "",
+			KeineAufnahme:    api.NochNichtEingerichtet,
 		},
 	})
 }

--- a/backend/internal/api/beitritt.go
+++ b/backend/internal/api/beitritt.go
@@ -1,0 +1,313 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/db"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/mitglied"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Beitritt: „Ich will bei euch mitmachen.“
+//
+// Bis hierher trug Mitgliedschaften ausschließlich ein Mensch in der
+// Zitadel-Konsole ein. Wer im Dorf einen Verein oder einen Arbeitskreis sah
+// und mitmachen wollte, konnte das nirgends sagen.
+//
+// Der Ablauf ist der der Befähigungen — beantragen, freigeben oder ablehnen.
+// Der eine Unterschied ist der wichtige: Ein erteilter Beitritt ist NICHT die
+// Mitgliedschaft. Die steht in der Rössing-ID. Deshalb wird hier zuerst dort
+// geschrieben und erst danach der Vorgang abgehakt; scheitert das Schreiben,
+// bleibt der Antrag offen und sagt, warum. Ein Verfahren, das am Ende nichts
+// bewirkt, wäre schlimmer als gar keins: Die App behauptete „Mitglied“, und
+// die Tür bliebe zu.
+
+func (s *Server) registerBeitritt(api *http.ServeMux) {
+	api.HandleFunc("POST /api/v1/traeger/{id}/beitritt", s.handleBeitrittBeantragen)
+	api.HandleFunc("GET /api/v1/traeger/{id}/beitritte", s.handleListBeitritte)
+	api.HandleFunc("POST /api/v1/traeger/{id}/mitglieder", s.handleMitgliedAufnehmen)
+	api.HandleFunc("POST /api/v1/beitritte/{id}", s.handleBeitrittEntscheiden)
+	api.HandleFunc("GET /api/v1/me/beitritte", s.handleMeineBeitritte)
+}
+
+// --- Antrag stellen ---------------------------------------------------------
+
+func (s *Server) handleBeitrittBeantragen(w http.ResponseWriter, r *http.Request) {
+	t, z, err := s.traegerAusPfad(r)
+	if err != nil {
+		schreibeZugriffsfehler(w, r, err)
+		return
+	}
+	if hindernis := z.BeitrittsHindernis(t); hindernis != "" {
+		// 409 und nicht 403: Es fehlt keine Berechtigung, es passt die Lage
+		// nicht — man ist schon dabei, oder die Gruppe nimmt keine Anträge.
+		writeErr(w, http.StatusConflict, hindernis)
+		return
+	}
+	var in struct {
+		Begruendung string `json:"begruendung"`
+	}
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			writeErr(w, http.StatusBadRequest, "ungültiges JSON")
+			return
+		}
+	}
+	if err := pruefeText("begruendung", in.Begruendung); err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	u, _ := auth.FromContext(r.Context())
+	// Das Profil anlegen, falls es noch keins gibt: Sonst stünde beim
+	// Träger-Admin eine nackte Kennung ohne Namen.
+	if _, err := ProfileFor(s.DB, u, s.now()); err != nil {
+		writeInternal(w, r, err)
+		return
+	}
+	b := model.Beitritt{TraegerID: t.ID, UserSub: u.Sub, Status: model.AntragBeantragt,
+		Begruendung: in.Begruendung, CreatedAt: s.now()}
+	if err := s.DB.InsertBeitritt(&b); err != nil {
+		writeInternal(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, b)
+}
+
+// --- Anträge sehen ----------------------------------------------------------
+
+func (s *Server) handleListBeitritte(w http.ResponseWriter, r *http.Request) {
+	t, z, err := s.traegerAusPfad(r)
+	if err != nil {
+		schreibeZugriffsfehler(w, r, err)
+		return
+	}
+	if !z.DarfBeitrittEntscheiden(t) {
+		schreibeZugriffsfehler(w, r, verwaltungAbgelehnt(z, t))
+		return
+	}
+	status := model.AntragStatus(r.URL.Query().Get("status"))
+	if status != "" && !model.ValidAntragStatus(status) {
+		writeErr(w, http.StatusBadRequest, "status muss beantragt, erteilt oder abgelehnt sein")
+		return
+	}
+	liste, err := s.DB.ListBeitritte(t.ID, status)
+	if err != nil {
+		writeInternal(w, r, err)
+		return
+	}
+	if err := s.namenEintragen(liste); err != nil {
+		writeInternal(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"beitritte": liste})
+}
+
+// namenEintragen löst die Kennungen zu Namen auf — ein Träger-Admin soll
+// lesen, wer da fragt, und nicht eine Zeichenkette aus der Rössing-ID.
+func (s *Server) namenEintragen(liste []model.Beitritt) error {
+	if len(liste) == 0 {
+		return nil
+	}
+	namen, err := s.DB.NameResolver()
+	if err != nil {
+		return err
+	}
+	for i := range liste {
+		liste[i].UserName = namen.Resolve(liste[i].UserSub, "")
+	}
+	return nil
+}
+
+func (s *Server) handleMeineBeitritte(w http.ResponseWriter, r *http.Request) {
+	u, _ := auth.FromContext(r.Context())
+	liste, err := s.DB.ListBeitritteVonPerson(u.Sub)
+	if err != nil {
+		writeInternal(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"beitritte": liste})
+}
+
+// --- Entscheiden ------------------------------------------------------------
+
+func (s *Server) handleBeitrittEntscheiden(w http.ResponseWriter, r *http.Request) {
+	z := s.zugriff(r)
+	id, err := pathID(r)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "ungültige ID")
+		return
+	}
+	b, err := s.DB.GetBeitritt(id)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, "Diesen Antrag gibt es nicht.")
+		return
+	}
+	t, err := s.DB.GetTraeger(b.TraegerID)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, "Den Träger zu diesem Antrag gibt es nicht mehr.")
+		return
+	}
+	if !z.DarfBeitrittEntscheiden(*t) {
+		schreibeZugriffsfehler(w, r, verwaltungAbgelehnt(z, *t))
+		return
+	}
+	var in struct {
+		Status string `json:"status"`
+		Notiz  string `json:"notiz"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, "ungültiges JSON")
+		return
+	}
+	if err := pruefeText("notiz", in.Notiz); err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	entschieden, err := BeitrittEntscheiden(r.Context(), s.DB, s.Mitglieder, *t, *b,
+		model.AntragStatus(in.Status), z.Sub, in.Notiz, s.now())
+	if err != nil {
+		schreibeZugriffsfehler(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, entschieden)
+}
+
+// --- Direkt aufnehmen -------------------------------------------------------
+
+// handleMitgliedAufnehmen nimmt jemanden ohne vorherigen Antrag auf.
+//
+// Warum es das gibt: Eine geschlossene Gruppe nimmt Anträge gar nicht erst
+// entgegen (siehe model.Zugriff.BeitrittsHindernis) — sie holt sich ihre
+// Leute selbst. Und auch bei einem offenen Träger wird im Dorf öfter am
+// Gartenzaun gefragt als in der App; wer zugesagt hat, soll nicht erst noch
+// einen Antrag stellen müssen. Ein offener Antrag wird dabei mitentschieden
+// statt verdoppelt.
+func (s *Server) handleMitgliedAufnehmen(w http.ResponseWriter, r *http.Request) {
+	t, z, err := s.traegerAusPfad(r)
+	if err != nil {
+		schreibeZugriffsfehler(w, r, err)
+		return
+	}
+	if !z.DarfBeitrittEntscheiden(t) {
+		schreibeZugriffsfehler(w, r, verwaltungAbgelehnt(z, t))
+		return
+	}
+	var in struct {
+		UserSub string `json:"userSub"`
+		Notiz   string `json:"notiz"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, "ungültiges JSON")
+		return
+	}
+	if err := pruefeText("notiz", in.Notiz); err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	b, err := Aufnehmen(r.Context(), s.DB, s.Mitglieder, t, in.UserSub, z.Sub, in.Notiz, s.now())
+	if err != nil {
+		schreibeZugriffsfehler(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, b)
+}
+
+// --- Der eine Weg nach Zitadel ----------------------------------------------
+
+// Aufnehmen schreibt die Mitgliedschaft in die Rössing-ID und hält den
+// Vorgang fest.
+//
+// REST, Web-Verwaltung und MCP nehmen denselben Weg. Drei eigene Wege wären
+// drei Gelegenheiten, den entscheidenden Schritt zu vergessen — und der
+// vergessene wäre jedes Mal derselbe: das Zurückschreiben.
+func Aufnehmen(ctx context.Context, d *db.DB, q mitglied.Quelle, t model.Traeger,
+	userSub, durch, notiz string, jetzt time.Time,
+) (*model.Beitritt, error) {
+	if userSub == "" {
+		return nil, &CompletionError{Status: http.StatusBadRequest,
+			Message: "Ohne Kennung der Person (userSub) geht das nicht — " +
+				"sie steht in der Rangliste und in jeder Erledigung."}
+	}
+	if err := nachZitadel(ctx, q, t, userSub); err != nil {
+		return nil, err
+	}
+	b := model.Beitritt{TraegerID: t.ID, UserSub: userSub, Status: model.AntragBeantragt,
+		CreatedAt: jetzt}
+	if err := d.InsertBeitritt(&b); err != nil {
+		return nil, err
+	}
+	if err := d.EntscheideBeitritt(b.ID, model.AntragErteilt, durch, notiz, jetzt); err != nil {
+		return nil, err
+	}
+	return d.GetBeitritt(b.ID)
+}
+
+// BeitrittEntscheiden gibt einen vorliegenden Antrag frei oder lehnt ihn ab.
+// Bei der Freigabe steht zuerst die Rollenzuweisung in der Rössing-ID, dann
+// erst der Vermerk hier — andersherum stünde hier „Mitglied“, während die
+// Tür zu bliebe.
+func BeitrittEntscheiden(ctx context.Context, d *db.DB, q mitglied.Quelle, t model.Traeger,
+	b model.Beitritt, status model.AntragStatus, durch, notiz string, jetzt time.Time,
+) (*model.Beitritt, error) {
+	if status != model.AntragErteilt && status != model.AntragAbgelehnt {
+		return nil, &CompletionError{Status: http.StatusBadRequest,
+			Message: "status muss erteilt oder abgelehnt sein"}
+	}
+	if status == model.AntragErteilt {
+		if err := nachZitadel(ctx, q, t, b.UserSub); err != nil {
+			return nil, err
+		}
+	}
+	if err := d.EntscheideBeitritt(b.ID, status, durch, notiz, jetzt); err != nil {
+		return nil, err
+	}
+	return d.GetBeitritt(b.ID)
+}
+
+// nachZitadel ist die einzige Stelle, an der eine Mitgliedschaft in die
+// Rössing-ID geschrieben wird.
+func nachZitadel(ctx context.Context, q mitglied.Quelle, t model.Traeger, userSub string) error {
+	if t.ProjektID == "" {
+		return &CompletionError{Status: http.StatusConflict,
+			Message: "Dieser Träger hat in der Rössing-ID kein Projekt — " +
+				"solange es keins gibt, kann er keine Mitglieder haben."}
+	}
+	a, ok := mitglied.AufnehmerVon(q)
+	if !ok {
+		return &CompletionError{Status: http.StatusServiceUnavailable, Message: NochNichtEingerichtet}
+	}
+	if err := a.Aufnehmen(ctx, t.ProjektID, userSub, model.RolleMitglied); err != nil {
+		// Die volle Antwort der Rössing-ID gehört ins Protokoll, nicht vor
+		// die Leute: Sie nennt Pfade und Kennungen.
+		slog.Error("Aufnahme in die Rössing-ID gescheitert",
+			"projekt", t.ProjektID, "person", userSub, "err", err)
+		return &CompletionError{Status: http.StatusBadGateway,
+			Message: "Die Mitgliedschaft konnte in der Rössing-ID nicht eingetragen werden — " +
+				"der Antrag bleibt deshalb offen. " + aufnahmeHinweis(err)}
+	}
+	return nil
+}
+
+// NochNichtEingerichtet ist die Antwort für den Betriebszustand ohne
+// schreibenden Dienst-Nutzer. Sie sagt ausdrücklich, dass nichts passiert
+// ist — eine Freigabe, die stillschweigend ins Leere liefe, wäre die
+// schlechteste aller Antworten.
+const NochNichtEingerichtet = "Aufnehmen geht noch nicht: Das Backend kann in der Rössing-ID " +
+	"keine Mitgliedschaften eintragen. Dafür braucht es einen Dienst-Nutzer mit Schreibrecht " +
+	"auf Rollenzuweisungen; bis dahin trägt der Betreiber die Mitgliedschaft von Hand ein."
+
+// aufnahmeHinweis sagt, ob es sich lohnt, es gleich noch einmal zu versuchen.
+func aufnahmeHinweis(err error) string {
+	var api *mitglied.APIFehler
+	if errors.As(err, &api) && api.FehlendesRecht() {
+		return "Der Dienst-Nutzer darf dort keine Rollen vergeben — das muss der Betreiber " +
+			"in der Rössing-ID freischalten."
+	}
+	return "Bitte gleich noch einmal versuchen."
+}

--- a/backend/internal/api/beitritt_test.go
+++ b/backend/internal/api/beitritt_test.go
@@ -1,0 +1,360 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/mitglied"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Beitritt: Jemand sieht einen offenen Träger, sagt „ich will mitmachen“, der
+// Träger-Admin gibt frei — und danach ist die Person wirklich Mitglied, ohne
+// dass jemand die Zitadel-Konsole öffnet.
+//
+// Das „wirklich“ ist der Kern dieser Proben: Eine Freigabe, die nur in der
+// eigenen Datenbank landet, wäre eine Lüge.
+
+// roessingID spielt die Rössing-ID: lesen wie die Dev-Quelle (Rollen aus dem
+// Token), schreiben wie der Dienst-Nutzer im Betrieb.
+type roessingID struct {
+	mu sync.Mutex
+	// aufgenommen: Kennung → Projekt → Rolle.
+	aufgenommen map[string]map[string]string
+	// fehler lässt die Rössing-ID die Aufnahme verweigern.
+	fehler error
+}
+
+func neueRoessingID() *roessingID {
+	return &roessingID{aufgenommen: map[string]map[string]string{}}
+}
+
+func (q *roessingID) Fuer(ctx context.Context, u auth.User) mitglied.Stand {
+	stand := mitglied.DevQuelle{}.Fuer(ctx, u)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for projekt, rolle := range q.aufgenommen[u.Sub] {
+		if stand.Rollen[projekt] == nil {
+			stand.Rollen[projekt] = map[string]bool{}
+		}
+		stand.Rollen[projekt][rolle] = true
+	}
+	return stand
+}
+
+func (q *roessingID) Aufnehmen(_ context.Context, projektID, userSub, rolle string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.fehler != nil {
+		return q.fehler
+	}
+	if q.aufgenommen[userSub] == nil {
+		q.aufgenommen[userSub] = map[string]string{}
+	}
+	q.aufgenommen[userSub][projektID] = rolle
+	return nil
+}
+
+func (q *roessingID) istMitglied(sub, projektID string) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.aufgenommen[sub][projektID] == model.RolleMitglied
+}
+
+// beitrittsServer ist der Testserver mit einer Rössing-ID, in die
+// zurückgeschrieben werden kann.
+func beitrittsServer(t *testing.T) (string, *roessingID) {
+	t.Helper()
+	ts, srv := newTestServer(t)
+	q := neueRoessingID()
+	srv.Mitglieder = q
+	return ts.URL, q
+}
+
+func beitrittStellen(t *testing.T, ts, token string, traegerID int64, grund string) *http.Response {
+	t.Helper()
+	return doReq(t, "POST", fmt.Sprintf("%s/api/v1/traeger/%d/beitritt", ts, traegerID),
+		token, map[string]any{"begruendung": grund})
+}
+
+// Der Durchstich: beantragen, freigeben, dabei sein.
+func TestBeitrittBeantragenUndFreigeben(t *testing.T) {
+	ts, roessing := beitrittsServer(t)
+	traegerID := traegerAnlegen(t, ts, "AK 2 Umwelt und Natur", "222")
+
+	resp := beitrittStellen(t, ts, aussenToken, traegerID, "Ich wohne neben dem Beet")
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("Antrag: HTTP %d", resp.StatusCode)
+	}
+	antragID := decode[struct {
+		ID int64 `json:"id"`
+	}](t, resp).ID
+
+	// Der Träger-Admin sieht ihn — mit Namen, nicht mit nackter Kennung.
+	resp = doReq(t, "GET", fmt.Sprintf("%s/api/v1/traeger/%d/beitritte?status=beantragt", ts, traegerID),
+		dorfpflegeAdmin, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Liste: HTTP %d", resp.StatusCode)
+	}
+	liste := decode[struct {
+		Beitritte []model.Beitritt `json:"beitritte"`
+	}](t, resp).Beitritte
+	if len(liste) != 1 || liste[0].UserName == "" {
+		t.Fatalf("offener Antrag fehlt oder ist namenlos: %+v", liste)
+	}
+
+	// Niemand entscheidet über sich selbst.
+	resp = doReq(t, "POST", fmt.Sprintf("%s/api/v1/beitritte/%d", ts, antragID), aussenToken,
+		map[string]any{"status": "erteilt"})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("Selbstaufnahme: HTTP %d, erwartet 403", resp.StatusCode)
+	}
+
+	resp = doReq(t, "POST", fmt.Sprintf("%s/api/v1/beitritte/%d", ts, antragID), dorfpflegeAdmin,
+		map[string]any{"status": "erteilt", "notiz": "willkommen"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Freigabe: HTTP %d", resp.StatusCode)
+	}
+	if got := decode[model.Beitritt](t, resp); got.Status != model.AntragErteilt {
+		t.Fatalf("Antrag nicht erteilt: %+v", got)
+	}
+
+	// Das eigentliche Versprechen: Die Mitgliedschaft steht in der
+	// Rössing-ID, nicht bloß in unserer Datenbank.
+	if !roessing.istMitglied("fremd", "222") {
+		t.Fatal("die Mitgliedschaft wurde nicht in die Rössing-ID zurückgeschrieben")
+	}
+
+	// Und sie wirkt sofort: derselbe Token, keine neue Anmeldung.
+	resp = doReq(t, "GET", ts+"/api/v1/traeger", aussenToken, nil)
+	sicht := decode[struct {
+		Traeger []TraegerAnsicht `json:"traeger"`
+	}](t, resp).Traeger
+	if len(sicht) != 1 || !sicht[0].IstMitglied {
+		t.Fatalf("die Aufnahme wirkt nicht: %+v", sicht)
+	}
+	if sicht[0].BeitrittMoeglich {
+		t.Error("wer dabei ist, bekommt weiter „mitmachen“ angeboten")
+	}
+}
+
+// Ohne schreibenden Dienst-Nutzer bewirkt eine Freigabe nichts. Dann muss sie
+// scheitern und sagen, was fehlt — der Antrag bleibt offen. Eine Verwaltung,
+// die „aufgenommen“ meldet, während die Tür zu bleibt, wäre schlimmer als
+// gar keine.
+func TestOhneSchreibendenDienstNutzerScheitertDieFreigabe(t *testing.T) {
+	ts, _ := newTestServer(t) // Dev-Quelle: liest aus dem Token, schreibt nicht
+	traegerID := traegerAnlegen(t, ts.URL, "AK 2 Umwelt und Natur", "222")
+	resp := beitrittStellen(t, ts.URL, aussenToken, traegerID, "bitte")
+	antragID := decode[struct {
+		ID int64 `json:"id"`
+	}](t, resp).ID
+
+	resp = doReq(t, "POST", fmt.Sprintf("%s/api/v1/beitritte/%d", ts.URL, antragID),
+		dorfpflegeAdmin, map[string]any{"status": "erteilt"})
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("HTTP %d, erwartet 503", resp.StatusCode)
+	}
+	if text, _ := decode[map[string]any](t, resp)["error"].(string); !strings.Contains(text, "Dienst-Nutzer") {
+		t.Errorf("die Absage sagt nicht, was einzurichten ist: %q", text)
+	}
+
+	// Der Antrag bleibt offen — nichts ist passiert, und das steht auch so da.
+	resp = doReq(t, "GET", fmt.Sprintf("%s/api/v1/traeger/%d/beitritte?status=beantragt", ts.URL, traegerID),
+		dorfpflegeAdmin, nil)
+	if liste := decode[struct {
+		Beitritte []model.Beitritt `json:"beitritte"`
+	}](t, resp).Beitritte; len(liste) != 1 {
+		t.Fatalf("der Antrag wurde trotz gescheiterter Aufnahme abgehakt: %+v", liste)
+	}
+}
+
+// Antwortet die Rössing-ID nicht, gilt dasselbe: kein Vermerk, kein
+// halbfertiger Zustand.
+func TestScheiterndeAufnahmeLaesstDenAntragOffen(t *testing.T) {
+	ts, roessing := beitrittsServer(t)
+	roessing.fehler = fmt.Errorf("Rössing-ID antwortet nicht")
+	traegerID := traegerAnlegen(t, ts, "AK 2 Umwelt und Natur", "222")
+	resp := beitrittStellen(t, ts, aussenToken, traegerID, "bitte")
+	antragID := decode[struct {
+		ID int64 `json:"id"`
+	}](t, resp).ID
+
+	resp = doReq(t, "POST", fmt.Sprintf("%s/api/v1/beitritte/%d", ts, antragID),
+		dorfpflegeAdmin, map[string]any{"status": "erteilt"})
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("HTTP %d, erwartet 502", resp.StatusCode)
+	}
+	resp = doReq(t, "GET", fmt.Sprintf("%s/api/v1/traeger/%d/beitritte?status=beantragt", ts, traegerID),
+		dorfpflegeAdmin, nil)
+	if liste := decode[struct {
+		Beitritte []model.Beitritt `json:"beitritte"`
+	}](t, resp).Beitritte; len(liste) != 1 {
+		t.Fatalf("der Antrag wurde abgehakt, obwohl nichts eingetragen wurde: %+v", liste)
+	}
+}
+
+// Ablehnen geht immer: Dabei ist in der Rössing-ID nichts zu schreiben.
+func TestAblehnenBrauchtKeineRoessingID(t *testing.T) {
+	ts, _ := newTestServer(t)
+	traegerID := traegerAnlegen(t, ts.URL, "AK 2 Umwelt und Natur", "222")
+	resp := beitrittStellen(t, ts.URL, aussenToken, traegerID, "bitte")
+	antragID := decode[struct {
+		ID int64 `json:"id"`
+	}](t, resp).ID
+
+	resp = doReq(t, "POST", fmt.Sprintf("%s/api/v1/beitritte/%d", ts.URL, antragID),
+		dorfpflegeAdmin, map[string]any{"status": "abgelehnt", "notiz": "gerade voll"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Ablehnen: HTTP %d", resp.StatusCode)
+	}
+	if got := decode[model.Beitritt](t, resp); got.Status != model.AntragAbgelehnt {
+		t.Fatalf("nicht abgelehnt: %+v", got)
+	}
+}
+
+// Eine geschlossene Gruppe steht nicht im Verzeichnis: Für Außenstehende gibt
+// es sie nicht, und selbst wer sie sieht, kann ihr nichts schicken. Sie nimmt
+// selbst auf.
+func TestGeschlosseneGruppeNimmtKeineAntraegeEntgegen(t *testing.T) {
+	ts, roessing := beitrittsServer(t)
+	traegerID := traegerAnlegen(t, ts, "Stiller Kreis", "222")
+	resp := doReq(t, "PUT", fmt.Sprintf("%s/api/v1/traeger/%d", ts, traegerID), betreiberToken,
+		map[string]any{"name": "Stiller Kreis", "projektId": "222",
+			"status": "zugelassen", "sichtbarkeit": "geschlossen"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("schließen: HTTP %d", resp.StatusCode)
+	}
+
+	// Für Außenstehende gibt es sie gar nicht.
+	if resp := beitrittStellen(t, ts, aussenToken, traegerID, "bitte"); resp.StatusCode != http.StatusNotFound {
+		t.Errorf("Antrag von außen: HTTP %d, erwartet 404", resp.StatusCode)
+	}
+	// Der Betreiber sieht sie — und bekommt trotzdem kein Antragsrecht.
+	resp = beitrittStellen(t, ts, betreiberToken, traegerID, "bitte")
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("Antrag an eine geschlossene Gruppe: HTTP %d, erwartet 409", resp.StatusCode)
+	}
+	if text, _ := decode[map[string]any](t, resp)["error"].(string); !strings.Contains(text, "geschlossen") {
+		t.Errorf("die Absage nennt den Grund nicht: %q", text)
+	}
+
+	// Aufnehmen kann die Gruppe trotzdem — das ist ihr Weg.
+	resp = doReq(t, "POST", fmt.Sprintf("%s/api/v1/traeger/%d/mitglieder", ts, traegerID),
+		dorfpflegeAdmin, map[string]any{"userSub": "erna", "notiz": "auf der Versammlung gefragt"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Aufnehmen: HTTP %d", resp.StatusCode)
+	}
+	if !roessing.istMitglied("erna", "222") {
+		t.Fatal("die Aufnahme steht nicht in der Rössing-ID")
+	}
+	if got := decode[model.Beitritt](t, resp); got.Status != model.AntragErteilt ||
+		got.Notiz != "auf der Versammlung gefragt" {
+		t.Fatalf("der Vorgang wurde nicht festgehalten: %+v", got)
+	}
+}
+
+// Wer schon dabei ist, fragt nicht noch einmal.
+func TestWerDabeiIstBeantragtNichtNochmal(t *testing.T) {
+	ts, _ := beitrittsServer(t)
+	traegerID := traegerAnlegen(t, ts, "Dorfpflege", "222")
+	resp := beitrittStellen(t, ts, dorfpflegeMitglied, traegerID, "bitte")
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("HTTP %d, erwartet 409", resp.StatusCode)
+	}
+}
+
+// Ein Träger ohne Zitadel-Projekt hat keine Mitglieder — dann gibt es auch
+// nichts zu beantragen und nichts einzutragen.
+func TestOhneProjektKeinBeitritt(t *testing.T) {
+	ts, _ := beitrittsServer(t)
+	resp := doReq(t, "POST", ts+"/api/v1/traeger", betreiberToken, map[string]any{
+		"name": "Noch ohne Projekt", "status": "zugelassen", "sichtbarkeit": "offen"})
+	traegerID := decode[struct {
+		ID int64 `json:"id"`
+	}](t, resp).ID
+
+	if resp := beitrittStellen(t, ts, aussenToken, traegerID, "bitte"); resp.StatusCode != http.StatusConflict {
+		t.Errorf("HTTP %d, erwartet 409", resp.StatusCode)
+	}
+	resp = doReq(t, "POST", fmt.Sprintf("%s/api/v1/traeger/%d/mitglieder", ts, traegerID),
+		betreiberToken, map[string]any{"userSub": "erna"})
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("Aufnehmen ohne Projekt: HTTP %d, erwartet 409", resp.StatusCode)
+	}
+}
+
+// Jede und jeder sieht die eigenen Anträge — mit dem Namen des Trägers, nicht
+// mit einer Kennung.
+func TestMeineBeitritte(t *testing.T) {
+	ts, _ := beitrittsServer(t)
+	traegerID := traegerAnlegen(t, ts, "AK 2 Umwelt und Natur", "222")
+	beitrittStellen(t, ts, aussenToken, traegerID, "bitte")
+
+	resp := doReq(t, "GET", ts+"/api/v1/me/beitritte", aussenToken, nil)
+	liste := decode[struct {
+		Beitritte []model.Beitritt `json:"beitritte"`
+	}](t, resp).Beitritte
+	if len(liste) != 1 || liste[0].TraegerName != "AK 2 Umwelt und Natur" ||
+		liste[0].Status != model.AntragBeantragt {
+		t.Fatalf("eigene Anträge fehlen oder sind unvollständig: %+v", liste)
+	}
+}
+
+// Die Liste der Träger sagt, was hier möglich ist: Ohne diese Felder müsste
+// die App die Regeln nachbauen — und käme früher oder später zu einem
+// anderen Ergebnis als der Server.
+func TestTraegerListeSagtWasMoeglichIst(t *testing.T) {
+	ts, _ := beitrittsServer(t)
+	traegerID := traegerAnlegen(t, ts, "AK 2 Umwelt und Natur", "222")
+
+	resp := doReq(t, "GET", ts+"/api/v1/traeger", aussenToken, nil)
+	sicht := decode[struct {
+		Traeger []TraegerAnsicht `json:"traeger"`
+	}](t, resp).Traeger
+	if len(sicht) != 1 || !sicht[0].BeitrittMoeglich || sicht[0].BeitrittStatus != "" {
+		t.Fatalf("Beitritt wird nicht angeboten: %+v", sicht)
+	}
+
+	beitrittStellen(t, ts, aussenToken, traegerID, "bitte")
+	resp = doReq(t, "GET", ts+"/api/v1/traeger", aussenToken, nil)
+	sicht = decode[struct {
+		Traeger []TraegerAnsicht `json:"traeger"`
+	}](t, resp).Traeger
+	if sicht[0].BeitrittStatus != model.AntragBeantragt {
+		t.Fatalf("der eigene Antrag taucht nicht auf: %+v", sicht)
+	}
+
+	// Der Träger-Admin sieht, dass etwas offen ist.
+	resp = doReq(t, "GET", ts+"/api/v1/traeger", dorfpflegeAdmin, nil)
+	sicht = decode[struct {
+		Traeger []TraegerAnsicht `json:"traeger"`
+	}](t, resp).Traeger
+	if len(sicht) != 1 || sicht[0].OffeneBeitritte != 1 || !sicht[0].DarfVerwalten {
+		t.Fatalf("der Träger-Admin sieht den offenen Antrag nicht: %+v", sicht)
+	}
+}
+
+// Fremde Anträge gehen niemanden etwas an — auch nicht die Verwaltung eines
+// anderen Vereins.
+func TestFremdeBeitritteBleibenFremd(t *testing.T) {
+	ts, _ := beitrittsServer(t)
+	traegerID := traegerAnlegen(t, ts, "AK 2 Umwelt und Natur", "222")
+	beitrittStellen(t, ts, aussenToken, traegerID, "bitte")
+
+	resp := doReq(t, "GET", fmt.Sprintf("%s/api/v1/traeger/%d/beitritte", ts, traegerID),
+		dorfpflegeMitglied, nil)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("ein einfaches Mitglied liest die Anträge: HTTP %d", resp.StatusCode)
+	}
+	resp = doReq(t, "POST", fmt.Sprintf("%s/api/v1/traeger/%d/mitglieder", ts, traegerID),
+		dorfpflegeMitglied, map[string]any{"userSub": "erna"})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("ein einfaches Mitglied nimmt Leute auf: HTTP %d", resp.StatusCode)
+	}
+}

--- a/backend/internal/api/traeger.go
+++ b/backend/internal/api/traeger.go
@@ -33,6 +33,8 @@ func (s *Server) registerTraeger(api *http.ServeMux) {
 	api.HandleFunc("GET /api/v1/traeger/{id}/antraege", s.handleListAntraege)
 	api.HandleFunc("POST /api/v1/antraege/{id}", s.handleAntragEntscheiden)
 	api.HandleFunc("GET /api/v1/me/befaehigungen", s.handleMeineBefaehigungen)
+
+	s.registerBeitritt(api)
 }
 
 // --- Zugriffs-Helfer --------------------------------------------------------
@@ -145,6 +147,46 @@ type TraegerInput struct {
 	Sichtbarkeit string `json:"sichtbarkeit"`
 }
 
+// TraegerAnsicht ist ein Träger, wie ihn genau diese Person sieht.
+//
+// Ohne diese Felder müsste die App raten, ob der Knopf „Mitmachen“ etwas
+// bewirkt — und die Antwort hinge an Regeln, die nur der Server kennt (Zutritt,
+// Sichtbarkeit, bestehende Mitgliedschaft, ein schon gestellter Antrag).
+// Deshalb steht hier, was gilt, und nicht bloß der Träger.
+type TraegerAnsicht struct {
+	model.Traeger
+	IstMitglied   bool `json:"istMitglied"`
+	DarfVerwalten bool `json:"darfVerwalten"`
+	// BeitrittMoeglich: Hier kann diese Person jetzt einen Antrag stellen.
+	BeitrittMoeglich bool `json:"beitrittMoeglich"`
+	// BeitrittHindernis nennt den Grund, warum nicht — leer, wenn es geht.
+	// Er ist deutsch und für die Anzeige gedacht.
+	BeitrittHindernis string `json:"beitrittHindernis,omitempty"`
+	// BeitrittStatus ist der Stand des eigenen Antrags („“ = keiner).
+	BeitrittStatus model.AntragStatus `json:"beitrittStatus,omitempty"`
+	// OffeneBeitritte zählt die unentschiedenen Anträge — nur für die,
+	// die den Träger verwalten.
+	OffeneBeitritte int `json:"offeneBeitritte,omitempty"`
+}
+
+// traegerAnsicht baut die Sicht einer Person auf einen Träger.
+func (s *Server) traegerAnsicht(z model.Zugriff, t model.Traeger, offen map[int64]int) TraegerAnsicht {
+	a := TraegerAnsicht{
+		Traeger:           t,
+		IstMitglied:       z.Mitglied.IstMitglied(t.ProjektID),
+		DarfVerwalten:     z.DarfVerwalten(t),
+		BeitrittHindernis: z.BeitrittsHindernis(t),
+	}
+	a.BeitrittMoeglich = a.BeitrittHindernis == ""
+	if eigener, err := s.DB.BeitrittVon(t.ID, z.Sub); err == nil && eigener != nil {
+		a.BeitrittStatus = eigener.Status
+	}
+	if a.DarfVerwalten {
+		a.OffeneBeitritte = offen[t.ID]
+	}
+	return a
+}
+
 func (s *Server) handleListTraeger(w http.ResponseWriter, r *http.Request) {
 	z := s.zugriff(r)
 	alle, err := s.DB.ListTraeger()
@@ -152,10 +194,15 @@ func (s *Server) handleListTraeger(w http.ResponseWriter, r *http.Request) {
 		writeInternal(w, r, err)
 		return
 	}
-	sichtbar := []model.Traeger{}
+	offen, err := s.DB.OffeneBeitritte()
+	if err != nil {
+		writeInternal(w, r, err)
+		return
+	}
+	sichtbar := []TraegerAnsicht{}
 	for _, t := range alle {
 		if z.SiehtTraeger(t) {
-			sichtbar = append(sichtbar, t)
+			sichtbar = append(sichtbar, s.traegerAnsicht(z, t, offen))
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"traeger": sichtbar})
@@ -167,8 +214,13 @@ func (s *Server) handleGetTraeger(w http.ResponseWriter, r *http.Request) {
 		schreibeZugriffsfehler(w, r, err)
 		return
 	}
+	offen, err := s.DB.OffeneBeitritte()
+	if err != nil {
+		writeInternal(w, r, err)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"traeger": t, "darfVerwalten": z.DarfVerwalten(t),
+		"traeger": s.traegerAnsicht(z, t, offen), "darfVerwalten": z.DarfVerwalten(t),
 	})
 }
 

--- a/backend/internal/db/beitritt_test.go
+++ b/backend/internal/db/beitritt_test.go
@@ -1,0 +1,139 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Beitritte in der Datenbank: der Vorgang, nicht die Mitgliedschaft. Wer
+// dazugehört, sagt die Rössing-ID — hier steht, wer gefragt und wer
+// entschieden hat.
+
+func beitrittStellen(t *testing.T, d *DB, traegerID int64, sub, grund string) model.Beitritt {
+	t.Helper()
+	b := model.Beitritt{TraegerID: traegerID, UserSub: sub, Status: model.AntragBeantragt,
+		Begruendung: grund, CreatedAt: time.Now().UTC()}
+	if err := d.InsertBeitritt(&b); err != nil {
+		t.Fatalf("Beitritt stellen: %v", err)
+	}
+	return b
+}
+
+func TestBeitrittStellenUndEntscheiden(t *testing.T) {
+	d := testDB(t)
+	tr := testTraeger(t, d, "AK 2 Umwelt und Natur", "388")
+	b := beitrittStellen(t, d, tr.ID, "erna", "Ich wohne neben dem Beet")
+
+	offen, err := d.ListBeitritte(tr.ID, model.AntragBeantragt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(offen) != 1 || offen[0].Begruendung != "Ich wohne neben dem Beet" {
+		t.Fatalf("offener Antrag fehlt: %+v", offen)
+	}
+
+	entschieden := time.Date(2026, 8, 31, 9, 0, 0, 0, time.UTC)
+	if err := d.EntscheideBeitritt(b.ID, model.AntragErteilt, "vorstand", "willkommen", entschieden); err != nil {
+		t.Fatal(err)
+	}
+	nachher, err := d.GetBeitritt(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nachher.Status != model.AntragErteilt || nachher.EntschiedenVon != "vorstand" ||
+		nachher.Notiz != "willkommen" || nachher.EntschiedenAm == nil {
+		t.Fatalf("Entscheidung nicht festgehalten: %+v", nachher)
+	}
+	if rest, _ := d.ListBeitritte(tr.ID, model.AntragBeantragt); len(rest) != 0 {
+		t.Errorf("der entschiedene Antrag steht noch als offen: %+v", rest)
+	}
+}
+
+// Je Person und Träger genau eine Zeile: Ein zweiter Antrag belebt den
+// bestehenden wieder, statt Karteileichen zu stapeln.
+func TestZweiterAntragBelebtDenErsten(t *testing.T) {
+	d := testDB(t)
+	tr := testTraeger(t, d, "Dorfpflege", "377")
+	erst := beitrittStellen(t, d, tr.ID, "erna", "erster Versuch")
+	if err := d.EntscheideBeitritt(erst.ID, model.AntragAbgelehnt, "vorstand", "später", time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	zweit := beitrittStellen(t, d, tr.ID, "erna", "jetzt aber")
+	if zweit.ID != erst.ID {
+		t.Fatalf("es entstand eine zweite Zeile (%d statt %d)", zweit.ID, erst.ID)
+	}
+	nachher, err := d.GetBeitritt(erst.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nachher.Status != model.AntragBeantragt || nachher.Begruendung != "jetzt aber" {
+		t.Fatalf("der Antrag wurde nicht wiederbelebt: %+v", nachher)
+	}
+	if nachher.Notiz != "" || nachher.EntschiedenVon != "" || nachher.EntschiedenAm != nil {
+		t.Errorf("die alte Entscheidung klebt am neuen Antrag: %+v", nachher)
+	}
+}
+
+// Auch ein erteilter Antrag lässt sich neu stellen — anders als bei der
+// Befähigung. Wer aus dem Verein ausgetreten ist, steht in der Rössing-ID
+// nicht mehr, und der alte Vermerk hier macht ihn nicht wieder zum Mitglied.
+func TestAuchNachAufnahmeLaesstSichNeuFragen(t *testing.T) {
+	d := testDB(t)
+	tr := testTraeger(t, d, "Dorfpflege", "377")
+	b := beitrittStellen(t, d, tr.ID, "erna", "bitte")
+	if err := d.EntscheideBeitritt(b.ID, model.AntragErteilt, "vorstand", "", time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	beitrittStellen(t, d, tr.ID, "erna", "wieder da")
+	nachher, err := d.GetBeitritt(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nachher.Status != model.AntragBeantragt {
+		t.Fatalf("der erteilte Antrag ließ sich nicht neu stellen: %+v", nachher)
+	}
+}
+
+func TestBeitritteJePersonUndZaehler(t *testing.T) {
+	d := testDB(t)
+	pflege := testTraeger(t, d, "Dorfpflege", "377")
+	ak := testTraeger(t, d, "AK 2 Umwelt und Natur", "388")
+	beitrittStellen(t, d, pflege.ID, "erna", "")
+	beitrittStellen(t, d, ak.ID, "erna", "")
+	beitrittStellen(t, d, ak.ID, "hans", "")
+
+	meine, err := d.ListBeitritteVonPerson("erna")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(meine) != 2 {
+		t.Fatalf("%d eigene Anträge statt 2: %+v", len(meine), meine)
+	}
+	// Der Trägername gehört dazu — sonst müsste die App Kennungen auflösen.
+	for _, b := range meine {
+		if b.TraegerName == "" {
+			t.Errorf("Antrag ohne Trägernamen: %+v", b)
+		}
+	}
+
+	zaehler, err := d.OffeneBeitritte()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if zaehler[pflege.ID] != 1 || zaehler[ak.ID] != 2 {
+		t.Fatalf("falsch gezählt: %+v", zaehler)
+	}
+
+	// Ein eigener Antrag ist über Träger und Person auffindbar.
+	eigener, err := d.BeitrittVon(ak.ID, "hans")
+	if err != nil || eigener == nil {
+		t.Fatalf("eigener Antrag nicht gefunden: %v %+v", err, eigener)
+	}
+	keiner, err := d.BeitrittVon(pflege.ID, "hans")
+	if err != nil || keiner != nil {
+		t.Fatalf("aus dem Nichts entstandener Antrag: %v %+v", err, keiner)
+	}
+}

--- a/backend/internal/db/traeger.go
+++ b/backend/internal/db/traeger.go
@@ -64,6 +64,26 @@ CREATE TABLE IF NOT EXISTS befaehigungs_antraege (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_antrag_person
   ON befaehigungs_antraege(befaehigung_id, user_sub);
 CREATE INDEX IF NOT EXISTS idx_antrag_status ON befaehigungs_antraege(status);
+
+-- Beitritte: „Ich will bei euch mitmachen.“ Anders als beim Befähigungs-
+-- antrag ist ein erteilter Beitritt NICHT die Mitgliedschaft — die steht in
+-- der Rössing-ID. Hier steht der Vorgang: wer gefragt hat, wer entschieden
+-- hat, wann. Je Person und Träger genau eine Zeile; ein erneuter Antrag
+-- belebt sie wieder, statt Karteileichen zu stapeln.
+CREATE TABLE IF NOT EXISTS beitritte (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  traeger_id      INTEGER NOT NULL REFERENCES traeger(id) ON DELETE CASCADE,
+  user_sub        TEXT NOT NULL,
+  status          TEXT NOT NULL DEFAULT 'beantragt',
+  begruendung     TEXT NOT NULL DEFAULT '',
+  notiz           TEXT NOT NULL DEFAULT '',
+  created_at      TEXT NOT NULL,
+  entschieden_am  TEXT NOT NULL DEFAULT '',
+  entschieden_von TEXT NOT NULL DEFAULT ''
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_beitritt_person
+  ON beitritte(traeger_id, user_sub);
+CREATE INDEX IF NOT EXISTS idx_beitritt_status ON beitritte(status);
 `); err != nil {
 		return err
 	}
@@ -556,4 +576,158 @@ func scanAntrag(row scannable) (*model.BefaehigungsAntrag, error) {
 	a.CreatedAt, _ = time.Parse(timeFormat, created)
 	a.EntschiedenAm = zeitWert(entschieden)
 	return &a, nil
+}
+
+// --- Beitritte --------------------------------------------------------------
+
+const beitrittSpalten = `id,traeger_id,user_sub,status,begruendung,notiz,created_at,entschieden_am,entschieden_von`
+
+// InsertBeitritt stellt einen Beitrittsantrag. Gibt es für diese Person und
+// diesen Träger schon einen, wird er wiederbelebt.
+//
+// Anders als beim Befähigungsantrag überlebt auch ein bereits erteilter
+// Antrag das nicht: Wer einmal aufgenommen war und heute nicht mehr in der
+// Rössing-ID steht, ist ausgetreten oder entfernt worden und fragt neu. Der
+// alte Vorgang ist damit erledigt, nicht mehr gültig — ob jemand Mitglied
+// ist, sagt ohnehin nur Zitadel.
+func (d *DB) InsertBeitritt(b *model.Beitritt) error {
+	res, err := d.sql.Exec(`INSERT INTO beitritte
+		(traeger_id,user_sub,status,begruendung,created_at) VALUES(?,?,?,?,?)
+		ON CONFLICT(traeger_id,user_sub) DO UPDATE SET
+		  status      = excluded.status,
+		  begruendung = excluded.begruendung,
+		  created_at  = excluded.created_at,
+		  entschieden_am = '', entschieden_von = '', notiz = ''`,
+		b.TraegerID, b.UserSub, string(b.Status), b.Begruendung,
+		b.CreatedAt.UTC().Format(timeFormat))
+	if err != nil {
+		return err
+	}
+	if b.ID, err = res.LastInsertId(); err != nil || b.ID > 0 {
+		return err
+	}
+	// Beim Aktualisieren liefert SQLite keine brauchbare ID zurück.
+	return d.sql.QueryRow(`SELECT id FROM beitritte WHERE traeger_id=? AND user_sub=?`,
+		b.TraegerID, b.UserSub).Scan(&b.ID)
+}
+
+// EntscheideBeitritt hält die Entscheidung fest.
+//
+// Sie wird erst geschrieben, wenn die Rollenzuweisung in der Rössing-ID
+// steht — sonst stünde hier „Mitglied“ und dort nichts.
+func (d *DB) EntscheideBeitritt(id int64, status model.AntragStatus, durch, notiz string, at time.Time) error {
+	res, err := d.sql.Exec(`UPDATE beitritte
+		SET status=?, notiz=?, entschieden_am=?, entschieden_von=? WHERE id=?`,
+		string(status), notiz, at.UTC().Format(timeFormat), durch, id)
+	if err != nil {
+		return err
+	}
+	return requireRow(res)
+}
+
+func (d *DB) GetBeitritt(id int64) (*model.Beitritt, error) {
+	return scanBeitritt(d.sql.QueryRow(`SELECT `+beitrittSpalten+` FROM beitritte WHERE id=?`, id))
+}
+
+// BeitrittVon liefert den Antrag dieser Person an diesen Träger, falls es
+// einen gibt. (nil, nil), wenn nicht.
+func (d *DB) BeitrittVon(traegerID int64, userSub string) (*model.Beitritt, error) {
+	b, err := scanBeitritt(d.sql.QueryRow(`SELECT `+beitrittSpalten+`
+		FROM beitritte WHERE traeger_id=? AND user_sub=?`, traegerID, userSub))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return b, err
+}
+
+// ListBeitritte liefert die Anträge eines Trägers, optional auf einen Stand
+// gefiltert (leerer Status = alle).
+func (d *DB) ListBeitritte(traegerID int64, status model.AntragStatus) ([]model.Beitritt, error) {
+	query := `SELECT ` + beitrittSpalten + ` FROM beitritte WHERE traeger_id = ?`
+	args := []any{traegerID}
+	if status != "" {
+		query += ` AND status = ?`
+		args = append(args, string(status))
+	}
+	query += ` ORDER BY created_at DESC`
+	rows, err := d.sql.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return sammleBeitritte(rows)
+}
+
+// ListBeitritteVonPerson liefert alles, was jemand beantragt hat — mit dem
+// Namen des Trägers, damit die App keine Kennungen auflösen muss.
+func (d *DB) ListBeitritteVonPerson(userSub string) ([]model.Beitritt, error) {
+	rows, err := d.sql.Query(`SELECT b.id,b.traeger_id,b.user_sub,b.status,b.begruendung,b.notiz,
+	                 b.created_at,b.entschieden_am,b.entschieden_von,t.name
+	            FROM beitritte b
+	            JOIN traeger t ON t.id = b.traeger_id
+	           WHERE b.user_sub = ? ORDER BY t.name`, userSub)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []model.Beitritt{}
+	for rows.Next() {
+		var b model.Beitritt
+		var status, created, entschieden string
+		if err := rows.Scan(&b.ID, &b.TraegerID, &b.UserSub, &status, &b.Begruendung, &b.Notiz,
+			&created, &entschieden, &b.EntschiedenVon, &b.TraegerName); err != nil {
+			return nil, err
+		}
+		b.Status = model.AntragStatus(status)
+		b.CreatedAt, _ = time.Parse(timeFormat, created)
+		b.EntschiedenAm = zeitWert(entschieden)
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// OffeneBeitritte zählt die unentschiedenen Anträge je Träger — für die
+// Listen, die den Zähler an jedem Träger zeigen, ohne je Zeile zu fragen.
+func (d *DB) OffeneBeitritte() (map[int64]int, error) {
+	rows, err := d.sql.Query(`SELECT traeger_id, COUNT(*) FROM beitritte
+		WHERE status = ? GROUP BY traeger_id`, string(model.AntragBeantragt))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[int64]int{}
+	for rows.Next() {
+		var id int64
+		var n int
+		if err := rows.Scan(&id, &n); err != nil {
+			return nil, err
+		}
+		out[id] = n
+	}
+	return out, rows.Err()
+}
+
+func sammleBeitritte(rows *sql.Rows) ([]model.Beitritt, error) {
+	out := []model.Beitritt{}
+	for rows.Next() {
+		b, err := scanBeitritt(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *b)
+	}
+	return out, rows.Err()
+}
+
+func scanBeitritt(row scannable) (*model.Beitritt, error) {
+	var b model.Beitritt
+	var status, created, entschieden string
+	if err := row.Scan(&b.ID, &b.TraegerID, &b.UserSub, &status, &b.Begruendung, &b.Notiz,
+		&created, &entschieden, &b.EntschiedenVon); err != nil {
+		return nil, err
+	}
+	b.Status = model.AntragStatus(status)
+	b.CreatedAt, _ = time.Parse(timeFormat, created)
+	b.EntschiedenAm = zeitWert(entschieden)
+	return &b, nil
 }

--- a/backend/internal/mcp/beitritt.go
+++ b/backend/internal/mcp/beitritt.go
@@ -1,0 +1,168 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/api"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Beitritte über MCP: sehen, entscheiden, jemanden aufnehmen.
+//
+// MCP ist der Verwaltungsweg (#62): Was in der Web-Verwaltung geht, muss auch
+// hier gehen. Sonst müsste der Betreiber für eine einzige Aufnahme einen
+// Browser mit angemeldeter Sitzung suchen — auf dem Telefon ist das eine
+// Sackgasse, für eine Maschine gar kein Weg.
+//
+// Alles Schreibende geht durch api.Aufnehmen bzw. api.BeitrittEntscheiden.
+// Dort steht der Schritt, auf den es ankommt: die Rollenzuweisung in der
+// Rössing-ID. Ein zweiter Weg daneben würde ihn früher oder später vergessen.
+
+// beitrittAnsicht nennt Träger und Person beim Namen. Wer eine Liste
+// vorgelesen bekommt, kann mit Kennungen nichts anfangen — die Kennung steht
+// trotzdem dabei, denn beitritt_entscheiden braucht sie.
+type beitrittAnsicht struct {
+	model.Beitritt
+	TraegerName string `json:"traegerName,omitempty"`
+}
+
+func (s *Server) toolListBeitritte(args json.RawMessage, _ auth.User) (any, error) {
+	var in struct {
+		TraegerID int64  `json:"traegerId"`
+		Status    string `json:"status"`
+	}
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &in); err != nil {
+			return nil, err
+		}
+	}
+	status := model.AntragStatus(in.Status)
+	if status != "" && !model.ValidAntragStatus(status) {
+		return nil, fmt.Errorf("status muss beantragt, erteilt oder abgelehnt sein, nicht %q", in.Status)
+	}
+	traeger, err := s.DB.TraegerIndex()
+	if err != nil {
+		return nil, err
+	}
+	namen, err := s.DB.NameResolver()
+	if err != nil {
+		return nil, err
+	}
+	out := []beitrittAnsicht{}
+	for id, t := range traeger {
+		if in.TraegerID > 0 && id != in.TraegerID {
+			continue
+		}
+		liste, err := s.DB.ListBeitritte(id, status)
+		if err != nil {
+			return nil, err
+		}
+		for _, b := range liste {
+			b.UserName = namen.Resolve(b.UserSub, "")
+			out = append(out, beitrittAnsicht{Beitritt: b, TraegerName: t.Name})
+		}
+	}
+	return out, nil
+}
+
+func (s *Server) toolBeitrittEntscheiden(args json.RawMessage, u auth.User) (any, error) {
+	if err := nurBetreiber(u, "über Beitritte entscheiden"); err != nil {
+		return nil, err
+	}
+	var in struct {
+		ID     int64  `json:"id"`
+		Status string `json:"status"`
+		Notiz  string `json:"notiz"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, err
+	}
+	b, err := s.DB.GetBeitritt(in.ID)
+	if err != nil {
+		return nil, fmt.Errorf("Beitrittsantrag %d nicht gefunden", in.ID)
+	}
+	t, err := s.DB.GetTraeger(b.TraegerID)
+	if err != nil {
+		return nil, fmt.Errorf("Träger %d nicht gefunden", b.TraegerID)
+	}
+	status := model.AntragStatus(in.Status)
+	if status == "" {
+		status = model.AntragErteilt
+	}
+	// Ein Werkzeug bekommt (noch) keinen Context durchgereicht; der Aufruf
+	// nach Zitadel hat seine eigene Frist (siehe internal/mitglied).
+	return api.BeitrittEntscheiden(context.Background(), s.DB, s.Mitglieder, *t, *b,
+		status, u.Sub, in.Notiz, s.now())
+}
+
+// toolMitgliedAufnehmen trägt jemanden ohne vorherigen Antrag ein.
+//
+// Wie beim Erteilen einer Befähigung fehlt hier der erste Schritt, und aus
+// demselben Grund: Zugesagt wird im Dorf am Gartenzaun, nicht in der App. Wer
+// eine geschlossene Gruppe verwaltet, hat überhaupt keinen anderen Weg — sie
+// nimmt keine Anträge entgegen.
+func (s *Server) toolMitgliedAufnehmen(args json.RawMessage, u auth.User) (any, error) {
+	if err := nurBetreiber(u, "Mitglieder aufnehmen"); err != nil {
+		return nil, err
+	}
+	var in struct {
+		TraegerID int64  `json:"traegerId"`
+		UserSub   string `json:"userSub"`
+		Notiz     string `json:"notiz"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return nil, err
+	}
+	t, err := s.DB.GetTraeger(in.TraegerID)
+	if err != nil {
+		return nil, fmt.Errorf("Träger %d nicht gefunden", in.TraegerID)
+	}
+	return api.Aufnehmen(context.Background(), s.DB, s.Mitglieder, *t,
+		in.UserSub, u.Sub, in.Notiz, s.now())
+}
+
+// beitrittTools sind die Werkzeuge dieses Bereichs. Sie stehen hier und nicht
+// in der großen Liste, damit der Bereich für sich lesbar bleibt.
+func (s *Server) beitrittTools() []tool {
+	return []tool{
+		{
+			Name: "beitritte_liste",
+			Description: "Listet Beitrittsanträge („ich will bei euch mitmachen“) samt Stand. " +
+				"Ohne Angabe alle Träger und alle Stände.",
+			Schema: obj(nil, map[string]any{
+				"traegerId": integer("Nur die Anträge an diesen Träger"),
+				"status":    enum("Nur Anträge in diesem Stand", "beantragt", "erteilt", "abgelehnt"),
+			}),
+			Handler: s.toolListBeitritte,
+		},
+		{
+			Name: "beitritt_entscheiden",
+			Description: "Gibt einen Beitrittsantrag frei oder lehnt ihn ab. Die Freigabe trägt " +
+				"die Rolle 'mitglied' unmittelbar in der Rössing-ID ein — niemand muss dafür " +
+				"in die Zitadel-Konsole. Klappt das Eintragen nicht, bleibt der Antrag offen " +
+				"und die Meldung sagt, woran es lag. Die IDs stehen in beitritte_liste.",
+			Schema: obj([]string{"id"}, map[string]any{
+				"id":     integer("ID des Beitrittsantrags"),
+				"status": enum("erteilt (Standard) oder abgelehnt", "erteilt", "abgelehnt"),
+				"notiz":  str("Notiz zur Entscheidung"),
+			}),
+			Handler: s.toolBeitrittEntscheiden,
+		},
+		{
+			Name: "mitglied_aufnehmen",
+			Description: "Nimmt jemanden in einen Träger auf, auch ohne vorherigen Antrag — " +
+				"z.B. wenn auf der Versammlung zugesagt wurde. Bei einer geschlossenen Gruppe " +
+				"ist das der einzige Weg: Anträge nimmt sie nicht entgegen. Die Kennung " +
+				"(userSub) steht in der Rangliste und in jeder Erledigung.",
+			Schema: obj([]string{"traegerId", "userSub"}, map[string]any{
+				"traegerId": integer("ID des Trägers"),
+				"userSub":   str("Kennung der Person aus der Rössing-ID"),
+				"notiz":     str("Notiz, z.B. wann und wo zugesagt wurde"),
+			}),
+			Handler: s.toolMitgliedAufnehmen,
+		},
+	}
+}

--- a/backend/internal/mcp/beitritt_test.go
+++ b/backend/internal/mcp/beitritt_test.go
@@ -1,0 +1,173 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/db"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/mitglied"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Beitritte über MCP: Was in der Web-Verwaltung geht, muss auch hier gehen
+// (#62). Vor allem das eine, worauf es ankommt — die Rolle landet wirklich in
+// der Rössing-ID.
+
+// roessingID spielt die Rössing-ID: Sie merkt sich, wer aufgenommen wurde.
+type roessingID struct {
+	mu          sync.Mutex
+	aufgenommen map[string]string // "sub@projekt" → Rolle
+	fehler      error
+}
+
+func (q *roessingID) Fuer(context.Context, auth.User) mitglied.Stand {
+	return mitglied.Stand{Rollen: model.Mitgliedschaften{}}
+}
+
+func (q *roessingID) Aufnehmen(_ context.Context, projektID, userSub, rolle string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.fehler != nil {
+		return q.fehler
+	}
+	q.aufgenommen[userSub+"@"+projektID] = rolle
+	return nil
+}
+
+func (q *roessingID) hat(sub, projektID string) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.aufgenommen[sub+"@"+projektID] == model.RolleMitglied
+}
+
+// serverMitRoessingID ist serverMitDB, aber mit einer Rössing-ID, in die
+// zurückgeschrieben werden kann.
+func serverMitRoessingID(t *testing.T) (*httptest.Server, *db.DB, *roessingID) {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { d.Close() })
+	q := &roessingID{aufgenommen: map[string]string{}}
+	s := New(d, stubVerifier{}, issuer, "https://api.example", "client-123")
+	s.Now = func() time.Time { return time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC) }
+	s.Mitglieder = q
+	mux := http.NewServeMux()
+	s.Register(mux)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts, d, q
+}
+
+func testTraeger(t *testing.T, d *db.DB, name, projektID string) model.Traeger {
+	t.Helper()
+	tr := model.Traeger{Name: name, ProjektID: projektID, Status: model.TraegerZugelassen,
+		Sichtbarkeit: model.TraegerOffen, CreatedAt: time.Now().UTC()}
+	if err := d.InsertTraeger(&tr); err != nil {
+		t.Fatal(err)
+	}
+	return tr
+}
+
+func TestBeitrittsWerkzeugeSindAngemeldet(t *testing.T) {
+	ts := newTestServer(t)
+	out := rpc(t, ts, "admin-jwt", "tools/list", nil)
+	namen := map[string]bool{}
+	for _, roh := range out["result"].(map[string]any)["tools"].([]any) {
+		namen[roh.(map[string]any)["name"].(string)] = true
+	}
+	for _, name := range []string{"beitritte_liste", "beitritt_entscheiden", "mitglied_aufnehmen"} {
+		if !namen[name] {
+			t.Errorf("Werkzeug %q fehlt", name)
+		}
+	}
+}
+
+// Der Durchstich über MCP: offenen Antrag sehen, freigeben, und die Rolle
+// steht in der Rössing-ID.
+func TestBeitrittUeberMCPEntscheiden(t *testing.T) {
+	ts, d, roessing := serverMitRoessingID(t)
+	tr := testTraeger(t, d, "AK 2 Umwelt und Natur", "388")
+	b := model.Beitritt{TraegerID: tr.ID, UserSub: "erna", Status: model.AntragBeantragt,
+		Begruendung: "Ich wohne neben dem Beet", CreatedAt: time.Now().UTC()}
+	if err := d.InsertBeitritt(&b); err != nil {
+		t.Fatal(err)
+	}
+
+	text, fehler := callTool(t, ts, "beitritte_liste", map[string]any{"status": "beantragt"})
+	if fehler {
+		t.Fatalf("beitritte_liste: %s", text)
+	}
+	var liste []struct {
+		ID          int64  `json:"id"`
+		TraegerName string `json:"traegerName"`
+	}
+	if err := json.Unmarshal([]byte(text), &liste); err != nil {
+		t.Fatalf("Antwort nicht lesbar: %v — %s", err, text)
+	}
+	if len(liste) != 1 || liste[0].TraegerName != "AK 2 Umwelt und Natur" {
+		t.Fatalf("der offene Antrag fehlt oder nennt den Träger nicht: %s", text)
+	}
+
+	text, fehler = callTool(t, ts, "beitritt_entscheiden",
+		map[string]any{"id": b.ID, "notiz": "willkommen"})
+	if fehler {
+		t.Fatalf("beitritt_entscheiden: %s", text)
+	}
+	nachher, err := d.GetBeitritt(b.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nachher.Status != model.AntragErteilt {
+		t.Fatalf("Antrag nicht erteilt: %+v", nachher)
+	}
+	if !roessing.hat("erna", "388") {
+		t.Fatal("die Mitgliedschaft wurde nicht in die Rössing-ID zurückgeschrieben")
+	}
+}
+
+// Aufnehmen ohne vorherigen Antrag — der Weg für die geschlossene Gruppe.
+func TestMitgliedUeberMCPAufnehmen(t *testing.T) {
+	ts, d, roessing := serverMitRoessingID(t)
+	tr := testTraeger(t, d, "Dorfpflege Rössing e.V.", "377")
+
+	text, fehler := callTool(t, ts, "mitglied_aufnehmen",
+		map[string]any{"traegerId": tr.ID, "userSub": "erna", "notiz": "Versammlung"})
+	if fehler {
+		t.Fatalf("mitglied_aufnehmen: %s", text)
+	}
+	if !roessing.hat("erna", "377") {
+		t.Fatal("die Mitgliedschaft steht nicht in der Rössing-ID")
+	}
+	vorgang, err := d.BeitrittVon(tr.ID, "erna")
+	if err != nil || vorgang == nil || vorgang.Status != model.AntragErteilt {
+		t.Fatalf("der Vorgang wurde nicht festgehalten: %v %+v", err, vorgang)
+	}
+}
+
+// Ohne schreibende Rössing-ID sagt das Werkzeug, was fehlt — und tut nichts.
+func TestOhneRoessingIDMeldetDasWerkzeugWasFehlt(t *testing.T) {
+	ts, d := serverMitDB(t) // ohne Mitglieder-Quelle
+	tr := testTraeger(t, d, "Dorfpflege Rössing e.V.", "377")
+
+	text, fehler := callTool(t, ts, "mitglied_aufnehmen",
+		map[string]any{"traegerId": tr.ID, "userSub": "erna"})
+	if !fehler {
+		t.Fatalf("die Aufnahme gelang, obwohl niemand schreiben kann: %s", text)
+	}
+	if !strings.Contains(text, "Dienst-Nutzer") {
+		t.Errorf("die Meldung sagt nicht, was einzurichten ist: %s", text)
+	}
+	if vorgang, _ := d.BeitrittVon(tr.ID, "erna"); vorgang != nil {
+		t.Fatalf("es wurde ein Vorgang festgehalten, obwohl nichts geschah: %+v", vorgang)
+	}
+}

--- a/backend/internal/mcp/mcp.go
+++ b/backend/internal/mcp/mcp.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/clock"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/db"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/mitglied"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
 	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/vergabe"
 )
@@ -37,7 +38,11 @@ type Server struct {
 	// (claude.ai) zurückbekommt.
 	ClientID string
 	Now      func() time.Time
-	tools    []tool
+	// Mitglieder liefert die Träger-Mitgliedschaften und nimmt Leute auf
+	// (siehe internal/mitglied). Ohne Quelle lässt sich in der Rössing-ID
+	// nichts eintragen — die Werkzeuge sagen das dann und tun nichts.
+	Mitglieder mitglied.Quelle
+	tools      []tool
 
 	discoveryMu sync.Mutex
 	discovery   *upstreamDiscovery
@@ -471,6 +476,7 @@ func (s *Server) registerTools() {
 	// Weitere Bereiche bringen ihre Werkzeuge selbst mit; bestehende Namen
 	// bleiben dabei unverändert.
 	s.tools = append(s.tools, s.ideenTools()...)
+	s.tools = append(s.tools, s.beitrittTools()...)
 }
 
 func (s *Server) toolListPlaces(json.RawMessage, auth.User) (any, error) {

--- a/backend/internal/mitglied/aufnahme.go
+++ b/backend/internal/mitglied/aufnahme.go
@@ -1,0 +1,127 @@
+package mitglied
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Die schreibende Seite: eine Mitgliedschaft nach Zitadel zurückschreiben.
+//
+// # Warum das hier stehen muss und nicht in der App
+//
+// Bis hierher las das Backend die Mitgliedschaften nur. Wer einem Verein
+// beitreten wollte, musste warten, bis ein Mensch ihn in der Zitadel-Konsole
+// einträgt. Ein Antragsverfahren in der App, das am Ende nichts bewirkt, wäre
+// eine Sackgasse: Der Träger-Admin drückt „aufnehmen“, die App sagt
+// „Mitglied“ — und die Rössing-ID weiß nichts davon. Deshalb gilt: Der
+// Vorgang gilt erst als erteilt, wenn die Rollenzuweisung dort wirklich
+// steht.
+//
+// # Was der Betreiber dafür einrichten muss
+//
+// Der Dienst-Nutzer braucht in der Rössing-ID das Recht, Nutzer-Zuweisungen
+// zu ändern („user.grant.write“; in Zitadel steckt es in der Manager-Rolle
+// ORG_USER_PERMISSION_EDITOR). Bis dahin scheitert jede Aufnahme mit einer
+// deutlichen Meldung, statt still nichts zu tun.
+
+// Aufnehmer schreibt eine Rollenzuweisung nach Zitadel zurück.
+//
+// Bewusst nur aufnehmen und nicht entfernen: Zu #56 gehört der Beitritt. Wer
+// jemanden wieder herausnimmt, tut das bis auf Weiteres in der Konsole — ein
+// Austritt hat andere Folgen (Zusagen, interne Aufgaben) und will eigens
+// bedacht werden.
+type Aufnehmer interface {
+	// Aufnehmen gibt der Person die Rolle im Projekt. Hat sie sie schon,
+	// passiert nichts — der Aufruf ist wiederholbar.
+	Aufnehmen(ctx context.Context, projektID, userSub, rolle string) error
+}
+
+// ErrKeineAufnahme heißt: Es gibt niemanden, der schreiben könnte. In der
+// Produktion ist das der Zustand ohne eingerichteten Dienst-Nutzer.
+var ErrKeineAufnahme = errors.New("in der Rössing-ID kann gerade niemand aufgenommen werden — " +
+	"dafür braucht das Backend einen Dienst-Nutzer mit Schreibrecht auf Rollenzuweisungen")
+
+// AufnehmerVon liefert die schreibende Seite einer Quelle, falls sie eine
+// hat. Die Dev-Quelle etwa hat keine: Sie liest die Rollen aus dem Token, und
+// in ein Token lässt sich nichts zurückschreiben.
+func AufnehmerVon(q Quelle) (Aufnehmer, bool) {
+	a, ok := q.(Aufnehmer)
+	return a, ok
+}
+
+// Aufnehmen trägt die Rolle in Zitadel ein.
+//
+// Drei Fälle, und alle drei kommen vor:
+//   - Es gibt noch keine Zuweisung zu diesem Projekt → eine neue anlegen.
+//   - Es gibt eine, aber ohne die Rolle → die Rolle ergänzen, statt die
+//     vorhandenen zu überschreiben. Wer schon „admin“ ist, bleibt es.
+//   - Es gibt eine und sie ist stillgelegt → wieder in Betrieb nehmen,
+//     sonst zählte sie nicht (siehe zuweisung.aktiv).
+func (z *Zitadel) Aufnehmen(ctx context.Context, projektID, userSub, rolle string) error {
+	if projektID == "" {
+		return errors.New("ohne Zitadel-Projekt gibt es keine Mitgliedschaft")
+	}
+	if userSub == "" {
+		return errors.New("ohne Kennung der Person geht das nicht")
+	}
+	if rolle == "" {
+		rolle = model.RolleMitglied
+	}
+	grants, err := z.zuweisungen(ctx, userSub)
+	if err != nil {
+		return err
+	}
+	for _, g := range grants {
+		if g.ProjectID != projektID {
+			continue
+		}
+		if err := z.zuweisungErgaenzen(ctx, userSub, rolle, g); err != nil {
+			return err
+		}
+		// Der gemerkte Stand ist jetzt falsch — die nächste Frage geht
+		// wieder nach Zitadel, damit die Aufnahme sofort wirkt.
+		z.cache.vergessen(userSub)
+		return nil
+	}
+	pfad := "/management/v1/users/" + userSub + "/grants"
+	rumpf := map[string]any{"projectId": projektID, "roleKeys": []string{rolle}}
+	if err := z.ruf(ctx, http.MethodPost, pfad, rumpf, nil); err != nil {
+		return schreibfehler(err)
+	}
+	z.cache.vergessen(userSub)
+	return nil
+}
+
+// zuweisungErgaenzen bringt eine bestehende Zuweisung auf den Stand.
+func (z *Zitadel) zuweisungErgaenzen(ctx context.Context, userSub, rolle string, g zuweisung) error {
+	pfad := "/management/v1/users/" + userSub + "/grants/" + g.ID
+	if !g.hat(rolle) {
+		rollen := append(append([]string{}, g.RoleKeys...), rolle)
+		if err := z.ruf(ctx, http.MethodPut, pfad, map[string]any{"roleKeys": rollen}, nil); err != nil {
+			return schreibfehler(err)
+		}
+	}
+	if !g.aktiv() {
+		if err := z.ruf(ctx, http.MethodPost, pfad+"/_reactivate", map[string]any{}, nil); err != nil {
+			return schreibfehler(err)
+		}
+	}
+	return nil
+}
+
+// schreibfehler übersetzt ein fehlendes Recht in einen Satz, aus dem der
+// Betreiber ablesen kann, was er in der Rössing-ID einzurichten hat. Alles
+// andere bleibt, wie es kam.
+func schreibfehler(err error) error {
+	var api *APIFehler
+	if errors.As(err, &api) && api.FehlendesRecht() {
+		return fmt.Errorf("der Dienst-Nutzer darf in der Rössing-ID keine Rollen vergeben "+
+			"(es fehlt das Recht „user.grant.write“, in Zitadel die Manager-Rolle "+
+			"ORG_USER_PERMISSION_EDITOR): %w", err)
+	}
+	return err
+}

--- a/backend/internal/mitglied/aufnahme_test.go
+++ b/backend/internal/mitglied/aufnahme_test.go
@@ -1,0 +1,273 @@
+package mitglied
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/auth"
+	"github.com/dorfentwicklungskreis-roessing/app/backend/internal/model"
+)
+
+// Das Zurückschreiben ist der Punkt, an dem ein Beitrittsverfahren steht oder
+// fällt: Ohne es sagt die App „Mitglied“ und die Rössing-ID weiß nichts
+// davon. Geprüft wird hier gegen einen nachgebauten Zitadel-Endpunkt — gegen
+// ein echtes Zitadel läuft dasselbe im E2E (backend/e2e).
+
+// aufnahmeServer spielt die Endpunkte, die eine Aufnahme braucht: Token,
+// Rollen-Suche, Zuweisung anlegen, ändern, wieder in Betrieb nehmen.
+type aufnahmeServer struct {
+	*httptest.Server
+	mu sync.Mutex
+	// grants sind die Zuweisungen je Person.
+	grants map[string][]zuweisung
+	// verboten: Der Dienst-Nutzer darf nicht schreiben (fehlendes Recht).
+	verboten bool
+	// protokoll hält fest, was wirklich geschrieben wurde.
+	protokoll []string
+}
+
+func neuerAufnahmeServer(t *testing.T) *aufnahmeServer {
+	t.Helper()
+	as := &aufnahmeServer{grants: map[string][]zuweisung{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth/v2/token", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "dienst-token", "expires_in": 3600})
+	})
+	mux.HandleFunc("POST /management/v1/users/grants/_search", func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			Queries []struct {
+				UserIDQuery struct {
+					UserID string `json:"userId"`
+				} `json:"userIdQuery"`
+			} `json:"queries"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		sub := ""
+		if len(in.Queries) > 0 {
+			sub = in.Queries[0].UserIDQuery.UserID
+		}
+		as.mu.Lock()
+		defer as.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": as.grants[sub]})
+	})
+	mux.HandleFunc("POST /management/v1/users/{sub}/grants", func(w http.ResponseWriter, r *http.Request) {
+		if as.abweisen(w) {
+			return
+		}
+		var in struct {
+			ProjectID string   `json:"projectId"`
+			RoleKeys  []string `json:"roleKeys"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		sub := r.PathValue("sub")
+		as.mu.Lock()
+		defer as.mu.Unlock()
+		as.grants[sub] = append(as.grants[sub],
+			zuweisung{ID: "g1", ProjectID: in.ProjectID, RoleKeys: in.RoleKeys})
+		as.protokoll = append(as.protokoll, "anlegen "+sub+" "+in.ProjectID+" "+strings.Join(in.RoleKeys, ","))
+		_ = json.NewEncoder(w).Encode(map[string]any{"userGrantId": "g1"})
+	})
+	mux.HandleFunc("PUT /management/v1/users/{sub}/grants/{gid}", func(w http.ResponseWriter, r *http.Request) {
+		if as.abweisen(w) {
+			return
+		}
+		var in struct {
+			RoleKeys []string `json:"roleKeys"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		sub, gid := r.PathValue("sub"), r.PathValue("gid")
+		as.mu.Lock()
+		defer as.mu.Unlock()
+		for i, g := range as.grants[sub] {
+			if g.ID == gid {
+				as.grants[sub][i].RoleKeys = in.RoleKeys
+			}
+		}
+		as.protokoll = append(as.protokoll, "aendern "+sub+" "+gid+" "+strings.Join(in.RoleKeys, ","))
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	mux.HandleFunc("POST /management/v1/users/{sub}/grants/{gid}/_reactivate", func(w http.ResponseWriter, r *http.Request) {
+		if as.abweisen(w) {
+			return
+		}
+		sub, gid := r.PathValue("sub"), r.PathValue("gid")
+		as.mu.Lock()
+		defer as.mu.Unlock()
+		for i, g := range as.grants[sub] {
+			if g.ID == gid {
+				as.grants[sub][i].State = "USER_GRANT_STATE_ACTIVE"
+			}
+		}
+		as.protokoll = append(as.protokoll, "beleben "+sub+" "+gid)
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	as.Server = httptest.NewServer(mux)
+	t.Cleanup(as.Close)
+	return as
+}
+
+func (as *aufnahmeServer) abweisen(w http.ResponseWriter) bool {
+	as.mu.Lock()
+	defer as.mu.Unlock()
+	if !as.verboten {
+		return false
+	}
+	w.WriteHeader(http.StatusForbidden)
+	_, _ = w.Write([]byte(`{"message":"No matching permissions found"}`))
+	return true
+}
+
+func (as *aufnahmeServer) setzen(sub string, g ...zuweisung) {
+	as.mu.Lock()
+	defer as.mu.Unlock()
+	as.grants[sub] = g
+}
+
+func (as *aufnahmeServer) geschrieben() []string {
+	as.mu.Lock()
+	defer as.mu.Unlock()
+	return append([]string{}, as.protokoll...)
+}
+
+func aufnahmeZitadel(t *testing.T, as *aufnahmeServer, jetzt func() time.Time) *Zitadel {
+	t.Helper()
+	z, err := New(Config{Issuer: as.URL, SchluesselDatei: schluesselDatei(t),
+		TTL: 30 * time.Second, Now: jetzt})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return z
+}
+
+// Der Normalfall: Jemand hatte mit diesem Verein noch nie zu tun. Danach ist
+// er Mitglied — und das gilt sofort, ohne Ab- und Anmelden.
+func TestAufnahmeLegtEineZuweisungAn(t *testing.T) {
+	as := neuerAufnahmeServer(t)
+	jetzt := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	z := aufnahmeZitadel(t, as, func() time.Time { return jetzt })
+
+	// Vorher gefragt und gemerkt: keine Mitgliedschaft.
+	if z.Fuer(context.Background(), auth.User{Sub: "erna"}).Rollen.IstMitglied("377") {
+		t.Fatal("Vorbedingung: Erna ist noch nicht dabei")
+	}
+
+	if err := z.Aufnehmen(context.Background(), "377", "erna", model.RolleMitglied); err != nil {
+		t.Fatalf("Aufnahme: %v", err)
+	}
+	if got := as.geschrieben(); len(got) != 1 || !strings.HasPrefix(got[0], "anlegen erna 377 mitglied") {
+		t.Fatalf("in Zitadel wurde nicht das Richtige geschrieben: %v", got)
+	}
+	// Der gemerkte Stand darf die frische Mitgliedschaft nicht verdecken.
+	if !z.Fuer(context.Background(), auth.User{Sub: "erna"}).Rollen.IstMitglied("377") {
+		t.Error("die Aufnahme wirkt nicht sofort — der Zwischenspeicher hält den alten Stand fest")
+	}
+}
+
+// Wer im Verein schon eine Rolle hat, verliert sie nicht: Aus dem Vorstand
+// wird kein bloßes Mitglied, nur weil jemand „aufnehmen“ drückt.
+func TestAufnahmeErgaenztDieRolleUndNimmtKeineWeg(t *testing.T) {
+	as := neuerAufnahmeServer(t)
+	as.setzen("vorstand", zuweisung{ID: "g7", ProjectID: "377", RoleKeys: []string{"admin"}})
+	z := aufnahmeZitadel(t, as, nil)
+
+	if err := z.Aufnehmen(context.Background(), "377", "vorstand", model.RolleMitglied); err != nil {
+		t.Fatalf("Aufnahme: %v", err)
+	}
+	got := as.geschrieben()
+	if len(got) != 1 || got[0] != "aendern vorstand g7 admin,mitglied" {
+		t.Fatalf("die vorhandene Rolle wurde nicht bewahrt: %v", got)
+	}
+}
+
+// Eine stillgelegte Zuweisung zählt nicht (siehe zuweisung.aktiv). Wer wieder
+// aufgenommen wird, muss sie wieder in Betrieb bekommen — sonst stünde die
+// Rolle da und wirkte trotzdem nicht.
+func TestAufnahmeBelebtEineStillgelegteZuweisung(t *testing.T) {
+	as := neuerAufnahmeServer(t)
+	as.setzen("erna", zuweisung{ID: "g9", ProjectID: "377",
+		RoleKeys: []string{"mitglied"}, State: "USER_GRANT_STATE_INACTIVE"})
+	z := aufnahmeZitadel(t, as, nil)
+
+	if err := z.Aufnehmen(context.Background(), "377", "erna", model.RolleMitglied); err != nil {
+		t.Fatalf("Aufnahme: %v", err)
+	}
+	got := as.geschrieben()
+	if len(got) != 1 || got[0] != "beleben erna g9" {
+		t.Fatalf("die stillgelegte Zuweisung wurde nicht wiederbelebt: %v", got)
+	}
+	if !z.Fuer(context.Background(), auth.User{Sub: "erna"}).Rollen.IstMitglied("377") {
+		t.Error("nach dem Wiederbeleben gilt die Mitgliedschaft nicht")
+	}
+}
+
+// Ein zweites Mal aufnehmen ändert nichts — und meldet keinen Fehler. Sonst
+// stünde nach einem Doppelklick eine Absage auf dem Schirm, obwohl alles in
+// Ordnung ist.
+func TestAufnahmeIstWiederholbar(t *testing.T) {
+	as := neuerAufnahmeServer(t)
+	as.setzen("erna", zuweisung{ID: "g1", ProjectID: "377", RoleKeys: []string{"mitglied"}})
+	z := aufnahmeZitadel(t, as, nil)
+
+	if err := z.Aufnehmen(context.Background(), "377", "erna", model.RolleMitglied); err != nil {
+		t.Fatalf("Aufnahme: %v", err)
+	}
+	if got := as.geschrieben(); len(got) != 0 {
+		t.Fatalf("es wurde unnötig geschrieben: %v", got)
+	}
+}
+
+// Der Fall, an dem in der Produktion alles hängt: Der Dienst-Nutzer darf
+// lesen, aber nicht schreiben. Dann muss die Meldung sagen, was fehlt —
+// stillschweigend nichts zu tun wäre die schlechteste aller Antworten.
+func TestOhneSchreibrechtSagtDieMeldungWasFehlt(t *testing.T) {
+	as := neuerAufnahmeServer(t)
+	as.verboten = true
+	z := aufnahmeZitadel(t, as, nil)
+
+	err := z.Aufnehmen(context.Background(), "377", "erna", model.RolleMitglied)
+	if err == nil {
+		t.Fatal("eine verweigerte Aufnahme muss ein Fehler sein")
+	}
+	var api *APIFehler
+	if !errors.As(err, &api) || !api.FehlendesRecht() {
+		t.Fatalf("das fehlende Recht ist nicht erkennbar: %v", err)
+	}
+	if !strings.Contains(err.Error(), "user.grant.write") {
+		t.Errorf("die Meldung nennt nicht, was einzurichten ist: %v", err)
+	}
+}
+
+// Ohne Zitadel-Projekt gibt es nichts, worin man Mitglied sein könnte.
+func TestAufnahmeOhneProjektIstEinFehler(t *testing.T) {
+	as := neuerAufnahmeServer(t)
+	z := aufnahmeZitadel(t, as, nil)
+	if err := z.Aufnehmen(context.Background(), "", "erna", model.RolleMitglied); err == nil {
+		t.Fatal("ohne Projekt darf keine Aufnahme gelingen")
+	}
+	if err := z.Aufnehmen(context.Background(), "377", "", model.RolleMitglied); err == nil {
+		t.Fatal("ohne Person darf keine Aufnahme gelingen")
+	}
+}
+
+// Die Dev-Quelle liest die Rollen aus dem Token — in ein Token lässt sich
+// nichts zurückschreiben. Genau daran erkennt der Rest des Systems, dass eine
+// Freigabe nichts bewirken würde.
+func TestDevQuelleKannNichtAufnehmen(t *testing.T) {
+	if _, ok := AufnehmerVon(DevQuelle{}); ok {
+		t.Error("die Dev-Quelle gibt sich fälschlich als Aufnehmer aus")
+	}
+	if _, ok := AufnehmerVon(nil); ok {
+		t.Error("ohne Quelle gibt es niemanden, der aufnehmen könnte")
+	}
+	as := neuerAufnahmeServer(t)
+	if _, ok := AufnehmerVon(aufnahmeZitadel(t, as, nil)); !ok {
+		t.Error("die Zitadel-Quelle muss aufnehmen können")
+	}
+}

--- a/backend/internal/mitglied/mitglied.go
+++ b/backend/internal/mitglied/mitglied.go
@@ -159,6 +159,16 @@ func (s *speicher) letzter(sub string) (eintrag, bool) {
 	return e, ok
 }
 
+// vergessen wirft die gemerkte Auskunft weg. Nach einer Aufnahme muss die
+// nächste Frage wieder nach Zitadel gehen: Sonst hätte die eben aufgenommene
+// Person bis zu einer Frist lang keine Mitgliedschaft — und die Freigabe
+// sähe aus, als hätte sie nicht gewirkt.
+func (s *speicher) vergessen(sub string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.nach, sub)
+}
+
 func (s *speicher) merken(sub string, rollen model.Mitgliedschaften, jetzt time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/backend/internal/mitglied/zitadel.go
+++ b/backend/internal/mitglied/zitadel.go
@@ -141,53 +141,57 @@ func (z *Zitadel) Fuer(ctx context.Context, u auth.User) Stand {
 	return Stand{Rollen: model.Mitgliedschaften{}, Veraltet: true}
 }
 
-// holen fragt die Rollenzuweisungen einer Person ab.
-func (z *Zitadel) holen(ctx context.Context, userSub string) (model.Mitgliedschaften, error) {
-	token, err := z.dienstToken(ctx)
-	if err != nil {
-		return nil, err
+// zuweisung ist eine Rollenzuweisung, wie Zitadel sie führt: eine Person,
+// ein Projekt, die Rollen darin. Die Kennung braucht das Zurückschreiben —
+// eine bestehende Zuweisung wird geändert, nicht ein zweites Mal angelegt.
+type zuweisung struct {
+	ID        string   `json:"id"`
+	ProjectID string   `json:"projectId"`
+	RoleKeys  []string `json:"roleKeys"`
+	State     string   `json:"state"`
+}
+
+// aktiv sagt, ob die Zuweisung zählt. Zitadel liefert stillgelegte mit,
+// statt sie wegzulassen — wer stillgelegt ist, ist draußen.
+func (g zuweisung) aktiv() bool {
+	return !strings.EqualFold(g.State, "USER_GRANT_STATE_INACTIVE")
+}
+
+func (g zuweisung) hat(rolle string) bool {
+	for _, r := range g.RoleKeys {
+		if r == rolle {
+			return true
+		}
 	}
-	rumpf, _ := json.Marshal(map[string]any{
+	return false
+}
+
+// zuweisungen liest alle Rollenzuweisungen einer Person.
+func (z *Zitadel) zuweisungen(ctx context.Context, userSub string) ([]zuweisung, error) {
+	rumpf := map[string]any{
 		// 500 ist weit jenseits dessen, was ein Dorfbewohner je an
 		// Vereinen hat — die Auskunft bleibt trotzdem in einer Seite.
 		"query":   map[string]any{"limit": 500},
 		"queries": []any{map[string]any{"userIdQuery": map[string]any{"userId": userSub}}},
-	})
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		z.issuer+"/management/v1/users/grants/_search", bytes.NewReader(rumpf))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := z.klient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 300 {
-		// Ein abgelaufenes Token beim nächsten Versuch neu holen.
-		if resp.StatusCode == http.StatusUnauthorized {
-			z.tokenVerwerfen()
-		}
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return nil, fmt.Errorf("Zitadel-Management-API: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	var out struct {
-		Result []struct {
-			ProjectID string   `json:"projectId"`
-			RoleKeys  []string `json:"roleKeys"`
-			State     string   `json:"state"`
-		} `json:"result"`
+		Result []zuweisung `json:"result"`
 	}
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&out); err != nil {
+	if err := z.ruf(ctx, http.MethodPost, "/management/v1/users/grants/_search", rumpf, &out); err != nil {
+		return nil, err
+	}
+	return out.Result, nil
+}
+
+// holen fragt die Rollenzuweisungen einer Person ab.
+func (z *Zitadel) holen(ctx context.Context, userSub string) (model.Mitgliedschaften, error) {
+	grants, err := z.zuweisungen(ctx, userSub)
+	if err != nil {
 		return nil, err
 	}
 	rollen := model.Mitgliedschaften{}
-	for _, g := range out.Result {
-		// Deaktivierte Zuweisungen zählen nicht: Wer stillgelegt ist, ist
-		// draußen. Zitadel liefert sie mit, statt sie wegzulassen.
-		if g.ProjectID == "" || strings.EqualFold(g.State, "USER_GRANT_STATE_INACTIVE") {
+	for _, g := range grants {
+		if g.ProjectID == "" || !g.aktiv() {
 			continue
 		}
 		for _, r := range g.RoleKeys {
@@ -201,6 +205,69 @@ func (z *Zitadel) holen(ctx context.Context, userSub string) (model.Mitgliedscha
 		}
 	}
 	return rollen, nil
+}
+
+// APIFehler ist eine Antwort der Management-API jenseits von 2xx. Er trägt
+// den Status mit, weil ein „darf nicht“ etwas anderes ist als ein „geht
+// gerade nicht“ — und weil nur der Erste dem Betreiber sagt, dass in der
+// Rössing-ID ein Recht fehlt.
+type APIFehler struct {
+	Methode string
+	Pfad    string
+	Status  int
+	Text    string
+}
+
+func (e *APIFehler) Error() string {
+	return fmt.Sprintf("Zitadel-Management-API %s %s: HTTP %d: %s", e.Methode, e.Pfad, e.Status, e.Text)
+}
+
+// FehlendesRecht sagt, ob der Dienst-Nutzer diese Aktion schlicht nicht darf.
+// Das ist kein Ausfall, den ein erneuter Versuch heilt, sondern eine fehlende
+// Berechtigung in der Rössing-ID.
+func (e *APIFehler) FehlendesRecht() bool {
+	return e.Status == http.StatusForbidden || e.Status == http.StatusUnauthorized
+}
+
+// ruf spricht die Management-API an: Dienst-Token holen, Anfrage stellen,
+// Antwort lesen. Ein 401 verwirft das Token, damit der nächste Versuch ein
+// frisches holt.
+func (z *Zitadel) ruf(ctx context.Context, methode, pfad string, rumpf, ziel any) error {
+	token, err := z.dienstToken(ctx)
+	if err != nil {
+		return err
+	}
+	var body io.Reader
+	if rumpf != nil {
+		roh, err := json.Marshal(rumpf)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(roh)
+	}
+	req, err := http.NewRequestWithContext(ctx, methode, z.issuer+pfad, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := z.klient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		if resp.StatusCode == http.StatusUnauthorized {
+			z.tokenVerwerfen()
+		}
+		roh, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return &APIFehler{Methode: methode, Pfad: pfad, Status: resp.StatusCode,
+			Text: strings.TrimSpace(string(roh))}
+	}
+	if ziel == nil {
+		return nil
+	}
+	return json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(ziel)
 }
 
 func (z *Zitadel) tokenVerwerfen() {

--- a/backend/internal/model/beitritt_test.go
+++ b/backend/internal/model/beitritt_test.go
@@ -1,0 +1,98 @@
+package model
+
+import "testing"
+
+// Wer darf wo um Aufnahme bitten? Die Frage wird an genau einer Stelle
+// beantwortet (Zugriff), damit REST, Web-Verwaltung und MCP nicht drei
+// verschiedene Antworten geben.
+
+func offenerTraeger() Traeger {
+	return Traeger{ID: 3, ProjektID: "388", Name: "AK 2 Umwelt und Natur",
+		Status: TraegerZugelassen, Sichtbarkeit: TraegerOffen}
+}
+
+func TestBeitrittZuEinemOffenenTraeger(t *testing.T) {
+	z := Zugriff{Sub: "erna", Mitglied: Mitgliedschaften{}}
+	if !z.DarfBeitrittBeantragen(offenerTraeger()) {
+		t.Fatalf("ein offener Träger nimmt keine Anträge entgegen: %q",
+			z.BeitrittsHindernis(offenerTraeger()))
+	}
+}
+
+// Wer schon dabei ist, fragt nicht noch einmal — sonst stapelten sich
+// Anträge von Leuten, die längst mitmachen.
+func TestWerSchonMitgliedIstBeantragtNichts(t *testing.T) {
+	z := Zugriff{Sub: "erna", Mitglied: Mitgliedschaften{"388": {RolleMitglied: true}}}
+	if z.DarfBeitrittBeantragen(offenerTraeger()) {
+		t.Error("ein Mitglied darf noch einmal beitreten")
+	}
+	// Auch der Vorstand gehört dazu (siehe IstMitglied).
+	z = Zugriff{Sub: "vorstand", Mitglied: Mitgliedschaften{"388": {RolleAdmin: true}}}
+	if z.DarfBeitrittBeantragen(offenerTraeger()) {
+		t.Error("der Träger-Admin darf sich selbst beitreten")
+	}
+}
+
+// Die Entscheidung des Zuschnitts: Eine geschlossene Gruppe nimmt keine
+// Anträge entgegen. Sie steht nicht im Verzeichnis; wer sie nicht findet,
+// kann ihr nichts schicken, und wer ihre Kennung errät, soll daraus nichts
+// erfahren. Sie nimmt selbst auf.
+func TestEineGeschlosseneGruppeNimmtKeineAntraege(t *testing.T) {
+	geschlossen := offenerTraeger()
+	geschlossen.Sichtbarkeit = TraegerGeschlossen
+
+	z := Zugriff{Sub: "erna", Mitglied: Mitgliedschaften{}}
+	if z.DarfBeitrittBeantragen(geschlossen) {
+		t.Error("einer geschlossenen Gruppe lässt sich ein Antrag schicken")
+	}
+	// Auch der Betreiber nicht: Die Regel gilt für die Gruppe, nicht für
+	// einzelne Personen.
+	betreiber := Zugriff{Sub: "levin", Betreiber: true, Mitglied: Mitgliedschaften{}}
+	if betreiber.DarfBeitrittBeantragen(geschlossen) {
+		t.Error("der Betreiber umgeht die Regel der geschlossenen Gruppe")
+	}
+}
+
+// Ein Träger ohne Zitadel-Projekt hat keine Mitglieder. Ein Antrag dorthin
+// hätte am Ende nichts, worin er wirken könnte.
+func TestOhneZitadelProjektKeinBeitritt(t *testing.T) {
+	ohne := offenerTraeger()
+	ohne.ProjektID = ""
+	z := Zugriff{Sub: "erna", Mitglied: Mitgliedschaften{}}
+	if z.DarfBeitrittBeantragen(ohne) {
+		t.Error("ein Träger ohne Projekt nimmt Anträge entgegen")
+	}
+}
+
+// Ein noch nicht zugelassener oder gesperrter Träger tritt nicht in
+// Erscheinung — beitreten kann man ihm auch nicht.
+func TestNichtZugelassenerTraegerNimmtNiemandenAuf(t *testing.T) {
+	z := Zugriff{Sub: "erna", Mitglied: Mitgliedschaften{}}
+	for _, status := range []TraegerStatus{TraegerBeantragt, TraegerGesperrt} {
+		tr := offenerTraeger()
+		tr.Status = status
+		if z.DarfBeitrittBeantragen(tr) {
+			t.Errorf("Beitritt zu einem Träger im Stand %q", status)
+		}
+	}
+}
+
+// Entscheiden darf, wer den Träger verwaltet — und mit veraltetem
+// Mitgliedschafts-Stand niemand: Wer ausgetreten ist, soll niemanden mehr
+// aufnehmen, bloß weil die Rössing-ID gerade schweigt.
+func TestUeberBeitritteEntscheidetDerTraegerAdmin(t *testing.T) {
+	tr := offenerTraeger()
+	admin := Zugriff{Sub: "vorstand", Mitglied: Mitgliedschaften{"388": {RolleAdmin: true}}}
+	if !admin.DarfBeitrittEntscheiden(tr) {
+		t.Error("der Träger-Admin darf nicht entscheiden")
+	}
+	nurMitglied := Zugriff{Sub: "erna", Mitglied: Mitgliedschaften{"388": {RolleMitglied: true}}}
+	if nurMitglied.DarfBeitrittEntscheiden(tr) {
+		t.Error("ein einfaches Mitglied entscheidet über Aufnahmen")
+	}
+	veraltet := admin
+	veraltet.Veraltet = true
+	if veraltet.DarfBeitrittEntscheiden(tr) {
+		t.Error("mit veraltetem Stand wird aufgenommen")
+	}
+}

--- a/backend/internal/model/traeger.go
+++ b/backend/internal/model/traeger.go
@@ -197,6 +197,43 @@ type BefaehigungsAntrag struct {
 	TraegerID       int64  `json:"traegerId,omitempty"`
 }
 
+// --- Beitritte --------------------------------------------------------------
+
+// Beitritt ist der Antrag auf Mitgliedschaft in einem Träger.
+//
+// Der Ablauf ist derselbe wie bei einer Befähigung — beantragen, freigeben
+// oder ablehnen. Ein Unterschied ist aber wesentlich, und er ist der Grund,
+// warum das hier ein eigener Typ ist und keine zweite Verwendung von
+// BefaehigungsAntrag:
+//
+// Ein erteilter Befähigungsantrag IST die Befähigung. Ein erteilter Beitritt
+// ist NICHT die Mitgliedschaft. Die steht in der Rössing-ID, und nirgends
+// sonst — hier steht nur der Vorgang: wer wann gefragt hat und wer wann
+// entschieden hat. Wäre es anders, hätte das Dorf zwei Wahrheiten darüber,
+// wer zum Verein gehört, und irgendwann widersprächen sie sich.
+//
+// Deshalb wird ein Beitritt auch erst dann auf „erteilt“ gesetzt, wenn die
+// Rollenzuweisung in Zitadel tatsächlich steht (siehe mitglied.Aufnehmer).
+type Beitritt struct {
+	ID        int64  `json:"id"`
+	TraegerID int64  `json:"traegerId"`
+	UserSub   string `json:"userSub"`
+	UserName  string `json:"userName,omitempty"`
+	// Status: beantragt, erteilt oder abgelehnt — dieselben drei Stände wie
+	// beim Befähigungsantrag, damit im Dorf nicht zwei Vokabulare gelten.
+	Status AntragStatus `json:"status"`
+	// Begruendung schreibt die antragstellende Person („ich wohne neben dem
+	// Beet und würde gern mitjäten“).
+	Begruendung string `json:"begruendung,omitempty"`
+	// Notiz schreibt der Träger-Admin bei der Entscheidung.
+	Notiz          string     `json:"notiz,omitempty"`
+	CreatedAt      time.Time  `json:"createdAt"`
+	EntschiedenAm  *time.Time `json:"entschiedenAm,omitempty"`
+	EntschiedenVon string     `json:"entschiedenVon,omitempty"`
+	// TraegerName ist ein Anzeigefeld, aus dem Träger nachgeladen.
+	TraegerName string `json:"traegerName,omitempty"`
+}
+
 // TaskSichtbarkeit steuert, wem eine Aufgabe angezeigt wird.
 type TaskSichtbarkeit string
 
@@ -396,3 +433,53 @@ func (z Zugriff) DarfZusagen(t Traeger, sicht TaskSichtbarkeit) bool {
 	}
 	return !z.Veraltet
 }
+
+// --- Beitritt ---------------------------------------------------------------
+
+// BeitrittsHindernis nennt den Grund, warum diese Person diesem Träger
+// gerade keinen Beitrittsantrag schicken kann — leer heißt: sie kann.
+//
+// Der Text ist deutsch, weil er genau so vor der Person landet. Er steht
+// hier und nicht in den Handlern, damit REST, Web-Verwaltung und MCP
+// dieselbe Antwort geben; eine zweite Prüfung daneben würde irgendwann
+// abweichen.
+func (z Zugriff) BeitrittsHindernis(t Traeger) string {
+	if z.Sub == "" {
+		return "Zum Beitreten musst du angemeldet sein."
+	}
+	if !t.Zugelassen() {
+		return "Dieser Träger ist nicht zugelassen — beitreten kann man ihm noch nicht."
+	}
+	// Ohne Zitadel-Projekt gibt es nichts, worin man Mitglied sein könnte.
+	// Eine Freigabe hätte hier nichts zurückzuschreiben.
+	if t.ProjektID == "" {
+		return "Dieser Träger hat in der Rössing-ID noch kein Projekt — " +
+			"solange es keins gibt, hat er auch keine Mitglieder."
+	}
+	if z.Mitglied.IstMitglied(t.ProjektID) {
+		return "Du gehörst schon dazu."
+	}
+	// Eine geschlossene Gruppe steht nicht im Verzeichnis. Wer sie nicht
+	// findet, kann ihr auch nichts schicken — und wer ihre Kennung errät,
+	// soll daraus nichts erfahren. Sie nimmt selbst auf, statt Anträge
+	// entgegenzunehmen (siehe Aufnahme durch den Träger-Admin).
+	if t.Sichtbarkeit != TraegerOffen {
+		return "Diese Gruppe ist geschlossen: Wer dazugehören soll, wird von ihr " +
+			"aufgenommen — Anträge nimmt sie nicht entgegen."
+	}
+	return ""
+}
+
+// DarfBeitrittBeantragen ist die Kurzform desselben.
+func (z Zugriff) DarfBeitrittBeantragen(t Traeger) bool {
+	return z.BeitrittsHindernis(t) == ""
+}
+
+// DarfBeitrittEntscheiden sagt, wer über einen Beitritt bestimmt: der
+// Träger-Admin. Ausdrücklich nicht der Plattform-Betreiber allein — der lässt
+// Träger zu, aber wer zu einem Verein gehört, entscheidet der Verein.
+//
+// Dass der Betreiber es technisch trotzdem kann (DarfVerwalten), ist keine
+// zweite Regel, sondern dieselbe: Er verwaltet jeden Träger, solange keiner
+// da ist, der es selbst tut.
+func (z Zugriff) DarfBeitrittEntscheiden(t Traeger) bool { return z.DarfVerwalten(t) }

--- a/deploy/overlays/production/deployment.yaml
+++ b/deploy/overlays/production/deployment.yaml
@@ -161,9 +161,17 @@ spec:
             #   1. In der Rössing-ID einen Machine-User anlegen
             #      (z.B. „dorf-app-rollen"), Access-Token-Typ JWT,
             #      JSON-Key erzeugen.
-            #   2. Ihm NUR Leserechte auf Rollenzuweisungen geben
-            #      (ORG_USER_GRANT_VIEWER). Er darf keine Nutzer anlegen und
-            #      keine Rollen vergeben.
+            #   2. Ihm Rechte auf Rollenzuweisungen geben — LESEN und
+            #      SCHREIBEN (user.grant.read/write; in Zitadel die
+            #      Manager-Rolle ORG_USER_PERMISSION_EDITOR). Nutzer anlegen
+            #      oder löschen darf er weiterhin nicht.
+            #      Das Schreibrecht ist neu: Seit ein Beitritt in der App
+            #      beantragt und vom Träger-Admin freigegeben wird, trägt die
+            #      Freigabe die Rolle „mitglied" unmittelbar in der Rössing-ID
+            #      ein — sonst wäre das Verfahren eine Sackgasse. Fehlt das
+            #      Recht, läuft die Freigabe nicht still ins Leere: Sie
+            #      scheitert mit genau diesem Hinweis, und der Antrag bleibt
+            #      offen.
             #   3. Den Key als SealedSecret ablegen (wie sealed-fcm.yaml),
             #      unter /secrets/zitadel einhängen und die beiden Zeilen
             #      unten einkommentieren.


### PR DESCRIPTION
Wer einem Verein oder Arbeitskreis im Dorf beitreten wollte, konnte das nirgends sagen: Mitgliedschaften trug ausschließlich ein Mensch in der Zitadel-Konsole ein. Jetzt fragt man in der App, der Träger-Admin gibt frei — und die Person ist danach **wirklich** Mitglied, ohne dass jemand die Konsole öffnet.

Anlass ist konkret: Die **Dorfpflege Rössing e.V.** hat den Arbeitskreis **AK 2 Umwelt und Natur** bekommen, und das Beet vor dem Dorfgemeinschaftshaus gehört ihm. Wer dort mitjäten will, muss Mitglied werden können.

## Wie ein Antrag entsteht und entschieden wird

1. **Beantragen** — `POST /api/v1/traeger/{id}/beitritt` mit einer Begründung. Möglich ist das bei einem zugelassenen, **offenen** Träger mit Zitadel-Projekt, bei dem man noch nicht dabei ist. Ob das gilt, entscheidet `model.Zugriff.BeitrittsHindernis` — an genau einer Stelle, und die Antwort ist zugleich der Satz, der der Person angezeigt wird.
2. **Sehen** — der Träger-Admin findet den Antrag auf der Trägerseite der Web-Verwaltung, über `GET /api/v1/traeger/{id}/beitritte` oder über MCP (`beitritte_liste`). Wer nur Mitglied ist, sieht nichts davon.
3. **Entscheiden** — `POST /api/v1/beitritte/{id}` mit `erteilt` oder `abgelehnt` (in der Verwaltung zwei Knöpfe, über MCP `beitritt_entscheiden`). Entscheiden darf, wer den Träger verwaltet — `DarfBeitrittEntscheiden` ist `DarfVerwalten`, mit allem, was daran hängt: nicht bei gesperrtem Träger, nicht mit veraltetem Mitgliedschafts-Stand, und niemand über sich selbst.
4. **Direkt aufnehmen** — `POST /api/v1/traeger/{id}/mitglieder` (MCP `mitglied_aufnehmen`), ohne vorherigen Antrag. Ein offener Antrag wird dabei mitentschieden statt verdoppelt.

## Was mit Zitadel passiert

Die Freigabe **schreibt die Rollenzuweisung zurück** (`internal/mitglied/aufnahme.go`):

- keine Zuweisung zu diesem Projekt → `POST /management/v1/users/{id}/grants` mit `roleKeys: ["mitglied"]`
- vorhandene Zuweisung ohne die Rolle → `PUT …/grants/{gid}` mit **ergänzten** Rollen; wer schon `admin` ist, bleibt es
- stillgelegte Zuweisung → `…/_reactivate`, sonst zählte sie nicht
- danach wird der gemerkte Stand dieser Person verworfen, damit die Aufnahme **sofort** wirkt — derselbe Token, keine neue Anmeldung

**Die Reihenfolge ist die eigentliche Entscheidung**: erst Zitadel, dann der eigene Vermerk. Andersherum stünde in der App „Mitglied", während die Tür zu bleibt. Scheitert das Schreiben, bleibt der Antrag **offen**, und die Meldung sagt warum — bei fehlendem Recht ausdrücklich, was einzurichten ist. Genau das wird geprüft (`TestOhneSchreibendenDienstNutzerScheitertDieFreigabe`, `TestScheiterndeAufnahmeLaesstDenAntragOffen`).

### Was der Betreiber noch einrichten muss

**Der Dienst-Nutzer braucht Schreibrecht auf Nutzer-Zuweisungen.** Bisher steht in der Anleitung ausdrücklich „NUR Leserechte" — das reicht jetzt nicht mehr:

- `user.grant.read` **und** `user.grant.write` — in Zitadel die Manager-Rolle `ORG_USER_PERMISSION_EDITOR`. Nutzer anlegen oder löschen darf er weiterhin nicht.
- In der Produktion ist der Dienst-Nutzer **überhaupt noch nicht eingerichtet**: `ZITADEL_SERVICE_USER_KEY_FILE` steht in `deploy/overlays/production/deployment.yaml` noch auskommentiert. Solange das so ist, gibt es keine Träger-Rollen, und eine Freigabe scheitert mit `503` und dem Satz, was fehlt. In der Web-Verwaltung steht der Hinweis schon **vor** dem Klick auf der Seite, damit niemand einen Knopf drückt, der nichts tut.

Anleitung und README sind entsprechend nachgezogen.

## Entscheidungen

- **Ein erteilter Beitritt ist nicht die Mitgliedschaft.** Beim Befähigungsantrag ist der erteilte Antrag die Befähigung; hier wäre dasselbe falsch. Wer zum Verein gehört, sagt die Rössing-ID — in der Tabelle `beitritte` steht nur der Vorgang: wer gefragt und wer entschieden hat. Zwei Wahrheiten darüber widersprächen sich irgendwann. Deshalb lässt sich ein Beitritt auch nach einer Aufnahme neu stellen (wer ausgetreten ist, fragt wieder), während ein erteilter Befähigungsantrag stehen bleibt.
- **Eine geschlossene Gruppe nimmt keine Anträge entgegen.** Sie steht nicht im Verzeichnis: Wer sie nicht findet, kann ihr nichts schicken, und wer ihre Kennung errät, soll aus der Antwort nichts erfahren (für Außenstehende 404, für den Betreiber 409 mit Begründung). Sie holt sich ihre Leute selbst — dafür gibt es das direkte Aufnehmen, das auch der offenen Gruppe den kurzen Weg nach dem Gespräch am Gartenzaun lässt.
- **Nur aufnehmen, nicht entfernen.** Ein Austritt hat andere Folgen (laufende Zusagen, interne Aufgaben) und will eigens bedacht werden; bis dahin bleibt das die Konsole.
- **Ein Weg nach Zitadel für alle drei Oberflächen.** REST, Web-Verwaltung und MCP gehen durch `api.Aufnehmen` / `api.BeitrittEntscheiden`. Drei eigene Wege wären drei Gelegenheiten, denselben Schritt zu vergessen.
- **Die Träger-Liste sagt, was möglich ist** (`istMitglied`, `beitrittMoeglich`, `beitrittHindernis`, `beitrittStatus`, `offeneBeitritte`). Die Regeln in der App nachzubauen führte früher oder später zu einer anderen Antwort als der Server gibt.
- **Deutsche Bezeichner in diesem Bereich**, entgegen der Regel „neuer Quelltext englisch": Der ganze Nachbarschaftscode heißt `DarfVerwalten`, `InsertAntrag`, `BefaehigungsAntrag`. Ein `MayApplyToJoin` neben `DarfVerwalten` im selben Typ wäre schlechter lesbar, nicht besser. Wenn `model.Zugriff` umgestellt wird, kommt das hier mit.

## Proben

- `internal/mitglied`: anlegen, ergänzen, wiederbeleben, Wiederholbarkeit, fehlendes Recht — gegen einen nachgebauten Zitadel-Endpunkt.
- `internal/model`: wer wo beitreten darf (offen, geschlossen, ohne Projekt, nicht zugelassen, schon dabei, veralteter Stand).
- `internal/db`: Vorgang stellen, entscheiden, wiederbeleben, zählen.
- `internal/api`, `internal/admin`, `internal/mcp`: der Durchstich in allen drei Oberflächen, jeweils mit der Prüfung, dass die Rolle wirklich in der (gespielten) Rössing-ID landet — und dass bei einem Fehlschlag nichts abgehakt wird.
- **E2E gegen ein echtes Zitadel** (`backend/e2e`): beantragen, freigeben, und danach wird die Rollenzuweisung **direkt über die Management-API** nachgesehen. Anschließend wirkt sie mit demselben Token, ohne neue Anmeldung. Kein Test fasst einen entfernten Server an; `pruefe_lokale_tests.py` geht durch.

## Was in den Apps fehlt

**Android und iOS sind nicht dabei** — beide Verzeichnisse waren während dieser Arbeit von anderen Agenten belegt, deshalb wurden sie ausdrücklich nicht angefasst. Es gibt dort bisher überhaupt keinen Träger-Bereich. Die Nacharbeit liegt als #88: mitmachen sagen, eigene Anträge sehen, als Vorstand entscheiden — in **beiden** Fassungen. Die REST-Seite dafür ist fertig und liefert je Träger mit, ob ein Beitritt möglich ist und wie der eigene Antrag steht.

Fixes #56
