### PR TITLE
Eine Aufgabe kann sagen, wann sie zuletzt gemacht wurde

### DIFF
--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -478,9 +478,21 @@ type TaskInput struct {
 	// Aufgabe nicht ihre Jahreszeit wegnehmen.
 	SeasonStartMonth *int `json:"seasonStartMonth"`
 	SeasonEndMonth   *int `json:"seasonEndMonth"`
+	// LastKnownDoneAt: wann diese Arbeit zuletzt gemacht wurde, bevor die App
+	// davon wusste („das Beet wurde im Juni gejätet"). Datum (2026-06-15)
+	// oder RFC3339. Leerer String nimmt die Angabe wieder weg.
+	//
+	// Ausdrücklich **keine** Erledigung: kein Punkt in der Rangliste, keine
+	// Person daran. Deshalb gilt hier auch nicht die Rückdatierungsgrenze —
+	// wer hier ein Datum einträgt, verschiebt Fälligkeiten, schreibt aber
+	// keine Rangliste um. Die erste echte Meldung löst die Angabe ab.
+	LastKnownDoneAt *string `json:"lastKnownDoneAt"`
 
 	// termin ist das geprüfte DueDate. Validate() setzt es, Apply() nutzt es.
 	termin *time.Time
+	// zuletzt ist das geprüfte LastKnownDoneAt.
+	zuletzt    *time.Time
+	zuletztWeg bool
 }
 
 func (in *TaskInput) Validate() error {
@@ -544,6 +556,48 @@ func (in *TaskInput) Validate() error {
 		von, bis := model.NormalizeSeasonMonths(*in.SeasonStartMonth, *in.SeasonEndMonth)
 		in.SeasonStartMonth, in.SeasonEndMonth = &von, &bis
 	}
+	if err := in.pruefeZuletzt(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ParseZuletztErledigt liest „zuletzt erledigt, bevor die App davon wusste"
+// aus einem rohen Text. Leer heißt: Angabe wegnehmen.
+//
+// Öffentlich, weil MCP dieselbe Prüfung braucht — dieselbe Regel zweimal
+// geschrieben ist beim nächsten Sonderfall einmal falsch.
+func ParseZuletztErledigt(roh string, jetzt time.Time) (*time.Time, bool, error) {
+	roh = strings.TrimSpace(roh)
+	if roh == "" {
+		return nil, true, nil
+	}
+	wann, err := ParseTermin(roh)
+	if err != nil {
+		return nil, false, errors.New("lastKnownDoneAt: " + err.Error())
+	}
+	if wann.After(jetzt) {
+		return nil, false, errors.New("lastKnownDoneAt darf nicht in der Zukunft liegen")
+	}
+	return &wann, false, nil
+}
+
+// pruefeZuletzt liest „zuletzt erledigt, bevor die App davon wusste".
+//
+// Ein leerer String nimmt die Angabe weg — das ist etwas anderes als ein
+// fehlendes Feld, das sie stehen lässt. In der Zukunft liegen darf sie
+// nicht: „zuletzt gemacht" ist eine Aussage über die Vergangenheit, und ein
+// Datum von morgen würde die Aufgabe stumm auf grün stellen.
+func (in *TaskInput) pruefeZuletzt() error {
+	in.zuletzt, in.zuletztWeg = nil, false
+	if in.LastKnownDoneAt == nil {
+		return nil
+	}
+	wann, weg, err := ParseZuletztErledigt(*in.LastKnownDoneAt, clock.Now())
+	if err != nil {
+		return err
+	}
+	in.zuletzt, in.zuletztWeg = wann, weg
 	return nil
 }
 
@@ -596,6 +650,12 @@ func (in *TaskInput) Apply(t *model.CareTask) {
 	}
 	if in.SeasonEndMonth != nil {
 		t.SeasonEndMonth = *in.SeasonEndMonth
+	}
+	switch {
+	case in.zuletztWeg:
+		t.LastKnownDoneAt = nil
+	case in.zuletzt != nil:
+		t.LastKnownDoneAt = in.zuletzt
 	}
 	t.Kind, t.Title = model.TaskKind(in.Kind), in.Title
 	t.Liters = in.Liters

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -195,6 +195,10 @@ CREATE INDEX IF NOT EXISTS idx_devices_person ON push_devices(user_sub);
 		// trotzdem sagen können, worum es ging (siehe loeseNotificationsVomVorgang).
 		`ALTER TABLE care_notifications ADD COLUMN place_name TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE care_notifications ADD COLUMN task_name TEXT NOT NULL DEFAULT ''`,
+		// Was vor der App war: der Startpunkt der Rechnung, wenn es noch
+		// keine Meldung gibt. Leer heißt „nichts bekannt" — dann zählt wie
+		// bisher das Anlegedatum.
+		`ALTER TABLE care_tasks ADD COLUMN last_known_done_at TEXT NOT NULL DEFAULT ''`,
 	} {
 		if _, err := d.sql.Exec(stmt); err != nil && !istDoppelteSpalte(err) {
 			return err
@@ -445,13 +449,13 @@ func (d *DB) InsertTask(t *model.CareTask) error {
 	}
 	res, err := d.sql.Exec(`INSERT INTO care_tasks(place_id,kind,title,liters,interval_days,red_after_days,
 			one_off,due_date,remove_when_done,active,created_at,sichtbarkeit,befaehigung_id,
-			season_start_month,season_end_month)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			season_start_month,season_end_month,last_known_done_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		t.PlaceID, string(t.Kind), t.Title, t.Liters, t.IntervalDays, t.RedAfterDays,
 		boolToInt(t.OneOff), zeitText(t.DueDate), boolToInt(t.RemoveWhenDone),
 		boolToInt(t.Active), t.CreatedAt.UTC().Format(timeFormat),
 		string(t.Sichtbarkeit), t.BefaehigungID,
-		t.SeasonStartMonth, t.SeasonEndMonth)
+		t.SeasonStartMonth, t.SeasonEndMonth, zeitText(t.LastKnownDoneAt))
 	if err != nil {
 		return err
 	}
@@ -465,11 +469,11 @@ func (d *DB) UpdateTask(t *model.CareTask) error {
 	}
 	res, err := d.sql.Exec(`UPDATE care_tasks SET kind=?,title=?,liters=?,interval_days=?,red_after_days=?,
 			one_off=?,due_date=?,remove_when_done=?,active=?,sichtbarkeit=?,befaehigung_id=?,
-			season_start_month=?,season_end_month=? WHERE id=?`,
+			season_start_month=?,season_end_month=?,last_known_done_at=? WHERE id=?`,
 		string(t.Kind), t.Title, t.Liters, t.IntervalDays, t.RedAfterDays,
 		boolToInt(t.OneOff), zeitText(t.DueDate), boolToInt(t.RemoveWhenDone),
 		boolToInt(t.Active), string(t.Sichtbarkeit), t.BefaehigungID,
-		t.SeasonStartMonth, t.SeasonEndMonth, t.ID)
+		t.SeasonStartMonth, t.SeasonEndMonth, zeitText(t.LastKnownDoneAt), t.ID)
 	if err != nil {
 		return err
 	}
@@ -499,7 +503,7 @@ func (d *DB) DeleteTask(id int64) error {
 
 const taskSpalten = `id,place_id,kind,title,liters,interval_days,red_after_days,
 	one_off,due_date,remove_when_done,removed_at,active,created_at,sichtbarkeit,befaehigung_id,
-	season_start_month,season_end_month`
+	season_start_month,season_end_month,last_known_done_at`
 
 // GetTask liefert auch abgeräumte Aufgaben — die Rangliste und die Historie
 // müssen ihre Erledigungen weiter zuordnen können.
@@ -530,10 +534,10 @@ func (d *DB) ListTasks() ([]model.CareTask, error) {
 func scanTask(row scannable) (*model.CareTask, error) {
 	var t model.CareTask
 	var active, oneOff, removeWhenDone int
-	var created, kind, dueDate, removedAt, sichtbarkeit string
+	var created, kind, dueDate, removedAt, sichtbarkeit, lastKnown string
 	err := row.Scan(&t.ID, &t.PlaceID, &kind, &t.Title, &t.Liters, &t.IntervalDays, &t.RedAfterDays,
 		&oneOff, &dueDate, &removeWhenDone, &removedAt, &active, &created,
-		&sichtbarkeit, &t.BefaehigungID, &t.SeasonStartMonth, &t.SeasonEndMonth)
+		&sichtbarkeit, &t.BefaehigungID, &t.SeasonStartMonth, &t.SeasonEndMonth, &lastKnown)
 	if err != nil {
 		return nil, err
 	}
@@ -545,6 +549,7 @@ func scanTask(row scannable) (*model.CareTask, error) {
 	t.RemovedAt = zeitWert(removedAt)
 	t.Active = active != 0
 	t.CreatedAt, _ = time.Parse(timeFormat, created)
+	t.LastKnownDoneAt = zeitWert(lastKnown)
 	return &t, nil
 }
 

--- a/backend/internal/mcp/mcp.go
+++ b/backend/internal/mcp/mcp.go
@@ -386,6 +386,10 @@ func (s *Server) registerTools() {
 				"oneOff":         boolean("Einmalige Aufgabe statt eines wiederkehrenden Plans"),
 				"dueDate":        str("Nur einmalig: Fälligkeitsdatum (2026-08-20 oder RFC3339). Gelb ab drei Tagen davor, rot danach"),
 				"removeWhenDone": boolean("Nach dem Erledigen von Karte und Liste nehmen (Erledigung zählt weiter für die Rangliste)"),
+				"lastKnownDoneAt": str("Wann diese Arbeit zuletzt gemacht wurde, BEVOR die App davon " +
+					"wusste (2026-06-15). Keine Erledigung: kein Punkt in der Rangliste, keine Person " +
+					"daran — nur der Startpunkt der Rechnung, damit ein Beet, das im Juni gejätet " +
+					"wurde, nicht bis Oktober auf grün steht. Leerer Text nimmt die Angabe weg."),
 				"seasonStartMonth": integer("Nur regelmäßig: erster Monat der Jahreszeit (1–12, einschließlich). " +
 					"Ohne Angabe fällt die Aufgabe ganzjährig an"),
 				"seasonEndMonth": integer("Nur regelmäßig: letzter Monat der Jahreszeit (1–12, einschließlich). " +
@@ -408,6 +412,10 @@ func (s *Server) registerTools() {
 				"dueDate":        str("Fälligkeitsdatum einmaliger Aufgaben (2026-08-20 oder RFC3339)"),
 				"removeWhenDone": boolean("Nach dem Erledigen entfernen"),
 				"active":         boolean("Aufgabe aktiv?"),
+				"lastKnownDoneAt": str("Wann diese Arbeit zuletzt gemacht wurde, BEVOR die App davon " +
+					"wusste (2026-06-15). Keine Erledigung: kein Punkt in der Rangliste, keine Person " +
+					"daran — nur der Startpunkt der Rechnung, damit ein Beet, das im Juni gejätet " +
+					"wurde, nicht bis Oktober auf grün steht. Leerer Text nimmt die Angabe weg."),
 				"seasonStartMonth": integer("Erster Monat der Jahreszeit (1–12); 0 nimmt die " +
 					"Jahreszeit weg, die Aufgabe fällt dann wieder ganzjährig an"),
 				"seasonEndMonth": integer("Letzter Monat der Jahreszeit (1–12); 0 = ganzjährig"),
@@ -614,6 +622,8 @@ func (s *Server) toolUpdateTask(args json.RawMessage, u auth.User) (any, error) 
 		// Jahreszeit: siehe model.Season. 0 nimmt sie weg.
 		SeasonStartMonth *int `json:"seasonStartMonth"`
 		SeasonEndMonth   *int `json:"seasonEndMonth"`
+		// Was vor der App war. Leerer Text nimmt die Angabe weg.
+		LastKnownDoneAt *string `json:"lastKnownDoneAt"`
 	}
 	if err := json.Unmarshal(args, &in); err != nil {
 		return nil, err
@@ -662,6 +672,18 @@ func (s *Server) toolUpdateTask(args json.RawMessage, u auth.User) (any, error) 
 	}
 	if in.SeasonEndMonth != nil {
 		t.SeasonEndMonth = *in.SeasonEndMonth
+	}
+	if in.LastKnownDoneAt != nil {
+		wann, weg, err := api.ParseZuletztErledigt(*in.LastKnownDoneAt, s.now())
+		if err != nil {
+			return nil, err
+		}
+		switch {
+		case weg:
+			t.LastKnownDoneAt = nil
+		default:
+			t.LastKnownDoneAt = wann
+		}
 	}
 	if t.OneOff {
 		if t.DueDate == nil {

--- a/backend/internal/mcp/traeger_test.go
+++ b/backend/internal/mcp/traeger_test.go
@@ -196,3 +196,63 @@ func TestTraegerWerkzeugeNurFuerAdmins(t *testing.T) {
 		t.Fatalf("Mitglied bekommt Status %d, erwartet 403", resp.StatusCode)
 	}
 }
+
+// --- Was vor der App war -----------------------------------------------------
+
+// Der Anlass: Das Beet vor dem Dorfgemeinschaftshaus wurde im Juni gejätet,
+// die Aufgabe dafür aber erst im August angelegt. Ohne diese Angabe stünde es
+// bis Ende Oktober auf grün.
+func TestZuletztErledigtUeberMCP(t *testing.T) {
+	ts, d := serverMitDB(t)
+
+	text, _ := callTool(t, ts, "ort_anlegen", map[string]any{
+		"name": "Beet vor dem Dorfgemeinschaftshaus", "kind": "beet",
+		"lat": 52.1829639, "lon": 9.8100629,
+	})
+	var ort model.Place
+	if err := json.Unmarshal([]byte(text), &ort); err != nil {
+		t.Fatalf("Ort nicht lesbar: %v — %s", err, text)
+	}
+
+	text, fehler := callTool(t, ts, "aufgabe_anlegen", map[string]any{
+		"placeId": ort.ID, "kind": "jaeten",
+		"intervalDays": 56, "redAfterDays": 77,
+		"lastKnownDoneAt": "2026-06-15",
+	})
+	if fehler {
+		t.Fatalf("aufgabe_anlegen: %s", text)
+	}
+	var aufgabe model.CareTask
+	if err := json.Unmarshal([]byte(text), &aufgabe); err != nil {
+		t.Fatalf("Aufgabe nicht lesbar: %v — %s", err, text)
+	}
+	if aufgabe.LastKnownDoneAt == nil {
+		t.Fatal("die Angabe kam nicht an")
+	}
+	if got := aufgabe.LastKnownDoneAt.Format("2006-01-02"); got != "2026-06-15" {
+		t.Fatalf("zuletzt erledigt am %s, erwartet 2026-06-15", got)
+	}
+
+	gespeichert, err := d.GetTask(aufgabe.ID)
+	if err != nil || gespeichert.LastKnownDoneAt == nil {
+		t.Fatalf("nicht gespeichert: %+v (%v)", gespeichert, err)
+	}
+
+	// Leerer Text nimmt die Angabe wieder weg.
+	if text, fehler := callTool(t, ts, "aufgabe_aendern", map[string]any{
+		"id": aufgabe.ID, "lastKnownDoneAt": "",
+	}); fehler {
+		t.Fatalf("aufgabe_aendern: %s", text)
+	}
+	nach, _ := d.GetTask(aufgabe.ID)
+	if nach.LastKnownDoneAt != nil {
+		t.Fatalf("Angabe blieb stehen: %v", nach.LastKnownDoneAt)
+	}
+
+	// „Zuletzt gemacht" ist eine Aussage über die Vergangenheit.
+	if _, fehler := callTool(t, ts, "aufgabe_aendern", map[string]any{
+		"id": aufgabe.ID, "lastKnownDoneAt": "2099-01-01",
+	}); !fehler {
+		t.Error("ein Datum in der Zukunft wurde angenommen")
+	}
+}

--- a/backend/internal/model/model.go
+++ b/backend/internal/model/model.go
@@ -128,6 +128,21 @@ type CareTask struct {
 	// BefaehigungID: verlangte Einweisung (0 = keine). Ohne sie kann
 	// niemand zusagen; durchgesetzt wird das serverseitig.
 	BefaehigungID int64 `json:"befaehigungId,omitempty"`
+	// LastKnownDoneAt: wann diese Arbeit zuletzt gemacht wurde, **bevor** die
+	// App davon wusste.
+	//
+	// Jeder Ort im Dorf hat eine Geschichte, die älter ist als die App. Wird
+	// eine Aufgabe heute angelegt, rechnet der Server sonst ab heute — und
+	// ein Beet, das im Juni zuletzt gejätet wurde, stünde bis Ende Oktober
+	// auf grün, obwohl es längst dran ist.
+	//
+	// Das ist **keine Erledigung**: kein Punkt in der Rangliste, keine
+	// Person daran, keine Historie. Es ist allein der Startpunkt der
+	// Rechnung, und die erste echte Meldung löst ihn ab. Genau deshalb
+	// umgeht es auch nicht die Rückdatierungsgrenze (model.MaxBackdate):
+	// Wer hier ein Datum einträgt, verschiebt Fälligkeiten, aber schreibt
+	// keine Rangliste um.
+	LastKnownDoneAt *time.Time `json:"lastKnownDoneAt,omitempty"`
 	// BefaehigungName ist ein Anzeigefeld (nicht gespeichert).
 	BefaehigungName string `json:"befaehigungName,omitempty"`
 }
@@ -233,7 +248,12 @@ func ComputeStatus(task CareTask, last *Completion, now time.Time, factor float6
 	if factor <= 0 {
 		factor = 1
 	}
+	// Startpunkt der Rechnung: die letzte echte Meldung, sonst das, was über
+	// die Zeit davor bekannt ist, sonst das Anlegedatum.
 	base := task.CreatedAt
+	if task.LastKnownDoneAt != nil {
+		base = *task.LastKnownDoneAt
+	}
 	if last != nil {
 		base = last.DoneAt
 	}

--- a/backend/internal/model/model_test.go
+++ b/backend/internal/model/model_test.go
@@ -138,3 +138,51 @@ func TestEinmaligKurzfristigStartetGelb(t *testing.T) {
 		t.Fatalf("Status = %s, erwartet %s", got, StatusYellow)
 	}
 }
+
+// --- Was vor der App war -----------------------------------------------------
+
+// Jeder Ort im Dorf hat eine Geschichte, die älter ist als die App. Wird eine
+// Aufgabe heute angelegt, rechnet der Server sonst ab heute — und ein Beet,
+// das im Juni zuletzt gejätet wurde, stünde bis Ende Oktober auf grün.
+func TestZuletztErledigtIstDerStartpunkt(t *testing.T) {
+	jetzt := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	juni := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+
+	// Alle acht Wochen jäten, angelegt heute.
+	aufgabe := CareTask{
+		Kind: TaskWeeding, IntervalDays: 56, RedAfterDays: 77,
+		Active: true, CreatedAt: jetzt,
+	}
+
+	// Ohne die Angabe: fällig erst in acht Wochen.
+	if status, _, _ := ComputeStatus(aufgabe, nil, jetzt, 1); status != StatusGreen {
+		t.Fatalf("ohne Angabe erwartet grün, ist %q", status)
+	}
+
+	// Mit „im Juni gemacht": längst überfällig.
+	aufgabe.LastKnownDoneAt = &juni
+	status, dueAt, _ := ComputeStatus(aufgabe, nil, jetzt, 1)
+	if status != StatusRed {
+		t.Fatalf("mit Juni erwartet rot, ist %q (fällig %s)", status, dueAt)
+	}
+	if want := juni.AddDate(0, 0, 56); !dueAt.Equal(want) {
+		t.Errorf("fällig %s, erwartet %s", dueAt, want)
+	}
+}
+
+// Die erste echte Meldung löst die Angabe ab — sonst bliebe eine einmal
+// eingetragene Vergangenheit für immer der Bezugspunkt.
+func TestEchteMeldungSchlaegtDieAngabe(t *testing.T) {
+	jetzt := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	juni := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	gestern := jetzt.AddDate(0, 0, -1)
+
+	aufgabe := CareTask{
+		Kind: TaskWeeding, IntervalDays: 56, RedAfterDays: 77,
+		Active: true, CreatedAt: juni, LastKnownDoneAt: &juni,
+	}
+	status, _, _ := ComputeStatus(aufgabe, &Completion{DoneAt: gestern}, jetzt, 1)
+	if status != StatusGreen {
+		t.Fatalf("nach der Meldung von gestern erwartet grün, ist %q", status)
+	}
+}


### PR DESCRIPTION
## Der Anlass

Das Beet vor dem Dorfgemeinschaftshaus wurde **im Juni** zuletzt gejätet. Die Aufgabe dafür habe ich Ende August angelegt — und damit rechnete der Server ab dem Anlegedatum: fällig am 26.10., Status grün. Tatsächlich ist es längst dran.

Nachtragen ging nicht. Rückdatieren einer Meldung erlaubt höchstens 14 Tage, und diese Grenze ist mit Bedacht gesetzt: Gewertet wird eine Meldung nur, wenn die Aufgabe zu ihrem Zeitpunkt nicht frisch erledigt war — wer den Zeitpunkt frei in ein breites Fenster legen darf, sucht sich einen, an dem sie zählt.

Die Lücke ist eine andere: **Jeder Ort im Dorf hat eine Geschichte, die älter ist als die App.**

## Was neu ist

`lastKnownDoneAt` an der Aufgabe — der Startpunkt der Rechnung, solange es noch keine Meldung gibt. Die erste echte Meldung löst ihn ab.

**Was es ausdrücklich nicht ist: eine Erledigung.** Kein Punkt in der Rangliste, keine Person daran, keine Historie. Genau deshalb umgeht es die Rückdatierungsgrenze auch nicht — wer hier ein Datum einträgt, verschiebt Fälligkeiten und sonst nichts. Die beiden Dinge sehen ähnlich aus und sind es nicht.

Ein Datum in der **Zukunft** wird abgewiesen: „zuletzt gemacht" ist eine Aussage über die Vergangenheit, und morgen würde die Aufgabe stumm auf grün stellen. **Leerer Text** nimmt die Angabe weg, ein **fehlendes Feld** lässt sie stehen — dieselbe Vorsicht wie bei `sichtbarkeit` und der Jahreszeit, damit eine ältere App-Fassung nichts wegnimmt, was sie nicht kennt.

## Bestand

Additive Spalte mit leerer Vorbelegung; für jede vorhandene Aufgabe ändert sich nichts. Über REST **und** MCP einstellbar (`aufgabe_anlegen`, `aufgabe_aendern`), beide durch dieselbe Prüfung — `api.ParseZuletztErledigt`, damit die Regel nicht zweimal dasteht.

## Geprüft

Drei neue Tests: der Juni-Fall (grün → rot, mit der richtigen Fälligkeit), die echte Meldung schlägt die Angabe, und der Weg über MCP samt Wegnehmen und Zukunfts-Abweisung. `go vet ./...`, `go test ./...`, `pruefe_lokale_tests.py` grün.

## Danach

Sobald das ausgerollt ist, trage ich am Beet nach: zuletzt gejätet Mitte Juni, Jahreszeit April bis September. Dann steht dort, was wirklich Sache ist.