### PR TITLE
Vereine und Gruppen in beiden Apps: Verzeichnis, Beitritt, Entscheidung

### DIFF
--- a/android/app/src/main/java/de/roessing/app/DorfApp.kt
+++ b/android/app/src/main/java/de/roessing/app/DorfApp.kt
@@ -20,7 +20,9 @@ import de.roessing.app.data.MietenRentalRepository
 import de.roessing.app.data.RentalRepository
 import de.roessing.app.data.PlacesRepository
 import de.roessing.app.data.ProfileRepository
+import de.roessing.app.data.ApiTraegerRepository
 import de.roessing.app.data.StatsRepository
+import de.roessing.app.data.TraegerRepository
 import de.roessing.app.data.VeranstaltungenRepository
 import de.roessing.app.data.VergabeRepository
 import de.roessing.app.data.WebsiteApi
@@ -54,6 +56,7 @@ class AppContainer(context: Context) {
     val deviceRepository: DeviceRepository = ApiDeviceRepository(api)
     val ideenRepository: IdeenRepository = ApiIdeenRepository(api)
     val chatRepository: ChatRepository = ApiChatRepository(api)
+    val traegerRepository: TraegerRepository = ApiTraegerRepository(api)
 
     // Die Veranstaltungen kommen nicht aus dem Dorf-Backend, sondern von der
     // Website — dort werden sie gepflegt. Eigener Client, ohne Token.

--- a/android/app/src/main/java/de/roessing/app/MainActivity.kt
+++ b/android/app/src/main/java/de/roessing/app/MainActivity.kt
@@ -32,6 +32,7 @@ import de.roessing.app.ui.PlacesViewModel
 import de.roessing.app.ui.ProfileViewModel
 import de.roessing.app.ui.PublicRentalScreen
 import de.roessing.app.ui.RentalViewModel
+import de.roessing.app.ui.TraegerViewModel
 import de.roessing.app.ui.VeranstaltungenViewModel
 import de.roessing.app.push.PushZiel
 import de.roessing.app.ui.theme.DorfAppTheme
@@ -152,6 +153,7 @@ private fun Root(pushZiel: PushZiel? = null, onPushZielVerbraucht: () -> Unit = 
             val chatVm: ChatViewModel = viewModel(factory = factory)
             val termineVm: VeranstaltungenViewModel = viewModel(factory = factory)
             val verleihVm: RentalViewModel = viewModel(factory = factory)
+            val traegerVm: TraegerViewModel = viewModel(factory = factory)
             HomeScreen(
                 viewModel = vm,
                 leaderboardViewModel = rangVm,
@@ -160,6 +162,7 @@ private fun Root(pushZiel: PushZiel? = null, onPushZielVerbraucht: () -> Unit = 
                 chatViewModel = chatVm,
                 veranstaltungenViewModel = termineVm,
                 rentalViewModel = verleihVm,
+                traegerViewModel = traegerVm,
                 pushZiel = pushZiel,
                 onPushZielVerbraucht = onPushZielVerbraucht,
                 onLogout = {
@@ -197,6 +200,9 @@ private fun viewModelFactory(container: AppContainer) =
 
             modelClass.isAssignableFrom(ChatViewModel::class.java) ->
                 ChatViewModel(container.chatRepository) as T
+
+            modelClass.isAssignableFrom(TraegerViewModel::class.java) ->
+                TraegerViewModel(container.traegerRepository) as T
 
             modelClass.isAssignableFrom(VeranstaltungenViewModel::class.java) ->
                 VeranstaltungenViewModel(container.veranstaltungenRepository) as T

--- a/android/app/src/main/java/de/roessing/app/data/Api.kt
+++ b/android/app/src/main/java/de/roessing/app/data/Api.kt
@@ -63,6 +63,48 @@ interface DorfApi {
     @POST("api/v1/assignments/{id}/release")
     suspend fun release(@Path("id") assignmentId: Long): AssignmentDto
 
+    // --- Träger (Vereine und Gruppen) ---------------------------------------
+
+    /**
+     * Das Verzeichnis. Es enthält nur, was diese Person sehen darf, und je
+     * Träger gleich mit, was für sie gilt (Mitglied, Verwaltung, Beitritt).
+     * Die Regeln stehen im Server — sie in der App nachzubauen führt früher
+     * oder später zu einer anderen Antwort als der, die er gibt.
+     */
+    @GET("api/v1/traeger")
+    suspend fun traeger(): TraegerListResponse
+
+    @GET("api/v1/traeger/{id}")
+    suspend fun traegerDetail(@Path("id") id: Long): TraegerResponse
+
+    /** „Ich will mitmachen." 409 heißt: geht gerade nicht, mit Grund im Text. */
+    @POST("api/v1/traeger/{id}/beitritt")
+    suspend fun beitritt(@Path("id") id: Long, @Body input: BeitrittInput): BeitrittDto
+
+    /** Die Anträge eines Trägers — nur für die, die ihn verwalten. */
+    @GET("api/v1/traeger/{id}/beitritte")
+    suspend fun beitritte(@Path("id") id: Long): BeitritteResponse
+
+    @GET("api/v1/me/beitritte")
+    suspend fun meineBeitritte(): BeitritteResponse
+
+    /**
+     * Freigeben oder ablehnen. Die Freigabe schreibt zuerst in die
+     * Rössing-ID: 503 heißt, das Backend kann dort (noch) nichts eintragen,
+     * 502 heißt, es hat nicht geklappt. In beiden Fällen bleibt der Antrag
+     * offen, und der Satz des Servers gehört auf den Schirm.
+     */
+    @POST("api/v1/beitritte/{id}")
+    suspend fun entscheideBeitritt(
+        @Path("id") id: Long,
+        @Body input: BeitrittDecisionInput,
+    ): BeitrittDto
+
+    /** Jemanden ohne Antrag aufnehmen — bei einer geschlossenen Gruppe der
+     *  einzige Weg hinein. */
+    @POST("api/v1/traeger/{id}/mitglieder")
+    suspend fun mitgliedAufnehmen(@Path("id") id: Long, @Body input: MitgliedInput): BeitrittDto
+
     // --- Ideen-Sammlung ------------------------------------------------------
 
     /**

--- a/android/app/src/main/java/de/roessing/app/data/Model.kt
+++ b/android/app/src/main/java/de/roessing/app/data/Model.kt
@@ -178,6 +178,15 @@ data class PlaceDto(
      * Sichtbarkeitsregel zweimal.
      */
     val traegerName: String = "",
+    /**
+     * Die Kennung desselben Trägers — der Weg von hier zu ihm.
+     *
+     * Sie steht auch dann im JSON, wenn der Name verdeckt ist. Ob der Weg
+     * angeboten wird, entscheidet die App trotzdem nicht an dieser Zahl,
+     * sondern am Verzeichnis: Steht der Träger nicht darin, hat der Server
+     * ihn für diese Person nicht vorgesehen.
+     */
+    val traegerId: Long = 0,
     val tasks: List<TaskDto> = emptyList(),
 ) {
     val careStatus: CareStatus get() = parseStatus(status)

--- a/android/app/src/main/java/de/roessing/app/data/Traeger.kt
+++ b/android/app/src/main/java/de/roessing/app/data/Traeger.kt
@@ -1,0 +1,181 @@
+package de.roessing.app.data
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import retrofit2.HttpException
+
+/**
+ * Träger (Vereine und Gruppen) und die Beitritte zu ihnen.
+ *
+ * What arrives here is already decided. The list holds only what this person
+ * may see, and every entry carries what applies to them: member, may
+ * administer, may join — and if not, why not, as a finished German sentence.
+ * None of that is recomputed here. The rules live in `model.Zugriff` in the
+ * backend; a second check in the app would answer differently than the server
+ * at the next special case.
+ *
+ * The field names follow the wire format, which is German — a DTO's job is to
+ * match the JSON, not to translate it.
+ */
+
+/** One Traeger, in the view of the person who asked. */
+@Serializable
+data class TraegerDto(
+    val id: Long = 0,
+    val name: String = "",
+    val beschreibung: String = "",
+    /** beantragt · zugelassen · gesperrt */
+    val status: String = "",
+    /** offen · geschlossen */
+    val sichtbarkeit: String = "",
+    /**
+     * The roof this Traeger works under — 0 means none. Exactly one level:
+     * association → working group. Rights travel along it in neither
+     * direction; whoever administers the working group does not thereby
+     * administer the association.
+     */
+    val parentId: Long = 0,
+    val istMitglied: Boolean = false,
+    val darfVerwalten: Boolean = false,
+    /** This person can file a request right now. */
+    val beitrittMoeglich: Boolean = false,
+    /** Why not — meant to be shown verbatim. */
+    val beitrittHindernis: String = "",
+    /** How my own request stands: beantragt · erteilt · abgelehnt. */
+    val beitrittStatus: String = "",
+    /** Undecided requests — filled only for those who administer. */
+    val offeneBeitritte: Int = 0,
+) {
+    /**
+     * A closed group is in the directory for members only, and it takes no
+     * requests — it takes people in itself. What follows for the buttons is
+     * [beitrittMoeglich]; this is only for the sentence beside them.
+     */
+    val istGeschlossen: Boolean get() = sichtbarkeit == "geschlossen"
+}
+
+@Serializable
+data class TraegerListResponse(val traeger: List<TraegerDto> = emptyList())
+
+@Serializable
+data class TraegerResponse(val traeger: TraegerDto = TraegerDto())
+
+/**
+ * A request for membership in a Traeger.
+ *
+ * A granted request is **not** the membership: that one lives in the
+ * Rössing-ID. Here stands the proceeding — who asked when, who decided when.
+ * Which is why granting can fail while the request stays open.
+ */
+@Serializable
+data class BeitrittDto(
+    val id: Long = 0,
+    val traegerId: Long = 0,
+    val traegerName: String = "",
+    val userSub: String = "",
+    val userName: String = "",
+    /** beantragt · erteilt · abgelehnt */
+    val status: String = "",
+    val begruendung: String = "",
+    val notiz: String = "",
+    val createdAt: String = "",
+) {
+    /** The server resolves the name from the profile; the bare identifier is
+     *  the fallback, not the normal case. */
+    val anzeigename: String get() = userName.ifBlank { userSub }
+}
+
+@Serializable
+data class BeitritteResponse(val beitritte: List<BeitrittDto> = emptyList())
+
+/** Body of `POST /api/v1/traeger/{id}/beitritt`. */
+@Serializable
+data class BeitrittInput(val begruendung: String = "")
+
+/** Body of `POST /api/v1/beitritte/{id}`. */
+@Serializable
+data class BeitrittDecisionInput(val status: String, val notiz: String = "")
+
+/** Body of `POST /api/v1/traeger/{id}/mitglieder`. */
+@Serializable
+data class MitgliedInput(val userSub: String, val notiz: String = "")
+
+/**
+ * The server refused, and it says why in plain German.
+ *
+ * This one exception covers every refusal that carries a sentence — 409
+ * ("you already belong", "closed group"), 403, and above all 502/503 from
+ * writing back into the Rössing-ID. The sentence is passed on word for word:
+ * an app that reports "taken in" while the door stays shut would be worse
+ * than no app at all.
+ */
+class TraegerRefusedException(val grund: String) : RuntimeException(grund)
+
+interface TraegerRepository {
+    suspend fun list(): List<TraegerDto>
+    suspend fun detail(id: Long): TraegerDto
+    suspend fun join(id: Long, reason: String): BeitrittDto
+    suspend fun requests(traegerId: Long): List<BeitrittDto>
+    suspend fun myRequests(): List<BeitrittDto>
+    suspend fun decide(requestId: Long, status: String): BeitrittDto
+    suspend fun addMember(traegerId: Long, userSub: String): BeitrittDto
+    suspend fun villagers(): List<MemberDto>
+}
+
+class ApiTraegerRepository(private val api: DorfApi) : TraegerRepository {
+    override suspend fun list(): List<TraegerDto> = api.traeger().traeger
+
+    override suspend fun detail(id: Long): TraegerDto = api.traegerDetail(id).traeger
+
+    override suspend fun join(id: Long, reason: String): BeitrittDto =
+        mitGrund { api.beitritt(id, BeitrittInput(reason)) }
+
+    override suspend fun requests(traegerId: Long): List<BeitrittDto> =
+        mitGrund { api.beitritte(traegerId).beitritte }
+
+    override suspend fun myRequests(): List<BeitrittDto> = api.meineBeitritte().beitritte
+
+    override suspend fun decide(requestId: Long, status: String): BeitrittDto =
+        mitGrund { api.entscheideBeitritt(requestId, BeitrittDecisionInput(status)) }
+
+    override suspend fun addMember(traegerId: Long, userSub: String): BeitrittDto =
+        mitGrund { api.mitgliedAufnehmen(traegerId, MitgliedInput(userSub)) }
+
+    override suspend fun villagers(): List<MemberDto> = api.members().members
+
+    /**
+     * Turns a refusal that carries a sentence into [TraegerRefusedException].
+     * Everything else stays as it is — a broken connection is not an answer
+     * from the server and must not be dressed up as one.
+     */
+    private suspend fun <T> mitGrund(block: suspend () -> T): T = try {
+        block()
+    } catch (e: HttpException) {
+        val grund = fehlergrund(e)
+        if (grund.isNotBlank()) throw TraegerRefusedException(grund) else throw e
+    }
+
+    private fun fehlergrund(e: HttpException): String = runCatching {
+        val roh = e.response()?.errorBody()?.string().orEmpty()
+        Json { ignoreUnknownKeys = true }.decodeFromString<ApiErrorDto>(roh).error
+    }.getOrNull().orEmpty()
+}
+
+/**
+ * Ein leeres Verzeichnis — die Vorgabe für Oberflächen-Tests und Vorschauen,
+ * die mit Vereinen nichts zu tun haben.
+ */
+object KeineTraeger : TraegerRepository {
+    override suspend fun list(): List<TraegerDto> = emptyList()
+    override suspend fun detail(id: Long): TraegerDto = TraegerDto(id = id)
+    override suspend fun join(id: Long, reason: String): BeitrittDto = BeitrittDto(traegerId = id)
+    override suspend fun requests(traegerId: Long): List<BeitrittDto> = emptyList()
+    override suspend fun myRequests(): List<BeitrittDto> = emptyList()
+    override suspend fun decide(requestId: Long, status: String): BeitrittDto =
+        BeitrittDto(id = requestId, status = status)
+
+    override suspend fun addMember(traegerId: Long, userSub: String): BeitrittDto =
+        BeitrittDto(traegerId = traegerId, userSub = userSub, status = "erteilt")
+
+    override suspend fun villagers(): List<MemberDto> = emptyList()
+}

--- a/android/app/src/main/java/de/roessing/app/ui/HomeScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/HomeScreen.kt
@@ -70,6 +70,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import de.roessing.app.R
 import de.roessing.app.data.DeviceLocation
 import de.roessing.app.data.KeinChat
+import de.roessing.app.data.KeineTraeger
 import de.roessing.app.data.KeineVeranstaltungen
 import de.roessing.app.data.NoRental
 import de.roessing.app.push.Geraeteanmeldung
@@ -101,6 +102,9 @@ fun HomeScreen(
     // Same reasoning: an empty rental platform, so that screen tests which
     // have nothing to do with renting keep working.
     rentalViewModel: RentalViewModel = remember { RentalViewModel(NoRental) },
+    // Same reasoning again: an empty directory, so that screen tests which
+    // have nothing to do with associations keep working.
+    traegerViewModel: TraegerViewModel = remember { TraegerViewModel(KeineTraeger) },
     pushZiel: PushZiel? = null,
     onPushZielVerbraucht: () -> Unit = {},
     onLogout: () -> Unit,
@@ -124,6 +128,7 @@ fun HomeScreen(
     val chat by chatViewModel.state.collectAsState()
     val veranstaltungen by veranstaltungenViewModel.state.collectAsState()
     val verleih by rentalViewModel.state.collectAsState()
+    val traeger by traegerViewModel.state.collectAsState()
     var bereich by rememberSaveable { mutableStateOf(Bereich.START) }
     val snackbar = remember { SnackbarHostState() }
     val context = LocalContext.current
@@ -147,11 +152,15 @@ fun HomeScreen(
     // aus dem Bereich auf die Startseite — und erst von dort aus der App
     // heraus. Jeder Schritt einzeln, keiner übersprungen.
     BackHandler(enabled = bereich != Bereich.START || termin != null) {
-        if (termin != null) {
-            offenerTermin = null
-        } else {
-            offenerTermin = null
-            bereich = Bereich.START
+        when {
+            termin != null -> offenerTermin = null
+            // Aus einem aufgeschlagenen Träger zurück ins Verzeichnis — ein
+            // Schritt, nicht zwei auf einmal.
+            bereich == Bereich.TRAEGER && traeger.open != null -> traegerViewModel.close()
+            else -> {
+                offenerTermin = null
+                bereich = Bereich.START
+            }
         }
     }
 
@@ -335,6 +344,31 @@ fun HomeScreen(
     LaunchedEffect(bereich) {
         if (bereich == Bereich.CHAT) chatViewModel.standPruefen()
     }
+    // Die Träger holt schon die Startseite: Ihre Kachel zählt die offenen
+    // Anfragen, und die Ortsansicht fragt das Verzeichnis, ob es zum Träger
+    // eines Ortes überhaupt einen Weg gibt.
+    LaunchedEffect(bereich) {
+        if (bereich == Bereich.START || bereich == Bereich.TRAEGER) traegerViewModel.load()
+        // Wer den Bereich verlässt, kommt beim nächsten Mal wieder im
+        // Verzeichnis an — ein einzelner Träger ist ein Weg dorthin, kein
+        // eigener Aufenthalt.
+        if (bereich != Bereich.TRAEGER) traegerViewModel.close()
+    }
+    val traegerJoined = stringResource(R.string.traeger_joined)
+    LaunchedEffect(Unit) {
+        traegerViewModel.events.collect { event ->
+            when (event) {
+                is TraegerEvent.Joined -> snackbar.showSnackbar(traegerJoined)
+                // Der Name steht im Ereignis, nicht im Text — deshalb erst
+                // hier eingesetzt.
+                is TraegerEvent.Granted ->
+                    snackbar.showSnackbar(context.getString(R.string.traeger_granted, event.name))
+
+                is TraegerEvent.Rejected ->
+                    snackbar.showSnackbar(context.getString(R.string.traeger_rejected, event.name))
+            }
+        }
+    }
     // Name und E-Mail im Ideen-Formular kommen aus dem Profil. Sie werden
     // nur nachgetragen, wenn die Felder noch leer sind — wer schon getippt
     // hat, verliert nichts (siehe IdeenViewModel.vorbelegen).
@@ -380,6 +414,8 @@ fun HomeScreen(
                             Bereich.VERLEIH -> stringResource(R.string.rental_title)
                             Bereich.IDEEN -> stringResource(R.string.ideas_title)
                             Bereich.CHAT -> stringResource(R.string.chat_title)
+                            Bereich.TRAEGER -> traeger.openTraeger?.name
+                                ?: stringResource(R.string.traeger_title)
                             Bereich.START -> stringResource(R.string.home_title)
                         },
                     )
@@ -389,7 +425,13 @@ fun HomeScreen(
                         IconButton(
                             onClick = {
                                 offenerTermin = null
-                                if (termin == null) bereich = Bereich.START
+                                when {
+                                    termin != null -> Unit
+                                    bereich == Bereich.TRAEGER && traeger.open != null ->
+                                        traegerViewModel.close()
+
+                                    else -> bereich = Bereich.START
+                                }
                             },
                             modifier = Modifier.testTag("zurueck"),
                         ) {
@@ -534,6 +576,7 @@ fun HomeScreen(
                     ladend = state.loading && state.places.isEmpty(),
                     isAdmin = state.me?.isAdmin == true,
                     modifier = Modifier.padding(padding),
+                    offeneTraegerAnfragen = traeger.openRequestsForMe,
                     notifications = state.notifications,
                     pendingAssignments = state.pendingAssignments,
                     meineVorgaenge = meineVorgaenge(state),
@@ -624,6 +667,26 @@ fun HomeScreen(
                     onSenden = ideenViewModel::absenden,
                 )
 
+                Bereich.TRAEGER -> TraegerScreen(
+                    state = traeger,
+                    modifier = Modifier.padding(padding),
+                    places = state.places,
+                    onOpen = traegerViewModel::open,
+                    onJoin = traegerViewModel::join,
+                    onDecide = traegerViewModel::decide,
+                    onAddMember = traegerViewModel::addMember,
+                    onLoadVillagers = traegerViewModel::loadVillagers,
+                    // Der Weg vom Träger zurück zu seinen Orten: derselbe
+                    // Ort, denselben Weg, den auch die Liste unter
+                    // „Mithelfen" nimmt.
+                    onPlace = { ortId ->
+                        bereich = Bereich.MITHELFEN
+                        tab = 1
+                        selectedPlaceId = ortId
+                    },
+                    onDismissError = traegerViewModel::dismissError,
+                )
+
                 Bereich.CHAT -> ChatScreen(
                     state = chat,
                     modifier = Modifier.padding(padding),
@@ -686,6 +749,20 @@ fun HomeScreen(
                 onSignup = { placeId, art, an -> viewModel.setSignup(placeId, art, an) },
                 onClaim = { viewModel.claim(it) },
                 onRelease = { viewModel.release(it) },
+                // Von hier zum Träger — aber nur, wenn der Server ihn dieser
+                // Person überhaupt ins Verzeichnis gestellt hat. Sonst bliebe
+                // der Weg eine Sackgasse: Eine geschlossene Gruppe heißt hier
+                // „Eine Gruppe aus dem Dorf", und ihre Seite gibt es für
+                // Außenstehende nicht.
+                onTraeger = if (traeger.inDirectory(selected.traegerId)) {
+                    {
+                        selectedPlaceId = null
+                        bereich = Bereich.TRAEGER
+                        traegerViewModel.open(selected.traegerId)
+                    }
+                } else {
+                    null
+                },
             )
         }
     }

--- a/android/app/src/main/java/de/roessing/app/ui/PlaceDetail.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/PlaceDetail.kt
@@ -1,5 +1,6 @@
 package de.roessing.app.ui
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -89,6 +90,12 @@ fun PlaceDetail(
     onSignup: (placeId: Long, taskKind: String?, an: Boolean) -> Unit = { _, _, _ -> },
     onClaim: (assignmentId: Long) -> Unit = {},
     onRelease: (assignmentId: Long) -> Unit = {},
+    /**
+     * Der Weg zum Träger dieses Ortes — null heißt: Es gibt keinen. Ob es
+     * einen gibt, entscheidet nicht diese Ansicht, sondern das Verzeichnis
+     * des Servers: Was nicht darin steht, gibt es für diese Person nicht.
+     */
+    onTraeger: (() -> Unit)? = null,
 ) {
     LaunchedEffect(place.id) {
         place.tasks.forEach { onLoadHistory(it.id) }
@@ -114,7 +121,14 @@ fun PlaceDetail(
         // mit Einweisung anfassen darf, ist genau das die wichtigste Angabe.
         if (place.traegerName.isNotEmpty()) {
             Spacer(Modifier.height(6.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = if (onTraeger == null) {
+                    Modifier
+                } else {
+                    Modifier.clickable(onClick = onTraeger)
+                },
+            ) {
                 Icon(
                     Icons.Filled.Group,
                     contentDescription = null,
@@ -125,7 +139,11 @@ fun PlaceDetail(
                 Text(
                     place.traegerName,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = if (onTraeger == null) {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    } else {
+                        MaterialTheme.colorScheme.primary
+                    },
                     modifier = Modifier.testTag("ort-traeger"),
                 )
             }

--- a/android/app/src/main/java/de/roessing/app/ui/StartScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/StartScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.filled.Handyman
 import androidx.compose.material.icons.filled.LocalFlorist
 import androidx.compose.material.icons.filled.Person
@@ -47,7 +48,9 @@ import de.roessing.app.ui.theme.statusFarben
  * Die Bereiche der App. „Mithelfen" ist der erste — weitere kommen, deshalb
  * ist die Startseite eine Übersicht und nicht die Gieß-Karte.
  */
-enum class Bereich { START, MITHELFEN, VERANSTALTUNGEN, VERLEIH, PROFIL, DORFBEWOHNER, IDEEN, CHAT }
+enum class Bereich {
+    START, MITHELFEN, VERANSTALTUNGEN, VERLEIH, PROFIL, DORFBEWOHNER, IDEEN, CHAT, TRAEGER,
+}
 
 /**
  * Startseite: freundlicher Einstieg mit dem Namen aus dem Profil, darunter
@@ -62,6 +65,12 @@ fun StartScreen(
     modifier: Modifier = Modifier,
     /** Only accounts holding the role "admin" see the hint on administering. */
     isAdmin: Boolean = false,
+    /**
+     * Wie viele Beitrittsanfragen auf **meine** Entscheidung warten. Die Zahl
+     * schickt der Server nur denen mit, die den Träger verwalten — wer nichts
+     * zu entscheiden hat, sieht deshalb gar nichts.
+     */
+    offeneTraegerAnfragen: Int = 0,
     notifications: List<de.roessing.app.data.NotificationDto> = emptyList(),
     pendingAssignments: Set<Long> = emptySet(),
     meineVorgaenge: Set<Long> = emptySet(),
@@ -132,6 +141,26 @@ fun StartScreen(
             symbol = Icons.Filled.Handyman,
             testTag = "bereich-verleih",
             onClick = { onBereich(Bereich.VERLEIH) },
+        )
+
+        // Wem die Orte und Aufgaben gehören — und wo man sagt „ich will
+        // mitmachen". Der Hinweis zählt, was auf eine Entscheidung wartet:
+        // Wer im Vorstand ist, soll es sehen, ohne erst hineinzugehen.
+        BereichKachel(
+            titel = stringResource(R.string.area_traeger_title),
+            text = stringResource(R.string.area_traeger_subtitle),
+            symbol = Icons.Filled.Groups,
+            testTag = "bereich-traeger",
+            hinweis = if (offeneTraegerAnfragen > 0) {
+                pluralStringResource(
+                    R.plurals.traeger_open_requests_hint,
+                    offeneTraegerAnfragen,
+                    offeneTraegerAnfragen,
+                )
+            } else {
+                null
+            },
+            onClick = { onBereich(Bereich.TRAEGER) },
         )
 
         Row(
@@ -276,6 +305,8 @@ private fun BereichKachel(
     symbol: ImageVector,
     testTag: String,
     modifier: Modifier = Modifier,
+    /** Optionale Zeile darunter („2 Anfragen warten auf dich"). */
+    hinweis: String? = null,
     onClick: () -> Unit,
 ) {
     Card(
@@ -304,6 +335,14 @@ private fun BereichKachel(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            if (hinweis != null) {
+                Text(
+                    hinweis,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.testTag("$testTag-hinweis"),
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/java/de/roessing/app/ui/TraegerScreen.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/TraegerScreen.kt
@@ -1,0 +1,691 @@
+package de.roessing.app.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.HourglassEmpty
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Verified
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import de.roessing.app.R
+import de.roessing.app.data.BeitrittDto
+import de.roessing.app.data.MemberDto
+import de.roessing.app.data.PlaceDto
+import de.roessing.app.data.TraegerDto
+import de.roessing.app.ui.theme.statusFarben
+
+/**
+ * Der Bereich „Vereine und Gruppen": das Verzeichnis, und dahinter je Träger
+ * die Seite mit Arbeitskreisen, Orten, dem Weg zum Mitmachen — und, für den
+ * Vorstand, den Anfragen.
+ *
+ * Was hier zu sehen und zu tun ist, entscheidet der Server: Die Liste enthält
+ * nur, was diese Person sehen darf, und jeder Eintrag bringt mit, ob sie
+ * Mitglied ist, verwalten darf und beitreten kann. Hier steht nur, wie das
+ * aussieht und welche Knöpfe es gibt.
+ */
+@Composable
+fun TraegerScreen(
+    state: TraegerUiState,
+    modifier: Modifier = Modifier,
+    places: List<PlaceDto> = emptyList(),
+    onOpen: (Long) -> Unit = {},
+    onJoin: (Long, String) -> Unit = { _, _ -> },
+    onDecide: (BeitrittDto, String) -> Unit = { _, _ -> },
+    onAddMember: (Long, MemberDto) -> Unit = { _, _ -> },
+    onLoadVillagers: () -> Unit = {},
+    onPlace: (Long) -> Unit = {},
+    onDismissError: () -> Unit = {},
+) {
+    val offen = state.openTraeger
+    Column(
+        modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp)
+            .padding(top = 8.dp, bottom = 28.dp)
+            .testTag(if (offen == null) "traeger-list" else "traeger-detail"),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        state.notice?.let { hinweis ->
+            Hinweiszeile(hinweis, testTag = "traeger-notice")
+        }
+        if (offen == null) {
+            Verzeichnis(state = state, onOpen = onOpen)
+        } else {
+            Detail(
+                state = state,
+                traeger = offen,
+                places = places.filter { it.traegerId == offen.id },
+                onOpen = onOpen,
+                onJoin = onJoin,
+                onDecide = onDecide,
+                onAddMember = onAddMember,
+                onLoadVillagers = onLoadVillagers,
+                onPlace = onPlace,
+            )
+        }
+    }
+
+    // Der Wortlaut kommt vom Server. Er weiß, warum es nicht ging — die App
+    // wüsste es nur ungefähr.
+    state.error?.let { fehler ->
+        AlertDialog(
+            onDismissRequest = onDismissError,
+            modifier = Modifier.testTag("traeger-error"),
+            title = { Text(stringResource(R.string.traeger_failed_title)) },
+            text = { Text(fehler) },
+            confirmButton = {
+                TextButton(onClick = onDismissError, modifier = Modifier.testTag("traeger-error-ok")) {
+                    Text("Ok")
+                }
+            },
+        )
+    }
+}
+
+// --- Verzeichnis ------------------------------------------------------------
+
+@Composable
+private fun Verzeichnis(state: TraegerUiState, onOpen: (Long) -> Unit) {
+    if (state.myPending.isNotEmpty()) {
+        Text(
+            stringResource(R.string.traeger_my_requests),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        state.myPending.forEach { antrag ->
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("my-request-${antrag.id}"),
+            ) {
+                Column(Modifier.padding(16.dp)) {
+                    Text(antrag.traegerName, style = MaterialTheme.typography.titleSmall)
+                    Text(
+                        stringResource(R.string.traeger_my_request_pending),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+
+    if (state.roots.isEmpty()) {
+        if (state.loading && !state.everLoaded) {
+            CircularProgressIndicator()
+        } else {
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("traeger-empty"),
+            ) {
+                Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text(
+                        stringResource(R.string.traeger_empty_title),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Text(
+                        stringResource(R.string.traeger_empty_text),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+        return
+    }
+
+    state.roots.forEach { verein ->
+        TraegerKarte(traeger = verein, onClick = { onOpen(verein.id) })
+        state.children(of = verein.id).forEach { arbeitskreis ->
+            TraegerKarte(
+                traeger = arbeitskreis,
+                unterTraeger = true,
+                onClick = { onOpen(arbeitskreis.id) },
+            )
+        }
+    }
+}
+
+/** Eine Zeile des Verzeichnisses. Arbeitskreise stehen eingerückt darunter. */
+@Composable
+private fun TraegerKarte(
+    traeger: TraegerDto,
+    unterTraeger: Boolean = false,
+    onClick: () -> Unit,
+) {
+    Card(
+        onClick = onClick,
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = if (unterTraeger) {
+                MaterialTheme.colorScheme.surfaceContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceContainerHigh
+            },
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = if (unterTraeger) 20.dp else 0.dp)
+            .testTag("traeger-${traeger.id}"),
+    ) {
+        Row(Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    traeger.name,
+                    style = if (unterTraeger) {
+                        MaterialTheme.typography.titleSmall
+                    } else {
+                        MaterialTheme.typography.titleMedium
+                    },
+                )
+                if (traeger.beschreibung.isNotBlank()) {
+                    Text(
+                        traeger.beschreibung,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Abzeichen(traeger)
+            }
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+/** Die kurzen Marken: dabei, offen, geschlossen — und wie viele Anfragen auf
+ *  eine Entscheidung warten. */
+@Composable
+private fun Abzeichen(traeger: TraegerDto) {
+    val farben = statusFarben
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        when {
+            traeger.istMitglied -> Marke(
+                stringResource(R.string.traeger_member_badge),
+                Icons.Filled.Verified,
+                farben.gruen,
+                "traeger-member-${traeger.id}",
+            )
+
+            traeger.istGeschlossen -> Marke(
+                stringResource(R.string.traeger_closed_badge),
+                Icons.Filled.Lock,
+                MaterialTheme.colorScheme.onSurfaceVariant,
+                "traeger-closed-${traeger.id}",
+            )
+
+            traeger.beitrittStatus == "beantragt" -> Marke(
+                stringResource(R.string.traeger_pending_badge),
+                Icons.Filled.HourglassEmpty,
+                MaterialTheme.colorScheme.onSurfaceVariant,
+                "traeger-pending-${traeger.id}",
+            )
+
+            traeger.beitrittMoeglich -> Marke(
+                stringResource(R.string.traeger_joinable_badge),
+                Icons.Filled.PersonAdd,
+                MaterialTheme.colorScheme.primary,
+                "traeger-joinable-${traeger.id}",
+            )
+        }
+        if (traeger.offeneBeitritte > 0) {
+            Marke(
+                stringResource(R.string.traeger_open_badge, traeger.offeneBeitritte),
+                Icons.Filled.HourglassEmpty,
+                farben.gelb,
+                "traeger-open-${traeger.id}",
+            )
+        }
+    }
+}
+
+@Composable
+private fun Marke(text: String, symbol: ImageVector, farbe: Color, tag: String) {
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.testTag(tag)) {
+        Icon(symbol, contentDescription = null, tint = farbe, modifier = Modifier.size(14.dp))
+        Spacer(Modifier.width(4.dp))
+        Text(text, style = MaterialTheme.typography.labelMedium, color = farbe)
+    }
+}
+
+@Composable
+private fun Hinweiszeile(text: String, testTag: String) {
+    Surface(
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(testTag),
+    ) {
+        Text(text, style = MaterialTheme.typography.bodySmall, modifier = Modifier.padding(14.dp))
+    }
+}
+
+// --- Ein einzelner Träger ---------------------------------------------------
+
+@Composable
+private fun Detail(
+    state: TraegerUiState,
+    traeger: TraegerDto,
+    places: List<PlaceDto>,
+    onOpen: (Long) -> Unit,
+    onJoin: (Long, String) -> Unit,
+    onDecide: (BeitrittDto, String) -> Unit,
+    onAddMember: (Long, MemberDto) -> Unit,
+    onLoadVillagers: () -> Unit,
+    onPlace: (Long) -> Unit,
+) {
+    var mitmachenOffen by remember { mutableStateOf(false) }
+    var aufnahmeOffen by remember { mutableStateOf(false) }
+
+    Text(traeger.name, style = MaterialTheme.typography.headlineSmall)
+    if (traeger.beschreibung.isNotBlank()) {
+        Text(traeger.beschreibung, style = MaterialTheme.typography.bodyMedium)
+    }
+    Abzeichen(traeger)
+
+    state.traeger(traeger.parentId)?.let { dach ->
+        TextButton(
+            onClick = { onOpen(dach.id) },
+            modifier = Modifier.testTag("traeger-parent"),
+        ) {
+            Text(stringResource(R.string.traeger_parent, dach.name))
+        }
+    }
+
+    HorizontalDivider()
+    Text(
+        stringResource(R.string.traeger_state_heading),
+        style = MaterialTheme.typography.titleSmall,
+    )
+    Zeile(
+        text = when (traeger.status) {
+            "zugelassen" -> stringResource(R.string.traeger_status_approved)
+            "beantragt" -> stringResource(R.string.traeger_status_pending)
+            "gesperrt" -> stringResource(R.string.traeger_status_blocked)
+            else -> traeger.status
+        },
+        symbol = Icons.Filled.Verified,
+    )
+    Zeile(
+        text = if (traeger.istGeschlossen) {
+            stringResource(R.string.traeger_visibility_closed)
+        } else {
+            stringResource(R.string.traeger_visibility_open)
+        },
+        symbol = if (traeger.istGeschlossen) Icons.Filled.Lock else Icons.Filled.Public,
+    )
+
+    // Mitmachen
+    HorizontalDivider()
+    Text(stringResource(R.string.traeger_join_heading), style = MaterialTheme.typography.titleSmall)
+    when {
+        traeger.istMitglied -> Zeile(
+            text = stringResource(R.string.traeger_i_am_member),
+            symbol = Icons.Filled.CheckCircle,
+            testTag = "traeger-i-am-member",
+        )
+
+        traeger.beitrittStatus == "beantragt" -> Zeile(
+            text = stringResource(R.string.traeger_my_request_state),
+            symbol = Icons.Filled.HourglassEmpty,
+            testTag = "traeger-my-request",
+        )
+
+        traeger.beitrittMoeglich -> Button(
+            onClick = { mitmachenOffen = true },
+            enabled = traeger.id !in state.busy,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("traeger-join"),
+        ) {
+            Text(stringResource(R.string.traeger_join))
+        }
+
+        // Der Satz kommt vom Server: „Diese Gruppe ist geschlossen …",
+        // „Dieser Träger hat in der Rössing-ID noch kein Projekt …". Ihn hier
+        // nachzubauen hieße, die Regeln ein zweites Mal zu haben.
+        traeger.beitrittHindernis.isNotBlank() -> Zeile(
+            text = traeger.beitrittHindernis,
+            symbol = Icons.Filled.Lock,
+            testTag = "traeger-obstacle",
+        )
+    }
+
+    // Arbeitskreise
+    val kinder = state.children(of = traeger.id)
+    if (kinder.isNotEmpty()) {
+        HorizontalDivider()
+        Text(
+            stringResource(R.string.traeger_working_groups),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        kinder.forEach { kind ->
+            TraegerKarte(traeger = kind, unterTraeger = true, onClick = { onOpen(kind.id) })
+        }
+        Text(
+            stringResource(R.string.traeger_working_groups_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    // Die Orte, die dieser Träger betreut — der Weg zurück zu dem, worum es
+    // eigentlich geht. Dieselbe Liste, die auch „Mithelfen" zeigt, und damit
+    // dieselbe Sichtbarkeit.
+    if (places.isNotEmpty()) {
+        HorizontalDivider()
+        Text(stringResource(R.string.traeger_places), style = MaterialTheme.typography.titleSmall)
+        places.forEach { ort ->
+            Card(
+                onClick = { onPlace(ort.id) },
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("traeger-place-${ort.id}"),
+            ) {
+                Row(
+                    Modifier.padding(14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    StatusPill(ort.careStatus, statusLabel(ort.careStatus))
+                    Text(ort.name, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+        Text(
+            stringResource(R.string.traeger_places_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    // Anfragen entscheiden — nur, wer verwalten darf, sieht das überhaupt.
+    // Ob er darf, sagt der Server.
+    if (traeger.darfVerwalten) {
+        HorizontalDivider()
+        Text(stringResource(R.string.traeger_requests), style = MaterialTheme.typography.titleSmall)
+        val offene = state.openRequests(traeger.id)
+        if (offene.isEmpty()) {
+            Text(
+                stringResource(R.string.traeger_requests_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("traeger-requests-empty"),
+            )
+        }
+        offene.forEach { antrag ->
+            AntragKarte(
+                antrag = antrag,
+                laeuft = antrag.id in state.busyRequests,
+                onDecide = onDecide,
+            )
+        }
+        OutlinedButton(
+            onClick = {
+                onLoadVillagers()
+                aufnahmeOffen = true
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("traeger-add-member"),
+        ) {
+            Text(stringResource(R.string.traeger_add_member))
+        }
+        Text(
+            stringResource(R.string.traeger_requests_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    if (mitmachenOffen) {
+        MitmachenDialog(
+            traeger = traeger,
+            laeuft = traeger.id in state.busy,
+            onDismiss = { mitmachenOffen = false },
+            onSend = { grund ->
+                mitmachenOffen = false
+                onJoin(traeger.id, grund)
+            },
+        )
+    }
+
+    if (aufnahmeOffen) {
+        AufnahmeDialog(
+            villagers = state.villagers,
+            onDismiss = { aufnahmeOffen = false },
+            onPick = { person ->
+                aufnahmeOffen = false
+                onAddMember(traeger.id, person)
+            },
+        )
+    }
+}
+
+@Composable
+private fun Zeile(text: String, symbol: ImageVector, testTag: String? = null) {
+    Row(
+        verticalAlignment = Alignment.Top,
+        modifier = if (testTag == null) Modifier else Modifier.testTag(testTag),
+    ) {
+        Icon(
+            symbol,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.width(10.dp))
+        Text(text, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun AntragKarte(
+    antrag: BeitrittDto,
+    laeuft: Boolean,
+    onDecide: (BeitrittDto, String) -> Unit,
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("request-${antrag.id}"),
+    ) {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text(antrag.anzeigename, style = MaterialTheme.typography.titleSmall)
+            if (antrag.begruendung.isNotBlank()) {
+                Text(
+                    antrag.begruendung,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                Button(
+                    onClick = { onDecide(antrag, "erteilt") },
+                    enabled = !laeuft,
+                    modifier = Modifier.testTag("request-grant-${antrag.id}"),
+                ) {
+                    Text(stringResource(R.string.traeger_grant))
+                }
+                OutlinedButton(
+                    onClick = { onDecide(antrag, "abgelehnt") },
+                    enabled = !laeuft,
+                    modifier = Modifier.testTag("request-reject-${antrag.id}"),
+                ) {
+                    Text(stringResource(R.string.traeger_reject))
+                }
+            }
+        }
+    }
+}
+
+/** „Ich will mitmachen" — mit einem Satz dazu, warum. */
+@Composable
+private fun MitmachenDialog(
+    traeger: TraegerDto,
+    laeuft: Boolean,
+    onDismiss: () -> Unit,
+    onSend: (String) -> Unit,
+) {
+    var grund by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.testTag("traeger-join-dialog"),
+        title = { Text(stringResource(R.string.traeger_join_heading)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(stringResource(R.string.traeger_join_intro, traeger.name))
+                OutlinedTextField(
+                    value = grund,
+                    onValueChange = { grund = it },
+                    placeholder = { Text(stringResource(R.string.traeger_join_placeholder)) },
+                    minLines = 2,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("join-reason"),
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onSend(grund) },
+                enabled = !laeuft,
+                modifier = Modifier.testTag("join-send"),
+            ) {
+                Text(stringResource(R.string.traeger_join_send))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        },
+    )
+}
+
+/** Jemanden ohne Antrag aufnehmen — bei einer geschlossenen Gruppe der
+ *  einzige Weg hinein. */
+@Composable
+private fun AufnahmeDialog(
+    villagers: List<MemberDto>,
+    onDismiss: () -> Unit,
+    onPick: (MemberDto) -> Unit,
+) {
+    var suche by remember { mutableStateOf("") }
+    val treffer = remember(suche, villagers) {
+        val begriff = suche.trim().lowercase()
+        if (begriff.isBlank()) {
+            villagers
+        } else {
+            villagers.filter { TraegerViewModel.anzeigename(it).lowercase().contains(begriff) }
+        }
+    }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.testTag("traeger-add-member-dialog"),
+        title = { Text(stringResource(R.string.traeger_add_member)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    stringResource(R.string.traeger_add_member_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+                OutlinedTextField(
+                    value = suche,
+                    onValueChange = { suche = it },
+                    label = { Text(stringResource(R.string.traeger_add_member_search)) },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("add-member-search"),
+                )
+                if (villagers.isEmpty()) {
+                    Text(
+                        stringResource(R.string.traeger_add_member_loading),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                LazyColumn(
+                    modifier = Modifier.heightIn(max = 260.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    items(treffer, key = { it.userSub }) { person ->
+                        TextButton(
+                            onClick = { onPick(person) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag("add-member-${person.userSub}"),
+                        ) {
+                            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                                Icon(Icons.Filled.Group, contentDescription = null, modifier = Modifier.size(18.dp))
+                                Spacer(Modifier.width(10.dp))
+                                Text(TraegerViewModel.anzeigename(person))
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        },
+    )
+}

--- a/android/app/src/main/java/de/roessing/app/ui/TraegerViewModel.kt
+++ b/android/app/src/main/java/de/roessing/app/ui/TraegerViewModel.kt
@@ -1,0 +1,271 @@
+package de.roessing.app.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import de.roessing.app.data.BeitrittDto
+import de.roessing.app.data.MemberDto
+import de.roessing.app.data.TraegerDto
+import de.roessing.app.data.TraegerRefusedException
+import de.roessing.app.data.TraegerRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * The state of the Traeger area: which associations and working groups there
+ * are, whether I belong to them, and what is currently running.
+ *
+ * Nothing here is re-decided. Whether joining is possible, whether the
+ * deciding buttons appear at all, whether a Traeger shows up — all of that
+ * arrives answered from the server (`model.Zugriff`). What this class does is
+ * remember the answer and say what is currently being written.
+ *
+ * As everywhere in this app: **the last state stays put.** If the network
+ * drops, the list is not emptied but gets a notice — "there are no
+ * associations" would be a false statement in a dead spot.
+ */
+data class TraegerUiState(
+    val all: List<TraegerDto> = emptyList(),
+    /** My own requests across all Traeger. */
+    val mine: List<BeitrittDto> = emptyList(),
+    /** Requests per Traeger, for those who administer it. */
+    val requests: Map<Long, List<BeitrittDto>> = emptyMap(),
+    /** The village directory — the only place a person's identifier can come
+     *  from when taking somebody in without a request of their own. */
+    val villagers: List<MemberDto> = emptyList(),
+    val loading: Boolean = false,
+    /** Whether a fetch ever completed — before that the list shows a spinner
+     *  instead of "no associations yet". */
+    val everLoaded: Boolean = false,
+    /** The last fetch failed, in the backend's own words. */
+    val notice: String? = null,
+    /** A genuinely refused write — shown as a dialog, in the server's words. */
+    val error: String? = null,
+    /** Traeger currently being written to. */
+    val busy: Set<Long> = emptySet(),
+    /** Requests currently being decided. */
+    val busyRequests: Set<Long> = emptySet(),
+    /** The Traeger whose detail page is open; null = the directory. */
+    val open: Long? = null,
+) {
+    fun traeger(id: Long): TraegerDto? = all.find { it.id == id }
+
+    val openTraeger: TraegerDto? get() = open?.let { traeger(it) }
+
+    /**
+     * Whether the server offered this Traeger to this person at all. The
+     * place detail asks before it offers a way there — not as a second
+     * visibility rule, but because the server's own directory is the only
+     * honest answer to "is there anything to see behind this?".
+     */
+    fun inDirectory(id: Long): Boolean = id != 0L && traeger(id) != null
+
+    /**
+     * Associations: everything without a roof — plus anything whose roof this
+     * person cannot see, because otherwise it would drop out of the directory
+     * altogether.
+     */
+    val roots: List<TraegerDto>
+        get() {
+            val sichtbar = all.map { it.id }.toSet()
+            return all
+                .filter { it.parentId == 0L || it.parentId !in sichtbar }
+                .sortedBy { it.name.lowercase() }
+        }
+
+    /** The working groups under an association. Exactly one level — deeper
+     *  nesting does not exist (see `model.Traeger.ParentID`). */
+    fun children(of: Long): List<TraegerDto> =
+        all.filter { it.parentId == of }.sortedBy { it.name.lowercase() }
+
+    /** How many undecided requests wait for my decision, across everything I
+     *  administer. The start page shows this — somebody is waiting. */
+    val openRequestsForMe: Int get() = all.sumOf { it.offeneBeitritte }
+
+    /** My own requests that nobody has decided yet. */
+    val myPending: List<BeitrittDto> get() = mine.filter { it.status == "beantragt" }
+
+    fun openRequests(traegerId: Long): List<BeitrittDto> =
+        requests[traegerId].orEmpty().filter { it.status == "beantragt" }
+}
+
+/** One-off events of the Traeger area. */
+sealed interface TraegerEvent {
+    data class Joined(val name: String) : TraegerEvent
+    data class Granted(val name: String) : TraegerEvent
+    data class Rejected(val name: String) : TraegerEvent
+}
+
+class TraegerViewModel(private val repo: TraegerRepository) : ViewModel() {
+    private val _state = MutableStateFlow(TraegerUiState())
+    val state: StateFlow<TraegerUiState> = _state
+
+    private val _events = MutableSharedFlow<TraegerEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<TraegerEvent> = _events
+
+    fun load() {
+        viewModelScope.launch {
+            _state.update { it.copy(loading = true) }
+            runCatching { repo.list() }
+                .onSuccess { liste ->
+                    _state.update {
+                        it.copy(all = liste, loading = false, everLoaded = true, notice = null)
+                    }
+                }
+                .onFailure { fehler ->
+                    // The list stays. A dead spot is not an empty village.
+                    _state.update {
+                        it.copy(loading = false, everLoaded = true, notice = hinweis(fehler))
+                    }
+                }
+            // The own requests are a second call and must not cost the list:
+            // a directory without them is still useful.
+            runCatching { repo.myRequests() }
+                .onSuccess { eigene -> _state.update { it.copy(mine = eigene) } }
+        }
+    }
+
+    /** Opens a Traeger's detail page and fetches what belongs on it. */
+    fun open(id: Long) {
+        _state.update { it.copy(open = id) }
+        viewModelScope.launch {
+            // The directory may be older than what is shown — the way here
+            // can come from a place. A failure stays silent: the entry that
+            // is there is not wrong, only possibly a minute old.
+            runCatching { repo.detail(id) }.onSuccess { frisch ->
+                _state.update { stand ->
+                    val ohne = stand.all.filterNot { it.id == id }
+                    stand.copy(all = ohne + frisch)
+                }
+            }
+            if (_state.value.traeger(id)?.darfVerwalten == true) loadRequests(id)
+        }
+    }
+
+    fun close() = _state.update { it.copy(open = null) }
+
+    /** Fetches the requests of one Traeger. Only for those who administer it
+     *  — the server answers everyone else with 403. */
+    fun loadRequests(traegerId: Long) {
+        viewModelScope.launch { fetchRequests(traegerId) }
+    }
+
+    private suspend fun fetchRequests(traegerId: Long) {
+        runCatching { repo.requests(traegerId) }
+            .onSuccess { liste ->
+                _state.update { it.copy(requests = it.requests + (traegerId to liste)) }
+            }
+            .onFailure { fehler -> _state.update { it.copy(notice = hinweis(fehler)) } }
+    }
+
+    /** The village directory — needed to take somebody in directly. */
+    fun loadVillagers() {
+        if (_state.value.villagers.isNotEmpty()) return
+        viewModelScope.launch {
+            runCatching { repo.villagers() }
+                .onSuccess { liste -> _state.update { it.copy(villagers = liste) } }
+        }
+    }
+
+    /** "I want to join." */
+    fun join(traegerId: Long, reason: String) {
+        if (traegerId in _state.value.busy) return
+        val name = _state.value.traeger(traegerId)?.name.orEmpty()
+        viewModelScope.launch {
+            _state.update { it.copy(busy = it.busy + traegerId, error = null) }
+            val ergebnis = runCatching { repo.join(traegerId, reason.trim()) }
+            _state.update { it.copy(busy = it.busy - traegerId) }
+            ergebnis
+                .onSuccess {
+                    reload()
+                    _events.emit(TraegerEvent.Joined(name))
+                }
+                // A 409 is not a mishap: the situation does not fit, and the
+                // server says in which way. Either way the list is stale now.
+                .onFailure { fehler ->
+                    reload()
+                    _state.update { it.copy(error = fehlertext(fehler)) }
+                }
+        }
+    }
+
+    /** Grants or rejects one request. */
+    fun decide(request: BeitrittDto, status: String) {
+        if (request.id in _state.value.busyRequests) return
+        viewModelScope.launch {
+            _state.update { it.copy(busyRequests = it.busyRequests + request.id, error = null) }
+            val ergebnis = runCatching { repo.decide(request.id, status) }
+            _state.update { it.copy(busyRequests = it.busyRequests - request.id) }
+            fetchRequests(request.traegerId)
+            ergebnis
+                .onSuccess {
+                    reload()
+                    _events.emit(
+                        if (status == "erteilt") {
+                            TraegerEvent.Granted(request.anzeigename)
+                        } else {
+                            TraegerEvent.Rejected(request.anzeigename)
+                        },
+                    )
+                }
+                // Granting writes into the Rössing-ID first. Fails that, the
+                // request stays open — and saying so is the whole point.
+                .onFailure { fehler -> _state.update { it.copy(error = fehlertext(fehler)) } }
+        }
+    }
+
+    /** Takes somebody in without a request of their own — the only way into a
+     *  closed group. */
+    fun addMember(traegerId: Long, person: MemberDto) {
+        if (traegerId in _state.value.busy) return
+        viewModelScope.launch {
+            _state.update { it.copy(busy = it.busy + traegerId, error = null) }
+            val ergebnis = runCatching { repo.addMember(traegerId, person.userSub) }
+            _state.update { it.copy(busy = it.busy - traegerId) }
+            fetchRequests(traegerId)
+            ergebnis
+                .onSuccess {
+                    reload()
+                    _events.emit(TraegerEvent.Granted(anzeigename(person)))
+                }
+                .onFailure { fehler -> _state.update { it.copy(error = fehlertext(fehler)) } }
+        }
+    }
+
+    fun dismissError() = _state.update { it.copy(error = null) }
+
+    fun dismissNotice() = _state.update { it.copy(notice = null) }
+
+    private suspend fun reload() {
+        runCatching { repo.list() }
+            .onSuccess { liste -> _state.update { it.copy(all = liste, notice = null) } }
+        runCatching { repo.myRequests() }
+            .onSuccess { eigene -> _state.update { it.copy(mine = eigene) } }
+    }
+
+    companion object {
+        /** The name a villager goes by — the resolved one before the bare
+         *  identifier. */
+        fun anzeigename(person: MemberDto): String =
+            listOf(person.name, person.nickname, person.displayName)
+                .firstOrNull { it.isNotBlank() } ?: person.userSub
+
+        /**
+         * The backend's reason is more precise than anything the app could
+         * guess — it is taken over word for word. Only a connection that
+         * never reached the server gets a sentence of our own.
+         */
+        fun fehlertext(fehler: Throwable): String = when (fehler) {
+            is TraegerRefusedException -> fehler.grund
+            else -> "Das hat nicht geklappt. Besteht eine Verbindung?"
+        }
+
+        fun hinweis(fehler: Throwable): String = when (fehler) {
+            is TraegerRefusedException -> fehler.grund
+            else -> "Keine Verbindung zum Server. Es werden ggf. alte Daten angezeigt."
+        }
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -410,4 +410,61 @@
     <string name="rental_block_reason">Grund (freiwillig)</string>
     <string name="rental_block_note">Für andere sieht die Sperre aus wie jeder belegte Zeitraum — ohne Grund und ohne Namen. Eine bestehende Buchung verdrängt sie nicht.</string>
     <string name="rental_block_saving">Wird gesperrt …</string>
+
+    <!-- Träger: die Vereine und Gruppen des Dorfes. Wer was betreut, wer
+         dazugehört, und wie man mitmacht. Was jemand sehen und tun darf,
+         entscheidet der Server — hier stehen nur die Worte dafür. -->
+    <string name="area_traeger_title">Vereine und Gruppen</string>
+    <string name="area_traeger_subtitle">Wer im Dorf was betreut — und wie du mitmachst.</string>
+    <string name="traeger_title">Vereine und Gruppen</string>
+    <plurals name="traeger_open_requests_hint">
+        <item quantity="one">Eine Anfrage wartet auf dich</item>
+        <item quantity="other">%1$d Anfragen warten auf dich</item>
+    </plurals>
+    <string name="traeger_empty_title">Noch keine Vereine im Verzeichnis</string>
+    <string name="traeger_empty_text">Sobald ein Verein oder eine Gruppe zugelassen ist, steht sie hier — mit ihren Arbeitskreisen und dem Weg zum Mitmachen.</string>
+    <string name="traeger_member_badge">Du bist dabei</string>
+    <string name="traeger_closed_badge">Geschlossene Gruppe</string>
+    <string name="traeger_pending_badge">Anfrage läuft</string>
+    <string name="traeger_joinable_badge">Mitmachen möglich</string>
+    <string name="traeger_open_badge">%1$d offen</string>
+    <string name="traeger_my_requests">Deine Anfragen</string>
+    <string name="traeger_my_request_pending">Liegt beim Vorstand.</string>
+    <string name="traeger_state_heading">Wie dieser Träger steht</string>
+    <string name="traeger_status_approved">Zugelassen</string>
+    <string name="traeger_status_pending">Noch nicht zugelassen</string>
+    <string name="traeger_status_blocked">Gesperrt</string>
+    <string name="traeger_visibility_open">Offen für alle im Dorf</string>
+    <string name="traeger_visibility_closed">Geschlossene Gruppe</string>
+    <string name="traeger_parent">Arbeitskreis von %1$s</string>
+    <string name="traeger_working_groups">Arbeitskreise</string>
+    <string name="traeger_working_groups_hint">Jeder Arbeitskreis entscheidet selbst, wer bei ihm mitmacht — eine Mitgliedschaft im Verein ist keine im Arbeitskreis.</string>
+    <string name="traeger_places">Orte dieses Trägers</string>
+    <string name="traeger_places_hint">Was hier ansteht, findest du auch im Bereich Mithelfen.</string>
+    <string name="traeger_not_found_title">Diesen Träger gibt es nicht</string>
+    <string name="traeger_not_found_text">Vielleicht wurde er gesperrt — oder er steht nicht für dich im Verzeichnis.</string>
+
+    <!-- Mitmachen sagen -->
+    <string name="traeger_join_heading">Mitmachen</string>
+    <string name="traeger_join">Ich will mitmachen</string>
+    <string name="traeger_join_intro">Schreib dem Vorstand von %1$s kurz, warum du dabei sein möchtest. Ein Satz reicht — er ist freiwillig.</string>
+    <string name="traeger_join_placeholder">Zum Beispiel: Ich wohne neben dem Beet und würde gern mitjäten.</string>
+    <string name="traeger_join_send">Anfrage abschicken</string>
+    <string name="traeger_joined">Deine Anfrage ist raus. Der Vorstand entscheidet sie.</string>
+    <string name="traeger_i_am_member">Du gehörst dazu.</string>
+    <string name="traeger_my_request_state">Deine Anfrage liegt beim Vorstand.</string>
+
+    <!-- Anträge entscheiden (Vorstand) -->
+    <string name="traeger_requests">Anfragen</string>
+    <string name="traeger_requests_empty">Gerade wartet niemand.</string>
+    <string name="traeger_requests_hint">Eine Freigabe trägt die Mitgliedschaft in die Rössing-ID ein. Klappt das nicht, bleibt die Anfrage offen — und es steht dabei, warum.</string>
+    <string name="traeger_grant">Aufnehmen</string>
+    <string name="traeger_reject">Ablehnen</string>
+    <string name="traeger_granted">%1$s gehört jetzt dazu.</string>
+    <string name="traeger_rejected">Abgelehnt. %1$s bleibt außen vor.</string>
+    <string name="traeger_add_member">Jemanden direkt aufnehmen</string>
+    <string name="traeger_add_member_search">Name suchen</string>
+    <string name="traeger_add_member_hint">Aufgenommen wird sofort: Die Mitgliedschaft wird in die Rössing-ID geschrieben, nicht bloß hier vermerkt.</string>
+    <string name="traeger_add_member_loading">Die Dorfbewohner werden geladen …</string>
+    <string name="traeger_failed_title">Das hat nicht geklappt</string>
 </resources>

--- a/android/app/src/test/java/de/roessing/app/TraegerAmOrtTest.kt
+++ b/android/app/src/test/java/de/roessing/app/TraegerAmOrtTest.kt
@@ -34,5 +34,20 @@ class TraegerAmOrtTest {
             """{"id":1,"name":"Unter den Eichen","lat":52.18,"lon":9.81}""",
         )
         assertTrue(ort.traegerName.isEmpty())
+        assertEquals(0L, ort.traegerId)
+    }
+
+    /**
+     * Die Kennung ist der Weg von hier zum Träger. Angeboten wird er
+     * trotzdem nicht an dieser Zahl, sondern am Verzeichnis des Servers —
+     * siehe TraegerViewModelTest.
+     */
+    @Test
+    fun `die Kennung des Traegers kommt mit`() {
+        val ort = json.decodeFromString<PlaceDto>(
+            """{"id":3,"name":"Beet vor dem Dorfgemeinschaftshaus","lat":52.18,"lon":9.81,
+                "traegerName":"AK 2 Umwelt und Natur","traegerId":2}""",
+        )
+        assertEquals(2L, ort.traegerId)
     }
 }

--- a/android/app/src/test/java/de/roessing/app/TraegerViewModelTest.kt
+++ b/android/app/src/test/java/de/roessing/app/TraegerViewModelTest.kt
@@ -1,0 +1,311 @@
+package de.roessing.app
+
+import de.roessing.app.data.BeitrittDto
+import de.roessing.app.data.MemberDto
+import de.roessing.app.data.TraegerDto
+import de.roessing.app.data.TraegerRefusedException
+import de.roessing.app.data.TraegerRepository
+import de.roessing.app.ui.TraegerViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Fake des Verzeichnisses: merkt sich, was geschickt wurde, und kann sowohl
+ * eine begründete Absage des Servers als auch einen Netzfehler nachstellen.
+ */
+private class FakeTraegerRepo(var liste: List<TraegerDto> = emptyList()) : TraegerRepository {
+    var eigene: List<BeitrittDto> = emptyList()
+    var antraege: List<BeitrittDto> = emptyList()
+    var dorf: List<MemberDto> = emptyList()
+
+    var ladeFehler: Throwable? = null
+    var absage: String? = null
+    var fehler: Throwable? = null
+
+    val beitritte = mutableListOf<Pair<Long, String>>()
+    val entscheidungen = mutableListOf<Pair<Long, String>>()
+    val aufnahmen = mutableListOf<Pair<Long, String>>()
+
+    override suspend fun list(): List<TraegerDto> {
+        ladeFehler?.let { throw it }
+        return liste
+    }
+
+    override suspend fun detail(id: Long): TraegerDto =
+        liste.find { it.id == id } ?: throw IOException("unbekannt")
+
+    override suspend fun join(id: Long, reason: String): BeitrittDto {
+        beitritte += id to reason
+        absage?.let { throw TraegerRefusedException(it) }
+        fehler?.let { throw it }
+        return BeitrittDto(id = 1, traegerId = id, status = "beantragt", begruendung = reason)
+    }
+
+    override suspend fun requests(traegerId: Long): List<BeitrittDto> = antraege
+
+    override suspend fun myRequests(): List<BeitrittDto> = eigene
+
+    override suspend fun decide(requestId: Long, status: String): BeitrittDto {
+        entscheidungen += requestId to status
+        absage?.let { throw TraegerRefusedException(it) }
+        fehler?.let { throw it }
+        return BeitrittDto(id = requestId, status = status)
+    }
+
+    override suspend fun addMember(traegerId: Long, userSub: String): BeitrittDto {
+        aufnahmen += traegerId to userSub
+        absage?.let { throw TraegerRefusedException(it) }
+        fehler?.let { throw it }
+        return BeitrittDto(traegerId = traegerId, userSub = userSub, status = "erteilt")
+    }
+
+    override suspend fun villagers(): List<MemberDto> = dorf
+}
+
+private fun traeger(
+    id: Long,
+    name: String,
+    parent: Long = 0,
+    mitglied: Boolean = false,
+    verwaltet: Boolean = false,
+    moeglich: Boolean = true,
+    hindernis: String = "",
+    antrag: String = "",
+    offen: Int = 0,
+    sichtbarkeit: String = "offen",
+) = TraegerDto(
+    id = id, name = name, status = "zugelassen", sichtbarkeit = sichtbarkeit,
+    parentId = parent, istMitglied = mitglied, darfVerwalten = verwaltet,
+    beitrittMoeglich = moeglich, beitrittHindernis = hindernis,
+    beitrittStatus = antrag, offeneBeitritte = offen,
+)
+
+/**
+ * Was das Verzeichnis der Vereine und Gruppen versprechen muss.
+ *
+ * Hier wird nirgends nachgerechnet, wer beitreten darf oder wer einen Träger
+ * sehen darf — das steht in `model.Zugriff` im Backend, und die Antwort kommt
+ * fertig mit. Geprüft wird, dass die App sie **übernimmt**, samt Wortlaut,
+ * wenn etwas schiefgeht.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TraegerViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun vorher() = Dispatchers.setMain(dispatcher)
+
+    @After fun nachher() = Dispatchers.resetMain()
+
+    @Test
+    fun `Arbeitskreise stehen unter ihrem Verein`() = runTest(dispatcher) {
+        val repo = FakeTraegerRepo(
+            listOf(
+                traeger(1, "Dorfpflege Rössing e.V."),
+                traeger(2, "AK 2 Umwelt und Natur", parent = 1),
+                traeger(3, "AK 1 Bauen", parent = 1),
+            ),
+        )
+        val vm = TraegerViewModel(repo)
+        vm.load()
+        advanceUntilIdle()
+
+        assertEquals(listOf(1L), vm.state.value.roots.map { it.id })
+        assertEquals(
+            listOf("AK 1 Bauen", "AK 2 Umwelt und Natur"),
+            vm.state.value.children(of = 1).map { it.name },
+        )
+        assertTrue("Genau eine Ebene", vm.state.value.children(of = 2).isEmpty())
+    }
+
+    /**
+     * Ein Arbeitskreis kann sichtbar sein, sein Verein aber nicht — dann
+     * verschwände er aus dem Verzeichnis, hinge er nur unter seinem Dach.
+     */
+    @Test
+    fun `ein Arbeitskreis ohne sichtbares Dach steht oben drin`() = runTest(dispatcher) {
+        val repo = FakeTraegerRepo(listOf(traeger(2, "AK 2 Umwelt und Natur", parent = 99)))
+        val vm = TraegerViewModel(repo)
+        vm.load()
+        advanceUntilIdle()
+
+        assertEquals(listOf(2L), vm.state.value.roots.map { it.id })
+    }
+
+    /**
+     * Das Verzeichnis des Servers ist die einzige Auskunft darüber, ob es
+     * hinter einem Trägernamen etwas zu sehen gibt. Eine eigene Regel daneben
+     * wäre die Sichtbarkeitsprüfung zum zweiten Mal.
+     */
+    @Test
+    fun `ein Weg zum Traeger gibt es nur wenn er im Verzeichnis steht`() = runTest(dispatcher) {
+        val repo = FakeTraegerRepo(listOf(traeger(1, "Dorfpflege Rössing e.V.")))
+        val vm = TraegerViewModel(repo)
+        vm.load()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.inDirectory(1))
+        assertFalse("Eine geschlossene Gruppe steht nicht drin", vm.state.value.inDirectory(5))
+        assertFalse("Ein Ort ohne Träger führt nirgendwohin", vm.state.value.inDirectory(0))
+    }
+
+    @Test
+    fun `Mitmachen schickt die Begruendung ohne Leerraum`() = runTest(dispatcher) {
+        val repo = FakeTraegerRepo(listOf(traeger(1, "Dorfpflege Rössing e.V.")))
+        val vm = TraegerViewModel(repo)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.join(1, "  Ich wohne nebenan.  ")
+        advanceUntilIdle()
+
+        assertEquals(listOf(1L to "Ich wohne nebenan."), repo.beitritte)
+        assertNull(vm.state.value.error)
+    }
+
+    /**
+     * Ein 409 ist keine Panne: Die Lage passt nicht, und der Server sagt in
+     * welcher Weise. Genau dieser Satz gehört auf den Schirm.
+     */
+    @Test
+    fun `eine Absage zeigt den Satz des Servers`() = runTest(dispatcher) {
+        val repo = FakeTraegerRepo(listOf(traeger(1, "Dorfpflege Rössing e.V.")))
+        repo.absage = "Du gehörst schon dazu."
+        val vm = TraegerViewModel(repo)
+        vm.load()
+        advanceUntilIdle()
+
+        vm.join(1, "")
+        advanceUntilIdle()
+
+        assertEquals("Du gehörst schon dazu.", vm.state.value.error)
+    }
+
+    /**
+     * Der wichtigste Fall überhaupt: Die Freigabe schreibt zuerst in die
+     * Rössing-ID. Klappt das nicht (502/503), bleibt der Antrag offen — und
+     * die App darf auf keinen Fall Erfolg melden, während die Tür zu bleibt.
+     */
+    @Test
+    fun `eine gescheiterte Freigabe meldet keinen Erfolg`() = runTest(dispatcher) {
+        val satz = "Die Mitgliedschaft konnte in der Rössing-ID nicht eingetragen werden — " +
+            "der Antrag bleibt deshalb offen. Bitte gleich noch einmal versuchen."
+        val repo = FakeTraegerRepo(listOf(traeger(1, "Dorfpflege", verwaltet = true, offen = 1)))
+        val antrag = BeitrittDto(
+            id = 4, traegerId = 1, userName = "Anna Beispiel", status = "beantragt",
+        )
+        repo.antraege = listOf(antrag)
+        repo.absage = satz
+        val vm = TraegerViewModel(repo)
+        vm.load()
+        vm.loadRequests(1)
+        advanceUntilIdle()
+
+        vm.decide(antrag, "erteilt")
+        advanceUntilIdle()
+
+        assertEquals("Der Wortlaut des Servers, nicht ein eigener", satz, vm.state.value.error)
+        assertEquals("Der Antrag bleibt stehen", 1, vm.state.value.openRequests(1).size)
+    }
+
+    @Test
+    fun `direkt aufnehmen schickt die Kennung der Person`() = runTest(dispatcher) {
+        val repo = FakeTraegerRepo(
+            listOf(
+                traeger(
+                    1, "Der stille Kreis", verwaltet = true, moeglich = false,
+                    sichtbarkeit = "geschlossen",
+                ),
+            ),
+        )
+        repo.dorf = listOf(MemberDto(userSub = "anna-sub", name = "Anna Beispiel"))
+        val vm = TraegerViewModel(repo)
+        vm.load()
+        vm.loadVillagers()
+        advanceUntilIdle()
+
+        vm.addMember(1, vm.state.value.villagers.first())
+        advanceUntilIdle()
+
+        assertEquals(listOf(1L to "anna-sub"), repo.aufnahmen)
+        assertNull(vm.state.value.error)
+    }
+
+    /** Eine leere Liste im Funkloch wäre eine Falschaussage über das Dorf. */
+    @Test
+    fun `ein Ausfall leert das Verzeichnis nicht`() = runTest(dispatcher) {
+        val repo = FakeTraegerRepo(listOf(traeger(1, "Dorfpflege Rössing e.V.")))
+        val vm = TraegerViewModel(repo)
+        vm.load()
+        advanceUntilIdle()
+        assertEquals(1, vm.state.value.all.size)
+
+        repo.ladeFehler = IOException("weg")
+        vm.load()
+        advanceUntilIdle()
+
+        assertEquals(1, vm.state.value.all.size)
+        assertTrue(vm.state.value.notice!!.isNotBlank())
+    }
+
+    @Test
+    fun `offene Anfragen werden ueber alle Traeger gezaehlt`() = runTest(dispatcher) {
+        val repo = FakeTraegerRepo(
+            listOf(
+                traeger(1, "Dorfpflege", verwaltet = true, offen = 2),
+                traeger(2, "AK 2", parent = 1, verwaltet = true, offen = 1),
+                traeger(3, "Feuerwehr"),
+            ),
+        )
+        val vm = TraegerViewModel(repo)
+        vm.load()
+        advanceUntilIdle()
+
+        assertEquals(3, vm.state.value.openRequestsForMe)
+    }
+
+    @Test
+    fun `eigene offene Anfragen stehen fuer sich`() = runTest(dispatcher) {
+        val repo = FakeTraegerRepo(listOf(traeger(1, "Dorfpflege")))
+        repo.eigene = listOf(
+            BeitrittDto(id = 1, traegerId = 1, traegerName = "Dorfpflege", status = "beantragt"),
+            BeitrittDto(id = 2, traegerId = 2, traegerName = "Feuerwehr", status = "abgelehnt"),
+        )
+        val vm = TraegerViewModel(repo)
+        vm.load()
+        advanceUntilIdle()
+
+        assertEquals(listOf(1L), vm.state.value.myPending.map { it.id })
+    }
+
+    /**
+     * Ein Netzfehler ist keine Antwort des Servers — er darf nicht so
+     * aussehen, als hätte jemand etwas entschieden.
+     */
+    @Test
+    fun `ohne Verbindung steht ein eigener Satz da`() {
+        assertEquals(
+            "Das hat nicht geklappt. Besteht eine Verbindung?",
+            TraegerViewModel.fehlertext(IOException("weg")),
+        )
+        assertEquals("Du gehörst schon dazu.", TraegerViewModel.fehlertext(TraegerRefusedException("Du gehörst schon dazu.")))
+    }
+
+    @Test
+    fun `der Anzeigename faellt auf die Kennung zurueck`() {
+        assertEquals("Anna", TraegerViewModel.anzeigename(MemberDto(userSub = "a", name = "Anna")))
+        assertEquals("a", TraegerViewModel.anzeigename(MemberDto(userSub = "a")))
+    }
+}

--- a/ios/Dorf/Bereiche/Mithelfen/OrtDetailView.swift
+++ b/ios/Dorf/Bereiche/Mithelfen/OrtDetailView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Ein Ort mit allem, was dort ansteht: Beschreibung, Aufgaben mit Ampel,
 /// Plan bzw. Termin, letzte Erledigung, Historie — und der Knopf zum Melden.
 struct OrtDetailView: View {
+    @EnvironmentObject private var umgebung: AppUmgebung
     @ObservedObject var modell: OrteModell
     let ortId: Int64
     let meinSub: String?
@@ -67,11 +68,26 @@ struct OrtDetailView: View {
                     // außen sehen, aber nur mit Einweisung anfassen darf, ist
                     // genau das die wichtigste Angabe.
                     if !ort.traegerName.isEmpty {
-                        Label(ort.traegerName, systemImage: "person.2")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                        // Von hier führt ein Weg zu ihm — aber nur, wenn der
+                        // Server ihn dieser Person überhaupt ins Verzeichnis
+                        // gestellt hat. Sonst bliebe der Weg eine Sackgasse:
+                        // Eine geschlossene Gruppe heißt hier „Eine Gruppe
+                        // aus dem Dorf", und ihre Seite gibt es für
+                        // Außenstehende nicht.
+                        if umgebung.traeger.inDirectory(ort.traegerId) {
+                            NavigationLink(value: Ziel.traegerDetail(ort.traegerId)) {
+                                Label(ort.traegerName, systemImage: "person.2")
+                                    .font(.subheadline)
+                            }
                             .accessibilityLabel("Betreut von \(ort.traegerName)")
                             .accessibilityIdentifier("ort-traeger")
+                        } else {
+                            Label(ort.traegerName, systemImage: "person.2")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .accessibilityLabel("Betreut von \(ort.traegerName)")
+                                .accessibilityIdentifier("ort-traeger")
+                        }
                     }
                     if !ort.description.isEmpty {
                         Text(ort.description)

--- a/ios/Dorf/Bereiche/Traeger/TraegerDetailView.swift
+++ b/ios/Dorf/Bereiche/Traeger/TraegerDetailView.swift
@@ -1,0 +1,429 @@
+import SwiftUI
+
+/// Ein Träger mit allem, was zu ihm gehört: wer er ist, welche Arbeitskreise
+/// unter ihm arbeiten, welche Orte er betreut — und der Weg zum Mitmachen.
+///
+/// Wer im Vorstand ist, entscheidet die Anfragen hier, ohne die App zu
+/// verlassen. Ob er das darf, sagt der Server (`darfVerwalten`); die App
+/// prüft es nicht nach.
+struct TraegerDetailView: View {
+    @EnvironmentObject private var umgebung: AppUmgebung
+    let traegerId: Int64
+
+    var body: some View {
+        TraegerDetailInhalt(modell: umgebung.traeger, orte: umgebung.orte, traegerId: traegerId)
+            .navigationBarTitleDisplayMode(.inline)
+            .task {
+                await umgebung.traeger.load()
+                await umgebung.traeger.refresh(traeger: traegerId)
+                await umgebung.orte.laden()
+            }
+    }
+}
+
+struct TraegerDetailInhalt: View {
+    @ObservedObject var modell: TraegerModel
+    @ObservedObject var orte: OrteModell
+    let traegerId: Int64
+
+    /// Der Text zum Mitmachen — steht in einem eigenen Blatt, damit ein
+    /// Fehlschlag ihn nicht kostet.
+    @State private var mitmachenOffen = false
+    @State private var begruendung = ""
+    /// Wen der Vorstand gerade direkt aufnehmen will.
+    @State private var aufnahmeOffen = false
+
+    private var traeger: Traeger? { modell.traeger(id: traegerId) }
+
+    var body: some View {
+        Group {
+            if let traeger {
+                inhalt(traeger)
+            } else if modell.loading && !modell.everLoaded {
+                ProgressView().controlSize(.large)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                Hinweistafel(
+                    "Diesen Träger gibt es nicht",
+                    symbol: "person.2.slash",
+                    beschreibung: "Vielleicht wurde er gesperrt — oder er steht nicht "
+                        + "für dich im Verzeichnis."
+                )
+            }
+        }
+        .navigationTitle(traeger?.name ?? "Träger")
+        .alert("Das hat nicht geklappt", isPresented: fehlerOffen) {
+            Button("Ok", role: .cancel) { modell.dismissError() }
+                .accessibilityIdentifier("traeger-error-ok")
+        } message: {
+            Text(modell.error ?? "")
+        }
+        .sheet(isPresented: $mitmachenOffen) {
+            if let traeger {
+                MitmachenBlatt(modell: modell, traeger: traeger, begruendung: $begruendung) {
+                    mitmachenOffen = false
+                }
+            }
+        }
+        .sheet(isPresented: $aufnahmeOffen) {
+            if let traeger {
+                AufnahmeBlatt(modell: modell, traeger: traeger) { aufnahmeOffen = false }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func inhalt(_ traeger: Traeger) -> some View {
+        List {
+            if let dank = modell.confirmation {
+                Hinweisstreifen(
+                    text: dank, symbol: "checkmark.circle.fill", farbe: Ampel.green.farbe,
+                    kennung: "traeger-confirmation"
+                )
+                .listRowInsets(EdgeInsets())
+                .onTapGesture { modell.dismissConfirmation() }
+            }
+
+            kopf(traeger)
+            mitmachen(traeger)
+            arbeitskreise(traeger)
+            orteAbschnitt(traeger)
+            anfragen(traeger)
+        }
+        .listStyle(.insetGrouped)
+        .refreshable {
+            await modell.load()
+            if traeger.darfVerwalten { await modell.loadRequests(traeger: traeger.id) }
+        }
+        .accessibilityIdentifier("traeger-detail")
+        .task(id: traeger.darfVerwalten) {
+            guard traeger.darfVerwalten else { return }
+            await modell.loadRequests(traeger: traeger.id)
+        }
+    }
+
+    // MARK: Kopf
+
+    @ViewBuilder
+    private func kopf(_ traeger: Traeger) -> some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(traeger.name)
+                    .font(.title2.bold())
+                    .accessibilityAddTraits(.isHeader)
+                if !traeger.beschreibung.isEmpty {
+                    Text(traeger.beschreibung)
+                        .font(.subheadline)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if let dach = dachTraeger(traeger) {
+                    NavigationLink(value: Ziel.traegerDetail(dach.id)) {
+                        Label("Arbeitskreis von \(dach.name)", systemImage: "arrow.turn.left.up")
+                            .font(.footnote)
+                    }
+                    .accessibilityIdentifier("traeger-parent")
+                }
+                TraegerAbzeichen(traeger: traeger)
+            }
+            .padding(.vertical, 2)
+            .accessibilityIdentifier("traeger-head")
+        }
+
+        Section("Wie dieser Träger steht") {
+            Label(TraegerTexte.status(traeger.status), systemImage: "checkmark.shield")
+                .font(.subheadline)
+            Label(TraegerTexte.sichtbarkeit(traeger.sichtbarkeit),
+                  systemImage: traeger.istGeschlossen ? "lock.fill" : "globe")
+                .font(.subheadline)
+        }
+    }
+
+    private func dachTraeger(_ traeger: Traeger) -> Traeger? {
+        guard traeger.parentId != 0 else { return nil }
+        return modell.traeger(id: traeger.parentId)
+    }
+
+    // MARK: Mitmachen
+
+    @ViewBuilder
+    private func mitmachen(_ traeger: Traeger) -> some View {
+        Section {
+            if traeger.istMitglied {
+                Label("Du gehörst dazu.", systemImage: "checkmark.seal.fill")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Ampel.green.farbe)
+                    .accessibilityIdentifier("traeger-i-am-member")
+            } else if let stand = TraegerTexte.beitrittStatus(traeger.beitrittStatus),
+                      traeger.beitrittStatus == "beantragt" {
+                Label(stand, systemImage: "hourglass")
+                    .font(.subheadline)
+                    .accessibilityIdentifier("traeger-my-request")
+            } else if traeger.beitrittMoeglich {
+                Button {
+                    begruendung = ""
+                    mitmachenOffen = true
+                } label: {
+                    Label("Ich will mitmachen", systemImage: "hand.raised.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(modell.isBusy(traeger: traeger.id))
+                .accessibilityIdentifier("traeger-join")
+            } else if !traeger.beitrittHindernis.isEmpty {
+                // Der Satz kommt vom Server. Er weiß, warum es nicht geht —
+                // die App wüsste es nur ungefähr.
+                Label(traeger.beitrittHindernis, systemImage: "info.circle")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("traeger-obstacle")
+            }
+        } header: {
+            Text("Mitmachen")
+        }
+    }
+
+    // MARK: Arbeitskreise
+
+    @ViewBuilder
+    private func arbeitskreise(_ traeger: Traeger) -> some View {
+        let kinder = modell.children(of: traeger.id)
+        if !kinder.isEmpty {
+            Section {
+                ForEach(kinder) { kind in
+                    TraegerZeile(traeger: kind, unterTraeger: true)
+                }
+            } header: {
+                Text("Arbeitskreise")
+            } footer: {
+                Text("Jeder Arbeitskreis entscheidet selbst, wer bei ihm mitmacht — "
+                    + "eine Mitgliedschaft im Verein ist keine im Arbeitskreis.")
+            }
+        }
+    }
+
+    // MARK: Orte
+
+    /// Der Weg zurück zu dem, was dieser Träger betreut. Die Orte kommen aus
+    /// dem gemeinsamen Ortsmodell — dieselbe Liste, die „Mithelfen" zeigt,
+    /// und damit auch dieselbe Sichtbarkeit.
+    @ViewBuilder
+    private func orteAbschnitt(_ traeger: Traeger) -> some View {
+        let seine = orte.orte.filter { $0.traegerId == traeger.id }
+        if !seine.isEmpty {
+            Section {
+                ForEach(seine) { ort in
+                    NavigationLink(value: Ziel.ort(ort.id)) {
+                        HStack(spacing: 12) {
+                            Ampelpunkt(ampel: ort.ampel)
+                            Text(ort.name).font(.subheadline)
+                        }
+                    }
+                    .accessibilityIdentifier("traeger-place-\(ort.id)")
+                }
+            } header: {
+                Text("Orte dieses Trägers")
+            } footer: {
+                Text("Was hier ansteht, findest du auch im Bereich Mithelfen.")
+            }
+        }
+    }
+
+    // MARK: Anfragen entscheiden
+
+    @ViewBuilder
+    private func anfragen(_ traeger: Traeger) -> some View {
+        if traeger.darfVerwalten {
+            let liste = modell.requests[traeger.id] ?? []
+            let offene = liste.filter { $0.status == "beantragt" }
+            Section {
+                if offene.isEmpty {
+                    Text("Gerade wartet niemand.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("traeger-requests-empty")
+                }
+                ForEach(offene) { antrag in
+                    AntragZeile(modell: modell, antrag: antrag)
+                }
+                Button {
+                    aufnahmeOffen = true
+                } label: {
+                    Label("Jemanden direkt aufnehmen", systemImage: "person.badge.plus")
+                }
+                .accessibilityIdentifier("traeger-add-member")
+            } header: {
+                Text("Anfragen")
+            } footer: {
+                Text("Eine Freigabe trägt die Mitgliedschaft in die Rössing-ID ein. "
+                    + "Klappt das nicht, bleibt die Anfrage offen — und es steht dabei, warum.")
+            }
+        }
+    }
+
+    private var fehlerOffen: Binding<Bool> {
+        Binding(get: { modell.error != nil }, set: { if !$0 { modell.dismissError() } })
+    }
+}
+
+/// Eine offene Anfrage mit den beiden Knöpfen.
+struct AntragZeile: View {
+    @ObservedObject var modell: TraegerModel
+    let antrag: Beitritt
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(antrag.anzeigename).font(.headline)
+            if !antrag.begruendung.isEmpty {
+                Text(antrag.begruendung)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            HStack(spacing: 12) {
+                Button("Aufnehmen") {
+                    Task { await modell.decide(request: antrag, status: "erteilt") }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(modell.isBusy(request: antrag.id))
+                .accessibilityIdentifier("request-grant-\(antrag.id)")
+
+                Button("Ablehnen", role: .destructive) {
+                    Task { await modell.decide(request: antrag, status: "abgelehnt") }
+                }
+                .buttonStyle(.bordered)
+                .disabled(modell.isBusy(request: antrag.id))
+                .accessibilityIdentifier("request-reject-\(antrag.id)")
+
+                if modell.isBusy(request: antrag.id) {
+                    ProgressView().controlSize(.small)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+        .accessibilityIdentifier("request-\(antrag.id)")
+    }
+}
+
+/// „Ich will mitmachen" — mit einem Satz dazu, warum.
+struct MitmachenBlatt: View {
+    @ObservedObject var modell: TraegerModel
+    let traeger: Traeger
+    @Binding var begruendung: String
+    var schliessen: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Text("Schreib dem Vorstand von \(traeger.name) kurz, warum du dabei sein "
+                        + "möchtest. Ein Satz reicht — er ist freiwillig.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Section {
+                    TextField("Zum Beispiel: Ich wohne neben dem Beet und würde gern mitjäten.",
+                              text: $begruendung, axis: .vertical)
+                        .lineLimit(3 ... 8)
+                        .accessibilityIdentifier("join-reason")
+                }
+                Section {
+                    Button {
+                        Task {
+                            if await modell.join(traeger: traeger.id, reason: begruendung) {
+                                schliessen()
+                            }
+                        }
+                    } label: {
+                        HStack(spacing: 12) {
+                            if modell.isBusy(traeger: traeger.id) {
+                                ProgressView()
+                            } else {
+                                Image(systemName: "paperplane.fill")
+                            }
+                            Text("Anfrage abschicken")
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 4)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(modell.isBusy(traeger: traeger.id))
+                    .accessibilityIdentifier("join-send")
+                }
+                .listRowBackground(Color.clear)
+            }
+            .navigationTitle("Mitmachen")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Abbrechen") { schliessen() }
+                }
+            }
+        }
+    }
+}
+
+/// Jemanden ohne Antrag aufnehmen — bei einer geschlossenen Gruppe der
+/// einzige Weg hinein.
+struct AufnahmeBlatt: View {
+    @ObservedObject var modell: TraegerModel
+    let traeger: Traeger
+    var schliessen: () -> Void
+
+    @State private var suche = ""
+
+    private var treffer: [Dorfbewohner] {
+        let begriff = suche.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !begriff.isEmpty else { return modell.villagers }
+        return modell.villagers.filter {
+            TraegerModel.name(of: $0).lowercased().contains(begriff)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    TextField("Name suchen", text: $suche)
+                        .textInputAutocapitalization(.words)
+                        .autocorrectionDisabled()
+                        .accessibilityIdentifier("add-member-search")
+                } footer: {
+                    Text("Aufgenommen wird sofort: Die Mitgliedschaft wird in die "
+                        + "Rössing-ID geschrieben, nicht bloß hier vermerkt.")
+                }
+                Section {
+                    if modell.villagers.isEmpty {
+                        Text("Die Dorfbewohner werden geladen …")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    ForEach(treffer) { person in
+                        Button {
+                            Task {
+                                await modell.addMember(traeger: traeger.id, person: person)
+                                schliessen()
+                            }
+                        } label: {
+                            HStack {
+                                Text(TraegerModel.name(of: person))
+                                Spacer()
+                                Image(systemName: "person.badge.plus").foregroundStyle(.tint)
+                            }
+                        }
+                        .disabled(modell.isBusy(traeger: traeger.id))
+                        .accessibilityIdentifier("add-member-\(person.userSub)")
+                    }
+                }
+            }
+            .navigationTitle("Aufnehmen")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Abbrechen") { schliessen() }
+                }
+            }
+            .task { await modell.loadVillagers() }
+        }
+    }
+}

--- a/ios/Dorf/Bereiche/Traeger/TraegerListView.swift
+++ b/ios/Dorf/Bereiche/Traeger/TraegerListView.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+
+/// Das Verzeichnis: Welche Vereine und Gruppen es im Dorf gibt, welche
+/// Arbeitskreise zu ihnen gehören — und ob ich selbst dabei bin.
+///
+/// Die Liste ist die des Servers. Eine geschlossene Gruppe steht nur für ihre
+/// Mitglieder darin; hier wird nichts gefiltert, sonst gäbe es die
+/// Sichtbarkeitsregel zweimal.
+struct TraegerListView: View {
+    @EnvironmentObject private var umgebung: AppUmgebung
+
+    var body: some View {
+        TraegerListInhalt(modell: umgebung.traeger)
+            .navigationTitle("Vereine und Gruppen")
+            .navigationBarTitleDisplayMode(.inline)
+            .task { await umgebung.traeger.load() }
+    }
+}
+
+/// Die Liste, sobald das Modell steht.
+struct TraegerListInhalt: View {
+    @ObservedObject var modell: TraegerModel
+
+    var body: some View {
+        List {
+            if let hinweis = modell.notice {
+                Hinweisstreifen(
+                    text: hinweis, symbol: "wifi.slash", farbe: .orange,
+                    kennung: "traeger-notice"
+                )
+                .listRowInsets(EdgeInsets())
+                .onTapGesture { modell.dismissNotice() }
+            }
+            if let dank = modell.confirmation {
+                Hinweisstreifen(
+                    text: dank, symbol: "checkmark.circle.fill", farbe: Ampel.green.farbe,
+                    kennung: "traeger-confirmation"
+                )
+                .listRowInsets(EdgeInsets())
+                .onTapGesture { modell.dismissConfirmation() }
+            }
+
+            offeneAnfragen
+
+            if modell.roots.isEmpty {
+                leerzeile
+            }
+
+            ForEach(modell.roots) { verein in
+                Section {
+                    TraegerZeile(traeger: verein)
+                    ForEach(modell.children(of: verein.id)) { arbeitskreis in
+                        TraegerZeile(traeger: arbeitskreis, unterTraeger: true)
+                    }
+                } footer: {
+                    if !modell.children(of: verein.id).isEmpty {
+                        Text("Arbeitskreise arbeiten unter dem Verein, entscheiden aber selbst, "
+                            + "wer bei ihnen mitmacht.")
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .refreshable { await modell.load() }
+        .accessibilityIdentifier("traeger-list")
+        .alert("Das hat nicht geklappt", isPresented: fehlerOffen) {
+            Button("Ok", role: .cancel) { modell.dismissError() }
+                .accessibilityIdentifier("traeger-error-ok")
+        } message: {
+            Text(modell.error ?? "")
+        }
+    }
+
+    /// Was ich selbst angefragt habe und noch nicht entschieden ist. Steht
+    /// oben: Wer gefragt hat, sucht als Erstes danach.
+    @ViewBuilder
+    private var offeneAnfragen: some View {
+        let offene = modell.mine.filter { $0.status == "beantragt" }
+        if !offene.isEmpty {
+            Section("Deine Anfragen") {
+                ForEach(offene) { antrag in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(antrag.traegerName.isEmpty ? "Ein Träger" : antrag.traegerName)
+                            .font(.subheadline.weight(.medium))
+                        Text("Liegt beim Vorstand.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityIdentifier("my-request-\(antrag.id)")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var leerzeile: some View {
+        if modell.loading && !modell.everLoaded {
+            HStack {
+                Spacer()
+                ProgressView()
+                Spacer()
+            }
+            .listRowSeparator(.hidden)
+        } else {
+            VStack(alignment: .leading, spacing: 6) {
+                Label("Noch keine Vereine im Verzeichnis", systemImage: "person.2.slash")
+                    .font(.headline)
+                Text("Sobald ein Verein oder eine Gruppe zugelassen ist, steht sie hier — "
+                    + "mit ihren Arbeitskreisen und dem Weg zum Mitmachen.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.vertical, 6)
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier("traeger-empty")
+        }
+    }
+
+    private var fehlerOffen: Binding<Bool> {
+        Binding(get: { modell.error != nil }, set: { if !$0 { modell.dismissError() } })
+    }
+}
+
+/// Eine Zeile des Verzeichnisses.
+struct TraegerZeile: View {
+    let traeger: Traeger
+    /// Arbeitskreise stehen eingerückt unter ihrem Verein.
+    var unterTraeger = false
+
+    var body: some View {
+        NavigationLink(value: Ziel.traegerDetail(traeger.id)) {
+            HStack(spacing: 12) {
+                Image(systemName: unterTraeger ? "arrow.turn.down.right" : "person.2.fill")
+                    .font(unterTraeger ? .footnote : .title3)
+                    .frame(width: 24)
+                    .foregroundStyle(unterTraeger ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tint))
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(traeger.name).font(unterTraeger ? .subheadline.weight(.medium) : .headline)
+                    if !traeger.beschreibung.isEmpty {
+                        Text(traeger.beschreibung)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                    TraegerAbzeichen(traeger: traeger)
+                }
+            }
+            .padding(.vertical, 2)
+            .padding(.leading, unterTraeger ? 12 : 0)
+        }
+        .accessibilityIdentifier("traeger-\(traeger.id)")
+    }
+}
+
+/// Die kurzen Marken unter dem Namen: dabei, offen, geschlossen, und wie
+/// viele Anfragen auf eine Entscheidung warten.
+struct TraegerAbzeichen: View {
+    let traeger: Traeger
+
+    var body: some View {
+        HStack(spacing: 10) {
+            if traeger.istMitglied {
+                Label("Du bist dabei", systemImage: "checkmark.seal.fill")
+                    .foregroundStyle(Ampel.green.farbe)
+                    .accessibilityIdentifier("traeger-member-\(traeger.id)")
+            } else if traeger.istGeschlossen {
+                Label("Geschlossene Gruppe", systemImage: "lock.fill")
+                    .foregroundStyle(.secondary)
+            } else if traeger.beitrittStatus == "beantragt" {
+                Label("Anfrage läuft", systemImage: "hourglass")
+                    .foregroundStyle(.secondary)
+            } else if traeger.beitrittMoeglich {
+                Label("Mitmachen möglich", systemImage: "hand.raised.fill")
+                    .foregroundStyle(.tint)
+            }
+            if traeger.offeneBeitritte > 0 {
+                Label("\(traeger.offeneBeitritte) offen", systemImage: "tray.full.fill")
+                    .foregroundStyle(Ampel.yellow.farbe)
+                    .accessibilityLabel("\(traeger.offeneBeitritte) Anfragen warten auf deine Entscheidung")
+                    .accessibilityIdentifier("traeger-open-\(traeger.id)")
+            }
+        }
+        .font(.caption.weight(.medium))
+    }
+}

--- a/ios/Dorf/Bereiche/Traeger/TraegerModel.swift
+++ b/ios/Dorf/Bereiche/Traeger/TraegerModel.swift
@@ -1,0 +1,309 @@
+import Combine
+import Foundation
+
+/// Where the Traeger area gets its data from.
+///
+/// A bundle of closures instead of a protocol — the same shape as
+/// `OrteQuelle` and `VergabeQuelle`: the area needs a handful of calls, and
+/// a test fills them itself. No test goes to the network, and `DorfApi`
+/// stays the only way to the backend.
+struct TraegerSource {
+    var list: @MainActor () async throws -> [Traeger]
+    var detail: @MainActor (Int64) async throws -> Traeger
+    /// Traeger id and the reason the person wrote.
+    var join: @MainActor (Int64, String) async throws -> Beitritt
+    var requests: @MainActor (Int64) async throws -> [Beitritt]
+    /// Request id, "erteilt" or "abgelehnt".
+    var decide: @MainActor (Int64, String) async throws -> Beitritt
+    /// Traeger id and the person's identifier.
+    var addMember: @MainActor (Int64, String) async throws -> Beitritt
+    var myRequests: @MainActor () async throws -> [Beitritt]
+    /// The village directory — needed to take somebody in without a request
+    /// of their own; it is the only place an identifier can come from.
+    var villagers: @MainActor () async throws -> [Dorfbewohner] = { [] }
+
+    static func of(_ api: DorfApi) -> TraegerSource {
+        TraegerSource(
+            list: { try await api.traegerListe() },
+            detail: { try await api.traeger(id: $0) },
+            join: { try await api.beitrittBeantragen(traeger: $0, begruendung: $1) },
+            requests: { try await api.beitritte(traeger: $0, status: "") },
+            decide: { try await api.beitrittEntscheiden(id: $0, status: $1) },
+            addMember: { try await api.mitgliedAufnehmen(traeger: $0, userSub: $1) },
+            myRequests: { try await api.meineBeitritte() },
+            villagers: { try await api.dorfbewohner().members }
+        )
+    }
+}
+
+/// The state of the Traeger area: which associations and working groups
+/// there are, whether I belong to them, and what is currently running.
+///
+/// As everywhere in this app: **the last state stays put.** If the network
+/// drops, the list is not emptied but gets a notice above it — "there are no
+/// associations" would be a false statement in a dead spot.
+///
+/// And: nothing here is re-decided. Whether joining is possible, whether the
+/// buttons for deciding appear at all, whether a Traeger shows up — all of
+/// that arrives answered from the server. What this class does is remember
+/// the answer and say what is currently being written.
+final class TraegerModel: ObservableObject {
+    private let source: TraegerSource
+
+    @Published private(set) var all: [Traeger] = []
+    /// My own requests across all Traeger — the answer to "did I ask
+    /// somewhere and is it still pending?".
+    @Published private(set) var mine: [Beitritt] = []
+    /// Requests per Traeger, for those who administer it.
+    @Published private(set) var requests: [Int64: [Beitritt]] = [:]
+    /// The village directory, loaded only when somebody wants to take a
+    /// person in directly.
+    @Published private(set) var villagers: [Dorfbewohner] = []
+    @Published private(set) var loading = false
+    /// Whether a fetch ever completed — before that the list shows a spinner
+    /// instead of "no associations yet".
+    @Published private(set) var everLoaded = false
+    /// The last fetch failed, in the backend's own words.
+    @Published private(set) var notice: String?
+    /// A genuinely rejected write — shown as an alert with an OK button.
+    /// This is where a 502/503 from the Rössing-ID lands, and the sentence
+    /// is the server's: an app that reports "taken in" while the door stays
+    /// shut would be worse than no app.
+    @Published private(set) var error: String?
+    /// Short feedback after a successful write.
+    @Published private(set) var confirmation: String?
+    /// Traeger currently being written to (join, take somebody in).
+    @Published private(set) var busy: Set<Int64> = []
+    /// Requests currently being decided.
+    @Published private(set) var busyRequests: Set<Int64> = []
+
+    private var fading: Task<Void, Never>?
+
+    init(source: TraegerSource) { self.source = source }
+
+    convenience init(api: DorfApi) { self.init(source: .of(api)) }
+
+    // MARK: Views on the state
+
+    func traeger(id: Int64) -> Traeger? { all.first { $0.id == id } }
+
+    /// Whether the server offered this Traeger to this person at all. The
+    /// place detail asks before it offers a way there — not as a second
+    /// visibility rule, but because the server's own directory is the only
+    /// honest answer to "is there anything to see behind this?".
+    func inDirectory(_ id: Int64) -> Bool { id != 0 && traeger(id: id) != nil }
+
+    /// Associations: everything without a roof — plus anything whose roof
+    /// this person cannot see, because otherwise it would fall out of the
+    /// directory entirely.
+    var roots: [Traeger] {
+        let sichtbar = Set(all.map(\.id))
+        return all
+            .filter { $0.parentId == 0 || !sichtbar.contains($0.parentId) }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// The working groups under an association. Exactly one level — deeper
+    /// nesting does not exist (see `model.Traeger.ParentID`).
+    func children(of id: Int64) -> [Traeger] {
+        all.filter { $0.parentId == id }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// How many undecided requests are waiting for me, across everything I
+    /// administer. The start page shows this — somebody is waiting.
+    var openRequestsForMe: Int { all.reduce(0) { $0 + $1.offeneBeitritte } }
+
+    func isBusy(traeger id: Int64) -> Bool { busy.contains(id) }
+
+    func isBusy(request id: Int64) -> Bool { busyRequests.contains(id) }
+
+    // MARK: Loading
+
+    func load() async {
+        loading = true
+        defer {
+            loading = false
+            everLoaded = true
+        }
+        do {
+            all = try await source.list()
+            notice = nil
+        } catch let fehler as DorfFehler {
+            notice = fehler.klartext
+        } catch {
+            notice = Self.networkNotice
+        }
+        // The own requests are a second call and must not cost the list: a
+        // Traeger directory without them is still useful.
+        if let eigene = try? await source.myRequests() { mine = eigene }
+    }
+
+    /// Fetches one Traeger anew and puts it into the list.
+    ///
+    /// The detail page can be reached from a place, and then the directory
+    /// may be older than what is shown. A failure is deliberately silent
+    /// here: the entry that is already there stays, and it is not wrong —
+    /// only possibly a minute old.
+    func refresh(traeger id: Int64) async {
+        guard let frisch = try? await source.detail(id) else { return }
+        if let stelle = all.firstIndex(where: { $0.id == id }) {
+            all[stelle] = frisch
+        } else {
+            all.append(frisch)
+        }
+    }
+
+    /// Fetches the requests of one Traeger. Only makes sense for those who
+    /// administer it — the server answers everyone else with 403, and that
+    /// then stands as a notice.
+    func loadRequests(traeger id: Int64) async {
+        do {
+            requests[id] = try await source.requests(id)
+            notice = nil
+        } catch let fehler as DorfFehler {
+            notice = fehler.klartext
+        } catch {
+            notice = Self.networkNotice
+        }
+    }
+
+    /// The village directory — needed to take somebody in directly.
+    func loadVillagers() async {
+        guard villagers.isEmpty else { return }
+        if let liste = try? await source.villagers() { villagers = liste }
+    }
+
+    // MARK: Joining
+
+    /// "I want to join." A rejection keeps the typed reason: it is returned
+    /// as false, and the view leaves the sheet open.
+    @discardableResult
+    func join(traeger id: Int64, reason: String) async -> Bool {
+        guard !busy.contains(id) else { return false }
+        busy.insert(id)
+        defer { busy.remove(id) }
+        do {
+            _ = try await source.join(id, reason.trimmingCharacters(in: .whitespacesAndNewlines))
+            await load()
+            show(confirmation: "Deine Anfrage ist raus. Der Vorstand entscheidet sie.")
+            return true
+        } catch let abgewiesen as DorfFehler {
+            // A 409 is not a mishap: the situation does not fit, and the
+            // server says in which way. Either way the list is stale now.
+            await load()
+            error = abgewiesen.klartext
+            return false
+        } catch {
+            self.error = Self.networkNotice
+            return false
+        }
+    }
+
+    // MARK: Deciding (for the board)
+
+    func decide(request: Beitritt, status: String) async {
+        guard !busyRequests.contains(request.id) else { return }
+        busyRequests.insert(request.id)
+        defer { busyRequests.remove(request.id) }
+        do {
+            _ = try await source.decide(request.id, status)
+            await loadRequests(traeger: request.traegerId)
+            await load()
+            show(confirmation: status == "erteilt"
+                ? "\(request.anzeigename) gehört jetzt dazu."
+                : "Abgelehnt. \(request.anzeigename) bleibt außen vor.")
+        } catch let abgewiesen as DorfFehler {
+            // Granting writes to the Rössing-ID first. Fails that, the
+            // request stays open — and saying so is the whole point.
+            await loadRequests(traeger: request.traegerId)
+            error = abgewiesen.klartext
+        } catch {
+            self.error = Self.networkNotice
+        }
+    }
+
+    /// Takes somebody in without a request of their own — the only way into
+    /// a closed group.
+    func addMember(traeger id: Int64, person: Dorfbewohner) async {
+        guard !busy.contains(id) else { return }
+        busy.insert(id)
+        defer { busy.remove(id) }
+        do {
+            _ = try await source.addMember(id, person.userSub)
+            await loadRequests(traeger: id)
+            await load()
+            show(confirmation: "\(Self.name(of: person)) gehört jetzt dazu.")
+        } catch let abgewiesen as DorfFehler {
+            error = abgewiesen.klartext
+        } catch {
+            self.error = Self.networkNotice
+        }
+    }
+
+    /// The name a villager goes by — nickname before display name before the
+    /// bare identifier.
+    static func name(of person: Dorfbewohner) -> String {
+        let kandidaten = [person.name, person.nickname, person.displayName]
+        return kandidaten.first { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+            ?? person.userSub
+    }
+
+    // MARK: Clearing messages
+
+    func dismissError() { error = nil }
+
+    func dismissNotice() { notice = nil }
+
+    func dismissConfirmation() {
+        fading?.cancel()
+        confirmation = nil
+    }
+
+    /// The same wording as `DorfFehler.netz` — so that a dead spot sounds
+    /// the same everywhere in the app.
+    static let networkNotice = DorfFehler.netz("").klartext
+
+    private func show(confirmation text: String) {
+        fading?.cancel()
+        confirmation = text
+        fading = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(6))
+            guard !Task.isCancelled else { return }
+            self?.confirmation = nil
+        }
+    }
+}
+
+/// Wie ein Zulassungsstand und eine Sichtbarkeit auf Deutsch heißen.
+///
+/// Reine Anzeige: Was daraus folgt — sichtbar, beitretbar, verwaltbar —
+/// steht schon in den Feldern, die der Server mitschickt.
+enum TraegerTexte {
+    static func status(_ roh: String) -> String {
+        switch roh {
+        case "zugelassen": return "Zugelassen"
+        case "beantragt": return "Noch nicht zugelassen"
+        case "gesperrt": return "Gesperrt"
+        default: return roh
+        }
+    }
+
+    static func sichtbarkeit(_ roh: String) -> String {
+        switch roh {
+        case "offen": return "Offen für alle im Dorf"
+        case "geschlossen": return "Geschlossene Gruppe"
+        default: return roh
+        }
+    }
+
+    /// Was der eigene Antrag gerade macht.
+    static func beitrittStatus(_ roh: String) -> String? {
+        switch roh {
+        case "beantragt": return "Deine Anfrage liegt beim Vorstand."
+        case "erteilt": return "Du wurdest aufgenommen."
+        case "abgelehnt": return "Deine Anfrage wurde abgelehnt."
+        default: return nil
+        }
+    }
+}

--- a/ios/Dorf/Daten/DorfApi+Traeger.swift
+++ b/ios/Dorf/Daten/DorfApi+Traeger.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Träger (Vereine und Gruppen) und die Beitritte zu ihnen.
+///
+/// Was hier ankommt, ist bereits entschieden: Die Liste enthält nur, was
+/// diese Person sehen darf, und jeder Eintrag sagt mit, ob sie Mitglied ist,
+/// verwalten darf, beitreten kann — und wenn nicht, warum nicht, in einem
+/// fertigen deutschen Satz. Nichts davon wird hier nachgerechnet. Die Regeln
+/// stehen in `model.Zugriff` im Backend; eine zweite Prüfung in der App gäbe
+/// beim nächsten Sonderfall eine andere Antwort als der Server.
+///
+/// Eine eigene Datei nur der Übersicht wegen: Es sind **Methoden auf
+/// `DorfApi`**, die denselben Transport benutzen wie alle anderen Endpunkte
+/// (`hole`, `schicke`). Die DTOs stehen bei den übrigen in `Modelle.swift`.
+nonisolated extension DorfApi {
+    // MARK: Verzeichnis
+
+    /// Alle Träger, die diese Person sehen darf. Eine geschlossene Gruppe
+    /// steht nur für ihre Mitglieder darin — das entscheidet der Server.
+    func traegerListe() async throws -> [Traeger] {
+        let antwort: TraegerListeAntwort = try await hole("api/v1/traeger")
+        return antwort.traeger
+    }
+
+    /// Ein einzelner Träger. 404 heißt hier auch „gibt es für dich nicht“ —
+    /// so verrät kein Durchprobieren von Kennungen eine geschlossene Gruppe.
+    func traeger(id: Int64) async throws -> Traeger {
+        let antwort: TraegerAntwort = try await hole("api/v1/traeger/\(id)")
+        return antwort.traeger
+    }
+
+    // MARK: Mitmachen sagen
+
+    /// „Ich will mitmachen.“ Ein 409 heißt: geht gerade nicht, und der Text
+    /// des Servers sagt warum (schon dabei, geschlossene Gruppe, kein
+    /// Zitadel-Projekt). Er wird im Wortlaut gezeigt.
+    func beitrittBeantragen(traeger id: Int64, begruendung: String) async throws -> Beitritt {
+        try await schicke("POST", "api/v1/traeger/\(id)/beitritt",
+                          rumpf: BeitrittEingabe(begruendung: begruendung))
+    }
+
+    /// Meine eigenen Anträge, quer über alle Träger.
+    func meineBeitritte() async throws -> [Beitritt] {
+        let antwort: BeitritteAntwort = try await hole("api/v1/me/beitritte")
+        return antwort.beitritte
+    }
+
+    // MARK: Entscheiden (Vorstand)
+
+    /// Die Anträge eines Trägers. Nur für die, die ihn verwalten — sonst
+    /// antwortet der Server mit 403.
+    func beitritte(traeger id: Int64, status: String = "") async throws -> [Beitritt] {
+        var abfrage: [String: String] = [:]
+        if !status.isEmpty { abfrage["status"] = status }
+        let antwort: BeitritteAntwort = try await hole("api/v1/traeger/\(id)/beitritte",
+                                                       abfrage: abfrage)
+        return antwort.beitritte
+    }
+
+    /// Freigeben oder ablehnen.
+    ///
+    /// Eine Freigabe kann scheitern, ohne dass am Bedienen etwas falsch war:
+    /// Das Backend trägt die Mitgliedschaft zuerst in die Rössing-ID ein und
+    /// hakt erst danach ab. Klappt das nicht, kommt 502 oder 503, der Antrag
+    /// bleibt offen — und der Satz des Servers gehört auf den Schirm.
+    func beitrittEntscheiden(id: Int64, status: String,
+                             notiz: String = "") async throws -> Beitritt {
+        try await schicke("POST", "api/v1/beitritte/\(id)",
+                          rumpf: BeitrittEntscheidung(status: status, notiz: notiz))
+    }
+
+    /// Jemanden ohne vorherigen Antrag aufnehmen — bei einer geschlossenen
+    /// Gruppe der einzige Weg hinein, und auch sonst der Alltag: Zugesagt
+    /// wird im Dorf öfter am Gartenzaun als in der App.
+    func mitgliedAufnehmen(traeger id: Int64, userSub: String,
+                           notiz: String = "") async throws -> Beitritt {
+        try await schicke("POST", "api/v1/traeger/\(id)/mitglieder",
+                          rumpf: MitgliedEingabe(userSub: userSub, notiz: notiz))
+    }
+}

--- a/ios/Dorf/Daten/Modelle.swift
+++ b/ios/Dorf/Daten/Modelle.swift
@@ -325,10 +325,20 @@ nonisolated struct Ort: Codable, Identifiable, Hashable, Sendable {
     /// (`model.TraegerAnzeigeName`). Die App entscheidet hier nichts, sie
     /// zeigt an — sonst gäbe es die Sichtbarkeitsregel zweimal.
     var traegerName: String = ""
+    /// Die Kennung desselben Trägers — der Weg von hier zu ihm.
+    ///
+    /// Sie steht auch dann im JSON, wenn der Name verdeckt ist; das verrät
+    /// nichts, denn abgerufen wird der Träger über denselben Server, der ihn
+    /// verdeckt hat. Ob dieser Weg angeboten wird, entscheidet trotzdem
+    /// nicht die App an dieser Zahl, sondern das Verzeichnis: Steht der
+    /// Träger nicht darin, hat der Server ihn für diese Person nicht
+    /// vorgesehen.
+    var traegerId: Int64 = 0
     var tasks: [Aufgabe] = []
 
     enum CodingKeys: String, CodingKey {
-        case id, name, description, kind, lat, lon, active, status, traegerName, tasks
+        case id, name, description, kind, lat, lon, active, status
+        case traegerName, traegerId, tasks
     }
 
     init(from decoder: Decoder) throws {
@@ -342,15 +352,17 @@ nonisolated struct Ort: Codable, Identifiable, Hashable, Sendable {
         active = c.wert(.active, true)
         status = c.wert(.status, "green")
         traegerName = c.wert(.traegerName, "")
+        traegerId = c.wert(.traegerId, 0)
         tasks = c.wert(.tasks, [])
     }
 
     init(id: Int64, name: String, description: String = "", kind: String = "blumenkasten",
          lat: Double, lon: Double, active: Bool = true, status: String = "green",
-         traegerName: String = "", tasks: [Aufgabe] = []) {
+         traegerName: String = "", traegerId: Int64 = 0, tasks: [Aufgabe] = []) {
         self.id = id; self.name = name; self.description = description; self.kind = kind
         self.lat = lat; self.lon = lon; self.active = active; self.status = status
         self.traegerName = traegerName
+        self.traegerId = traegerId
         self.tasks = tasks
     }
 
@@ -909,4 +921,177 @@ nonisolated enum RFC3339 {
         if text.isEmpty { return nil }
         return mitBruchteilen.date(from: text) ?? ohneBruchteile.date(from: text)
     }
+}
+
+// MARK: - Träger (Vereine und Gruppen)
+
+/// A Traeger — the association or working group that owns places and tasks.
+///
+/// Everything about what *this* person may see and do arrives decided from
+/// the server (`model.Zugriff`): whether joining is possible, why not, and
+/// how an own request stands. The app shows it and decides nothing itself —
+/// a second check is a second answer, and at the next special case it is the
+/// wrong one.
+///
+/// The property names follow the wire format, which is German. Renaming them
+/// would mean a `CodingKeys` entry per field and would tell nobody anything
+/// the JSON does not already say.
+nonisolated struct Traeger: Codable, Identifiable, Hashable, Sendable {
+    var id: Int64
+    var name: String = ""
+    var beschreibung: String = ""
+    /// beantragt · zugelassen · gesperrt
+    var status: String = ""
+    /// offen · geschlossen
+    var sichtbarkeit: String = ""
+    /// The roof this Traeger works under — 0 means none. Exactly one level:
+    /// association → working group. Rights travel along it in neither
+    /// direction; whoever administers the working group does not thereby
+    /// administer the association.
+    var parentId: Int64 = 0
+    var istMitglied = false
+    var darfVerwalten = false
+    /// This person can file a request right now.
+    var beitrittMoeglich = false
+    /// Why not — a finished German sentence, meant to be shown verbatim.
+    var beitrittHindernis = ""
+    /// How my own request stands: beantragt · erteilt · abgelehnt. Empty
+    /// means there is none.
+    var beitrittStatus = ""
+    /// Undecided requests — the server fills it only for those who
+    /// administer this Traeger.
+    var offeneBeitritte = 0
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, beschreibung, status, sichtbarkeit, parentId
+        case istMitglied, darfVerwalten, beitrittMoeglich, beitrittHindernis
+        case beitrittStatus, offeneBeitritte
+    }
+
+    init(id: Int64, name: String = "", beschreibung: String = "",
+         status: String = "zugelassen", sichtbarkeit: String = "offen",
+         parentId: Int64 = 0, istMitglied: Bool = false, darfVerwalten: Bool = false,
+         beitrittMoeglich: Bool = false, beitrittHindernis: String = "",
+         beitrittStatus: String = "", offeneBeitritte: Int = 0) {
+        self.id = id; self.name = name; self.beschreibung = beschreibung
+        self.status = status; self.sichtbarkeit = sichtbarkeit; self.parentId = parentId
+        self.istMitglied = istMitglied; self.darfVerwalten = darfVerwalten
+        self.beitrittMoeglich = beitrittMoeglich; self.beitrittHindernis = beitrittHindernis
+        self.beitrittStatus = beitrittStatus; self.offeneBeitritte = offeneBeitritte
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(Int64.self, forKey: .id)
+        name = c.wert(.name, "")
+        beschreibung = c.wert(.beschreibung, "")
+        status = c.wert(.status, "")
+        sichtbarkeit = c.wert(.sichtbarkeit, "")
+        parentId = c.wert(.parentId, 0)
+        istMitglied = c.wert(.istMitglied, false)
+        darfVerwalten = c.wert(.darfVerwalten, false)
+        beitrittMoeglich = c.wert(.beitrittMoeglich, false)
+        beitrittHindernis = c.wert(.beitrittHindernis, "")
+        beitrittStatus = c.wert(.beitrittStatus, "")
+        offeneBeitritte = c.wert(.offeneBeitritte, 0)
+    }
+
+    /// A closed group is in the directory for members only, and it takes no
+    /// requests — it takes people in itself. Whether a button does anything
+    /// is `beitrittMoeglich`; this is only for the sentence beside it.
+    var istGeschlossen: Bool { sichtbarkeit == "geschlossen" }
+}
+
+/// A request for membership in a Traeger.
+///
+/// A granted request is **not** the membership: that one lives in the
+/// Rössing-ID. Here stands the proceeding — who asked when, who decided
+/// when. Which is why granting can fail while the request stays open, and
+/// why the server's sentence about it belongs on the screen verbatim.
+nonisolated struct Beitritt: Codable, Identifiable, Hashable, Sendable {
+    var id: Int64
+    var traegerId: Int64 = 0
+    var traegerName: String = ""
+    var userSub: String = ""
+    var userName: String = ""
+    /// beantragt · erteilt · abgelehnt
+    var status: String = ""
+    var begruendung: String = ""
+    var notiz: String = ""
+    var createdAt: String = ""
+    var entschiedenAm: String = ""
+
+    enum CodingKeys: String, CodingKey {
+        case id, traegerId, traegerName, userSub, userName, status
+        case begruendung, notiz, createdAt, entschiedenAm
+    }
+
+    init(id: Int64, traegerId: Int64 = 0, traegerName: String = "", userSub: String = "",
+         userName: String = "", status: String = "beantragt", begruendung: String = "",
+         notiz: String = "", createdAt: String = "", entschiedenAm: String = "") {
+        self.id = id; self.traegerId = traegerId; self.traegerName = traegerName
+        self.userSub = userSub; self.userName = userName; self.status = status
+        self.begruendung = begruendung; self.notiz = notiz
+        self.createdAt = createdAt; self.entschiedenAm = entschiedenAm
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(Int64.self, forKey: .id)
+        traegerId = c.wert(.traegerId, 0)
+        traegerName = c.wert(.traegerName, "")
+        userSub = c.wert(.userSub, "")
+        userName = c.wert(.userName, "")
+        status = c.wert(.status, "")
+        begruendung = c.wert(.begruendung, "")
+        notiz = c.wert(.notiz, "")
+        createdAt = c.wert(.createdAt, "")
+        entschiedenAm = c.wert(.entschiedenAm, "")
+    }
+
+    /// The name to show. The server resolves it from the profile; the bare
+    /// identifier is the fallback, not the normal case.
+    var anzeigename: String { userName.isEmpty ? userSub : userName }
+}
+
+nonisolated struct TraegerListeAntwort: Codable, Sendable {
+    var traeger: [Traeger] = []
+    enum CodingKeys: String, CodingKey { case traeger }
+    init(traeger: [Traeger] = []) { self.traeger = traeger }
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        traeger = c.wert(.traeger, [])
+    }
+}
+
+nonisolated struct TraegerAntwort: Codable, Sendable {
+    var traeger: Traeger
+}
+
+nonisolated struct BeitritteAntwort: Codable, Sendable {
+    var beitritte: [Beitritt] = []
+    enum CodingKeys: String, CodingKey { case beitritte }
+    init(beitritte: [Beitritt] = []) { self.beitritte = beitritte }
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        beitritte = c.wert(.beitritte, [])
+    }
+}
+
+/// Body of `POST /api/v1/traeger/{id}/beitritt`.
+nonisolated struct BeitrittEingabe: Codable, Sendable {
+    var begruendung: String = ""
+}
+
+/// Body of `POST /api/v1/beitritte/{id}`.
+nonisolated struct BeitrittEntscheidung: Codable, Sendable {
+    var status: String
+    var notiz: String = ""
+}
+
+/// Body of `POST /api/v1/traeger/{id}/mitglieder` — the only way into a
+/// closed group.
+nonisolated struct MitgliedEingabe: Codable, Sendable {
+    var userSub: String
+    var notiz: String = ""
 }

--- a/ios/Dorf/Navigation/StartView.swift
+++ b/ios/Dorf/Navigation/StartView.swift
@@ -71,6 +71,16 @@ struct StartView: View {
                         ziel: .rangliste, symbol: "trophy.fill", titel: "Rangliste",
                         untertitel: "Wer wie viel geschafft hat."
                     )
+                    // Wem die Orte und Aufgaben gehören — und wo man sagt
+                    // „ich will mitmachen". Der Hinweis zählt, was auf eine
+                    // Entscheidung wartet: Wer im Vorstand ist, soll es
+                    // sehen, ohne erst hineinzugehen.
+                    Bereichskachel(
+                        ziel: .traeger, symbol: "person.2.fill", titel: "Vereine und Gruppen",
+                        untertitel: "Wer im Dorf was betreut — und wie du mitmachst.",
+                        hinweis: Startseitentexte.traegerHinweis(
+                            offeneAnfragen: umgebung.traeger.openRequestsForMe)
+                    )
                 }
 
                 Section("Du und das Dorf") {
@@ -127,6 +137,9 @@ struct StartView: View {
             // Die Orte gehören der Umgebung, nicht dieser Seite: „Mithelfen"
             // benutzt dasselbe Modell und lädt deshalb nicht ein zweites Mal.
             .task { await umgebung.orte.laden() }
+            // Dasselbe für die Träger: Die Kachel zählt die offenen Anfragen,
+            // die Ortsansicht fragt, ob es zum Träger einen Weg gibt.
+            .task { await umgebung.traeger.load() }
         }
     }
 }

--- a/ios/Dorf/Navigation/Startseitentexte.swift
+++ b/ios/Dorf/Navigation/Startseitentexte.swift
@@ -42,4 +42,18 @@ enum Startseitentexte {
         guard giessfaktor.isFinite, giessfaktor < 1 else { return nil }
         return "Heiß — bitte großzügig gießen."
     }
+
+    /// Der Hinweis auf der Kachel „Vereine und Gruppen".
+    ///
+    /// Gezählt werden die Anfragen, die auf **meine** Entscheidung warten —
+    /// die Zahl schickt der Server nur denen mit, die den Träger verwalten.
+    /// Für alle anderen bleibt die Kachel still: Wer nichts zu entscheiden
+    /// hat, braucht keine Null.
+    static func traegerHinweis(offeneAnfragen: Int) -> String? {
+        switch offeneAnfragen {
+        case ..<1: return nil
+        case 1: return "Eine Anfrage wartet auf dich"
+        default: return "\(offeneAnfragen) Anfragen warten auf dich"
+        }
+    }
 }

--- a/ios/Dorf/Navigation/Ziel.swift
+++ b/ios/Dorf/Navigation/Ziel.swift
@@ -14,6 +14,12 @@ enum Ziel: Hashable {
     case ideen
     case anfragen
     case einstellungen
+    /// Das Verzeichnis der Vereine und Gruppen.
+    case traeger
+    /// Ein einzelner Träger.
+    case traegerDetail(Int64)
+    /// Ein einzelner Ort — der Weg vom Träger zurück zu dem, was er betreut.
+    case ort(Int64)
 }
 
 extension View {
@@ -33,7 +39,27 @@ extension View {
             case .ideen: IdeenView()
             case .anfragen: VergabeView()
             case .einstellungen: EinstellungenView()
+            case .traeger: TraegerListView()
+            case .traegerDetail(let id): TraegerDetailView(traegerId: id)
+            case .ort(let id): OrtZiel(ortId: id)
             }
         }
+    }
+}
+
+/// Ein Ort als Wertziel.
+///
+/// „Mithelfen" öffnet seine Orte selbst — es hat die Liste ohnehin in der
+/// Hand. Vom Träger aus gibt es die aber nicht: Dort steht nur eine Kennung.
+/// Diese Hülle holt das gemeinsame Ortsmodell aus der Umgebung und reicht es
+/// weiter, damit der Weg vom Träger zu seinen Orten ohne einen zweiten Abruf
+/// und ohne einen zweiten Stand auskommt.
+struct OrtZiel: View {
+    @EnvironmentObject private var umgebung: AppUmgebung
+    let ortId: Int64
+
+    var body: some View {
+        OrtDetailView(modell: umgebung.orte, ortId: ortId, meinSub: umgebung.meinSub)
+            .task { await umgebung.orte.laden() }
     }
 }

--- a/ios/Dorf/Umgebung.swift
+++ b/ios/Dorf/Umgebung.swift
@@ -29,6 +29,13 @@ final class AppUmgebung: ObservableObject {
     /// zählte dann etwas anderes, als die Liste dahinter zeigt.
     let orte: OrteModell
 
+    /// Die Vereine und Gruppen des Dorfes — aus demselben Grund **ein**
+    /// Modell für alle: Die Startseite zeigt daraus nur, wie viele Anfragen
+    /// auf eine Entscheidung warten, das Verzeichnis die ganze Liste, und die
+    /// Ortsansicht fragt es, ob es zu ihrem Träger überhaupt einen Weg gibt.
+    /// Zwei Modelle hießen zwei Abrufe und zwei Stände.
+    let traeger: TraegerModel
+
     /// Wer gerade angemeldet ist. Wird nach der Anmeldung einmal geladen und
     /// danach von den Bereichen mitbenutzt — `isAdmin` entscheidet, ob der
     /// Bereich „Verwaltung" überhaupt auftaucht.
@@ -59,6 +66,7 @@ final class AppUmgebung: ObservableObject {
             await anmeldung.frischesToken()
         })
         self.orte = OrteModell(api: api)
+        self.traeger = TraegerModel(api: api)
         // Die Benachrichtigungen brauchen denselben Zugang: Sie melden die
         // Gerätekennung an und beim Abmelden wieder ab. Gefragt wird damit
         // noch niemand — das passiert erst beim Eintragen als Helfer:in.
@@ -68,13 +76,14 @@ final class AppUmgebung: ObservableObject {
 
     /// Für Vorschauen und Tests: eine Umgebung, die nichts abruft.
     init(anmeldung: Anmeldung, api: DorfApi, ich: Ich?, orte: OrteModell? = nil,
-         rental: RentalClient? = nil) {
+         rental: RentalClient? = nil, traeger: TraegerModel? = nil) {
         self.anmeldung = anmeldung
         self.api = api
         self.rental = rental ?? RentalClient(tokenProvider: { [anmeldung] in
             await anmeldung.frischesToken()
         })
         self.orte = orte ?? OrteModell(api: api)
+        self.traeger = traeger ?? TraegerModel(api: api)
         self.ich = ich
         kinderWeiterreichen()
     }
@@ -83,6 +92,7 @@ final class AppUmgebung: ObservableObject {
         weiterleitungen = [
             anmeldung.objectWillChange.sink { [weak self] in self?.objectWillChange.send() },
             orte.objectWillChange.sink { [weak self] in self?.objectWillChange.send() },
+            traeger.objectWillChange.sink { [weak self] in self?.objectWillChange.send() },
         ]
     }
 
@@ -115,6 +125,7 @@ final class AppUmgebung: ObservableObject {
     func erneutVersuchen() async {
         await ichLaden()
         await orte.laden()
+        await traeger.load()
     }
 
     func profilUebernehmen(_ profil: Profil) {

--- a/ios/DorfTests/TraegerTests.swift
+++ b/ios/DorfTests/TraegerTests.swift
@@ -1,0 +1,307 @@
+import Foundation
+import Testing
+
+@testable import Dorf
+
+/// Was das Verzeichnis der Vereine und Gruppen versprechen muss — geprüft
+/// ohne Oberfläche und ohne Netz.
+///
+/// Die Quelle des Modells ist ein Bündel Verschlüsse (`TraegerSource`), das
+/// der Test selbst füllt. Es wird also nie ein Server angefasst.
+///
+/// Und vor allem: Hier wird nirgends nachgerechnet, wer beitreten darf oder
+/// wer einen Träger sehen darf. Das steht in `model.Zugriff` im Backend, und
+/// die Antwort kommt fertig mit. Geprüft wird, dass die App sie **übernimmt**
+/// — samt Wortlaut, wenn etwas schiefgeht.
+@MainActor
+struct TraegerTests {
+    // MARK: Werkzeug
+
+    /// Merkt sich, was das Modell tatsächlich getan hat, und gibt vor, was
+    /// der Server antwortet.
+    private final class Spur {
+        var listen: [[Traeger]]
+        var abrufe = 0
+        var eigene: [Beitritt] = []
+        var antraege: [Beitritt] = []
+        var villagers: [Dorfbewohner] = []
+
+        var ladeFehler: DorfFehler?
+        var beitrittFehler: DorfFehler?
+        var entscheidungsFehler: DorfFehler?
+        var aufnahmeFehler: DorfFehler?
+
+        var beitritte: [(Int64, String)] = []
+        var entscheidungen: [(Int64, String)] = []
+        var aufnahmen: [(Int64, String)] = []
+
+        init(_ listen: [[Traeger]]) { self.listen = listen }
+
+        func naechste() throws -> [Traeger] {
+            let stelle = min(abrufe, max(listen.count - 1, 0))
+            abrufe += 1
+            if let ladeFehler { throw ladeFehler }
+            return listen.isEmpty ? [] : listen[stelle]
+        }
+    }
+
+    private static func quelle(_ spur: Spur) -> TraegerSource {
+        TraegerSource(
+            list: { try spur.naechste() },
+            detail: { id in
+                guard let t = (try? spur.naechste())?.first(where: { $0.id == id }) else {
+                    throw DorfFehler.nichtGefunden
+                }
+                return t
+            },
+            join: { id, grund in
+                spur.beitritte.append((id, grund))
+                if let fehler = spur.beitrittFehler { throw fehler }
+                return Beitritt(id: 1, traegerId: id, status: "beantragt", begruendung: grund)
+            },
+            requests: { _ in spur.antraege },
+            decide: { id, status in
+                spur.entscheidungen.append((id, status))
+                if let fehler = spur.entscheidungsFehler { throw fehler }
+                return Beitritt(id: id, status: status)
+            },
+            addMember: { id, sub in
+                spur.aufnahmen.append((id, sub))
+                if let fehler = spur.aufnahmeFehler { throw fehler }
+                return Beitritt(id: 7, traegerId: id, userSub: sub, status: "erteilt")
+            },
+            myRequests: { spur.eigene },
+            villagers: { spur.villagers }
+        )
+    }
+
+    private static func modell(_ spur: Spur) -> TraegerModel {
+        TraegerModel(source: Self.quelle(spur))
+    }
+
+    private static func verein(_ id: Int64, _ name: String, parent: Int64 = 0,
+                               mitglied: Bool = false, verwaltet: Bool = false,
+                               moeglich: Bool = true, hindernis: String = "",
+                               antrag: String = "", offen: Int = 0,
+                               sichtbarkeit: String = "offen") -> Traeger {
+        Traeger(id: id, name: name, status: "zugelassen", sichtbarkeit: sichtbarkeit,
+                parentId: parent, istMitglied: mitglied, darfVerwalten: verwaltet,
+                beitrittMoeglich: moeglich, beitrittHindernis: hindernis,
+                beitrittStatus: antrag, offeneBeitritte: offen)
+    }
+
+    // MARK: Was vom Server kommt, wird gelesen
+
+    @Test func dieSichtDesServersWirdUebernommen() throws {
+        let roh = """
+        {"id":2,"name":"AK 2 Umwelt und Natur","beschreibung":"Beete und Blumenkästen",
+         "status":"zugelassen","sichtbarkeit":"offen","parentId":1,
+         "istMitglied":false,"darfVerwalten":true,"beitrittMoeglich":true,
+         "beitrittStatus":"beantragt","offeneBeitritte":3}
+        """.data(using: .utf8)!
+        let t = try JSONDecoder().decode(Traeger.self, from: roh)
+        #expect(t.name == "AK 2 Umwelt und Natur")
+        #expect(t.parentId == 1)
+        #expect(t.darfVerwalten)
+        #expect(t.beitrittMoeglich)
+        #expect(t.beitrittStatus == "beantragt")
+        #expect(t.offeneBeitritte == 3)
+    }
+
+    /// Ein Träger, dem man nicht beitreten kann, bringt den Grund im Klartext
+    /// mit. Die App erfindet ihn nicht — sie zeigt ihn.
+    @Test func dasHindernisKommtImWortlaut() throws {
+        let satz = "Diese Gruppe ist geschlossen: Wer dazugehören soll, wird von ihr aufgenommen."
+        let roh = """
+        {"id":5,"name":"Der stille Kreis","sichtbarkeit":"geschlossen",
+         "beitrittMoeglich":false,"beitrittHindernis":"\(satz)"}
+        """.data(using: .utf8)!
+        let t = try JSONDecoder().decode(Traeger.self, from: roh)
+        #expect(!t.beitrittMoeglich)
+        #expect(t.beitrittHindernis == satz)
+        #expect(t.istGeschlossen)
+    }
+
+    /// Ein älterer Backend-Stand schickt die Sichtfelder nicht mit. Dann darf
+    /// nichts unlesbar werden — es gilt schlicht „nein".
+    @Test func fehlendeFelderMachenNichtsKaputt() throws {
+        let roh = #"{"id":9,"name":"Dorfpflege Rössing e.V."}"#.data(using: .utf8)!
+        let t = try JSONDecoder().decode(Traeger.self, from: roh)
+        #expect(t.name == "Dorfpflege Rössing e.V.")
+        #expect(!t.istMitglied)
+        #expect(!t.darfVerwalten)
+        #expect(!t.beitrittMoeglich)
+        #expect(t.parentId == 0)
+    }
+
+    @Test func derOrtBringtDieKennungSeinesTraegersMit() throws {
+        let roh = """
+        {"id":3,"name":"Beet vor dem Dorfgemeinschaftshaus","lat":52.18,"lon":9.81,
+         "traegerName":"AK 2 Umwelt und Natur","traegerId":2}
+        """.data(using: .utf8)!
+        let ort = try JSONDecoder().decode(Ort.self, from: roh)
+        #expect(ort.traegerId == 2)
+    }
+
+    // MARK: Verein und Arbeitskreis
+
+    @Test func arbeitskreiseStehenUnterIhremVerein() async {
+        let spur = Spur([[
+            Self.verein(1, "Dorfpflege Rössing e.V."),
+            Self.verein(2, "AK 2 Umwelt und Natur", parent: 1),
+            Self.verein(3, "AK 1 Bauen", parent: 1),
+        ]])
+        let modell = Self.modell(spur)
+        await modell.load()
+
+        #expect(modell.roots.map(\.id) == [1])
+        #expect(modell.children(of: 1).map(\.name) == ["AK 1 Bauen", "AK 2 Umwelt und Natur"])
+        #expect(modell.children(of: 2).isEmpty, "Genau eine Ebene, nicht tiefer")
+    }
+
+    /// Ein Arbeitskreis kann sichtbar sein, sein Verein aber nicht — dann
+    /// verschwände er aus dem Verzeichnis, hinge er nur unter seinem Dach.
+    @Test func einArbeitskreisOhneSichtbaresDachStehtObenDrin() async {
+        let spur = Spur([[Self.verein(2, "AK 2 Umwelt und Natur", parent: 99)]])
+        let modell = Self.modell(spur)
+        await modell.load()
+
+        #expect(modell.roots.map(\.id) == [2])
+    }
+
+    // MARK: Der Weg vom Ort zum Träger
+
+    /// Das Verzeichnis des Servers ist die einzige Auskunft darüber, ob es
+    /// hinter einem Namen etwas zu sehen gibt. Eine eigene Regel daneben wäre
+    /// die Sichtbarkeitsprüfung zum zweiten Mal.
+    @Test func einWegZumTraegerGibtEsNurWennErImVerzeichnisSteht() async {
+        let spur = Spur([[Self.verein(1, "Dorfpflege Rössing e.V.")]])
+        let modell = Self.modell(spur)
+        await modell.load()
+
+        #expect(modell.inDirectory(1))
+        #expect(!modell.inDirectory(5), "Eine geschlossene Gruppe steht nicht drin")
+        #expect(!modell.inDirectory(0), "Ein Ort ohne Träger führt nirgendwohin")
+    }
+
+    // MARK: Mitmachen
+
+    @Test func mitmachenSchicktDieBegruendungUndLaedtNeu() async {
+        let spur = Spur([
+            [Self.verein(1, "Dorfpflege Rössing e.V.")],
+            [Self.verein(1, "Dorfpflege Rössing e.V.", moeglich: false, antrag: "beantragt")],
+        ])
+        let modell = Self.modell(spur)
+        await modell.load()
+
+        let geklappt = await modell.join(traeger: 1, reason: "  Ich wohne nebenan.  ")
+        #expect(geklappt)
+        #expect(spur.beitritte.count == 1)
+        #expect(spur.beitritte.first?.1 == "Ich wohne nebenan.", "Leerraum gehört nicht mit")
+        #expect(modell.traeger(id: 1)?.beitrittStatus == "beantragt", "Der Stand wird neu geholt")
+        #expect(modell.confirmation != nil)
+        #expect(modell.error == nil)
+    }
+
+    /// Ein 409 ist keine Panne: Die Lage passt nicht, und der Server sagt in
+    /// welcher Weise. Genau dieser Satz gehört auf den Schirm.
+    @Test func einAbgelehnterBeitrittZeigtDenSatzDesServers() async {
+        let spur = Spur([[Self.verein(1, "Dorfpflege Rössing e.V.")]])
+        spur.beitrittFehler = .schonVergeben(grund: "Du gehörst schon dazu.")
+        let modell = Self.modell(spur)
+        await modell.load()
+
+        let geklappt = await modell.join(traeger: 1, reason: "")
+        #expect(!geklappt)
+        #expect(modell.error == "Du gehörst schon dazu.")
+        #expect(modell.confirmation == nil)
+    }
+
+    // MARK: Entscheiden
+
+    @Test func freigebenMeldetDenNamenZurueck() async {
+        let spur = Spur([[Self.verein(1, "Dorfpflege", verwaltet: true, offen: 1)]])
+        spur.antraege = [Beitritt(id: 4, traegerId: 1, userName: "Anna Beispiel")]
+        let modell = Self.modell(spur)
+        await modell.load()
+        await modell.loadRequests(traeger: 1)
+
+        await modell.decide(request: spur.antraege[0], status: "erteilt")
+        #expect(spur.entscheidungen.first?.1 == "erteilt")
+        #expect(modell.confirmation == "Anna Beispiel gehört jetzt dazu.")
+    }
+
+    /// Der wichtigste Fall überhaupt: Die Freigabe schreibt zuerst in die
+    /// Rössing-ID. Klappt das nicht, bleibt der Antrag offen — und die App
+    /// darf auf keinen Fall „aufgenommen" melden, während die Tür zu bleibt.
+    @Test func eineGescheiterteFreigabeMeldetKeinenErfolg() async {
+        let satz = "Die Mitgliedschaft konnte in der Rössing-ID nicht eingetragen werden — "
+            + "der Antrag bleibt deshalb offen. Bitte gleich noch einmal versuchen."
+        let spur = Spur([[Self.verein(1, "Dorfpflege", verwaltet: true, offen: 1)]])
+        spur.antraege = [Beitritt(id: 4, traegerId: 1, userName: "Anna Beispiel")]
+        spur.entscheidungsFehler = .nichtVerfuegbar(grund: satz)
+        let modell = Self.modell(spur)
+        await modell.load()
+
+        await modell.decide(request: spur.antraege[0], status: "erteilt")
+        #expect(modell.error == satz, "Der Wortlaut des Servers, nicht ein eigener")
+        #expect(modell.confirmation == nil)
+        #expect(modell.requests[1]?.count == 1, "Der Antrag bleibt stehen")
+    }
+
+    @Test func direktAufnehmenSchicktDieKennungDerPerson() async {
+        let spur = Spur([[Self.verein(1, "Der stille Kreis", verwaltet: true,
+                                      moeglich: false, sichtbarkeit: "geschlossen")]])
+        spur.villagers = [Dorfbewohner(userSub: "anna-sub", name: "Anna Beispiel")]
+        let modell = Self.modell(spur)
+        await modell.load()
+        await modell.loadVillagers()
+
+        await modell.addMember(traeger: 1, person: modell.villagers[0])
+        #expect(spur.aufnahmen.first?.1 == "anna-sub")
+        #expect(modell.confirmation == "Anna Beispiel gehört jetzt dazu.")
+    }
+
+    // MARK: Der letzte Stand bleibt stehen
+
+    @Test func einAusfallLeertDasVerzeichnisNicht() async {
+        let spur = Spur([[Self.verein(1, "Dorfpflege Rössing e.V.")]])
+        let modell = Self.modell(spur)
+        await modell.load()
+        #expect(modell.all.count == 1)
+
+        spur.ladeFehler = .netz("weg")
+        await modell.load()
+        #expect(modell.all.count == 1, "Eine leere Liste im Funkloch wäre eine Falschaussage")
+        #expect(modell.notice != nil)
+    }
+
+    // MARK: Zahlen und Sätze
+
+    @Test func offeneAnfragenWerdenUeberAlleTraegerGezaehlt() async {
+        let spur = Spur([[
+            Self.verein(1, "Dorfpflege", verwaltet: true, offen: 2),
+            Self.verein(2, "AK 2", parent: 1, verwaltet: true, offen: 1),
+            Self.verein(3, "Feuerwehr"),
+        ]])
+        let modell = Self.modell(spur)
+        await modell.load()
+        #expect(modell.openRequestsForMe == 3)
+    }
+
+    @Test func derKachelhinweisSchweigtBeiNull() {
+        #expect(Startseitentexte.traegerHinweis(offeneAnfragen: 0) == nil)
+        #expect(Startseitentexte.traegerHinweis(offeneAnfragen: 1) == "Eine Anfrage wartet auf dich")
+        #expect(Startseitentexte.traegerHinweis(offeneAnfragen: 4) == "4 Anfragen warten auf dich")
+    }
+
+    @Test func standUndSichtbarkeitStehenAufDeutschDa() {
+        #expect(TraegerTexte.status("zugelassen") == "Zugelassen")
+        #expect(TraegerTexte.sichtbarkeit("geschlossen") == "Geschlossene Gruppe")
+        #expect(TraegerTexte.beitrittStatus("beantragt") == "Deine Anfrage liegt beim Vorstand.")
+        #expect(TraegerTexte.beitrittStatus("") == nil)
+        // Ein Wert, den diese App-Fassung nicht kennt, verschwindet nicht
+        // stillschweigend — er steht so da, wie er kam.
+        #expect(TraegerTexte.status("ruhend") == "ruhend")
+    }
+}


### PR DESCRIPTION
Der Betreiber sucht die Dorfpflege in der App und findet sie nicht. Seit gestern
steht der Trägername am Ort — mehr kannten beide Apps von dem Begriff nicht. Es
gab keine Stelle, an der man sieht, welche Vereine und Arbeitskreise es im Dorf
gibt, wer wozu gehört, oder an der man sagen kann „ich will mitmachen".

Beide Apps bekommen jetzt denselben Bereich **„Vereine und Gruppen"**.

## Was beide Apps können

- **Verzeichnis**: Die Vereine des Dorfes, darunter eingerückt ihre
  Arbeitskreise — genau eine Ebene, wie das Modell sie kennt. Je Zeile eine
  Marke: „Du bist dabei", „Geschlossene Gruppe", „Anfrage läuft", „Mitmachen
  möglich", und für Verwaltende „n offen".
- **Ein Träger**: Beschreibung, Zulassungsstand, Sichtbarkeit, das Dach (bei
  einem Arbeitskreis, mit Weg dorthin), die Arbeitskreise darunter, **die Orte,
  die er betreut** — und der Weg zum Mitmachen.
- **Mitmachen sagen**: Knopf mit freiwilliger Begründung
  (`POST /api/v1/traeger/{id}/beitritt`). Die eigenen noch offenen Anfragen
  stehen oben im Verzeichnis (`GET /api/v1/me/beitritte`).
- **Anträge entscheiden** (wer `darfVerwalten` hat): die offenen Anfragen mit
  Name und Begründung, „Aufnehmen" und „Ablehnen"
  (`GET /api/v1/traeger/{id}/beitritte`, `POST /api/v1/beitritte/{id}`).
- **Jemanden direkt aufnehmen** aus der Dorfbewohner-Liste
  (`POST /api/v1/traeger/{id}/mitglieder`) — der einzige Weg in eine
  geschlossene Gruppe.
- **Vom Ort zum Träger**: Der Trägername in der Ortsansicht ist antippbar und
  führt zu seiner Seite.
- **Vom Träger zurück zu den Orten**: Auf der Trägerseite steht der Abschnitt
  „Orte dieses Trägers"; ein Tipp öffnet den Ort mit seinen Aufgaben.
- Auf der Startseite eine Kachel, deren Hinweiszeile zählt, wie viele Anfragen
  auf **meine** Entscheidung warten.

## Die Regeln stehen weiterhin nur im Server

Keine der beiden Apps prüft etwas nach. Ob ein Beitritt möglich ist, ob jemand
entscheiden darf, ob ein Träger überhaupt sichtbar ist — das entscheidet
`model.Zugriff` und schickt es mit: `istMitglied`, `darfVerwalten`,
`beitrittMoeglich`, `beitrittHindernis` (fertiger deutscher Satz),
`beitrittStatus`, `offeneBeitritte`. Die Apps zeigen an.

Das gilt auch für den Weg vom Ort zum Träger. Ein Ort bringt jetzt neben dem
(gegebenenfalls verdeckten) Namen auch `traegerId` mit — angeboten wird der Weg
aber **nicht** an dieser Zahl, sondern am Verzeichnis des Servers: Steht der
Träger nicht darin, gibt es ihn für diese Person nicht, und die Zeile bleibt
unantippbar. So heißt eine geschlossene Gruppe am Ort weiterhin „Eine Gruppe aus
dem Dorf" und führt nirgendwohin — ohne dass die App eine zweite
Sichtbarkeitsregel bekommen hätte.

Der wichtigste Fall hat in beiden Apps einen eigenen Test: Eine Freigabe
schreibt zuerst in die Rössing-ID. Klappt das nicht (502/503), bleibt die
Anfrage offen, es wird **kein** Erfolg gemeldet, und der Satz des Servers steht
im Wortlaut auf dem Schirm.

## Entscheidungen, die offen waren

**Sieht ein Nicht-Angemeldeter das Verzeichnis? Nein.** Das ist keine
Geschmacksfrage: `GET /api/v1/traeger` hängt hinter `authMW`, es gibt also gar
keine anonyme Antwort. Dazu kommt, dass die iOS-App ohne Anmeldung nur den
Anmeldeschirm zeigt und auf Android allein der Maschinchenring ohne Anmeldung
erreichbar ist — weil dessen eigener Server das hergibt. Wollte man das ändern,
wäre es eine Backend-Änderung, keine App-Änderung.

**Wo hängt es in der Navigation? Beides.** Ein eigener Bereich neben
„Mithelfen" auf der Startseite, **und** der Weg aus der Ortsansicht heraus.
Der Bereich allein hätte niemandem geholfen, der einen Blumenkasten anschaut und
wissen will, wen er fragen muss; der Weg aus dem Ort allein hätte kein
Verzeichnis ergeben, in dem man das Dorf überblickt.

**Wie kommt man vom Träger zurück zu seinen Orten?** Über einen Abschnitt „Orte
dieses Trägers" auf der Trägerseite, gespeist aus derselben Ortsliste, die auch
„Mithelfen" zeigt — nicht aus einem zweiten Abruf. Damit gilt dort automatisch
dieselbe Sichtbarkeit, und Kachel und Liste können nicht auseinanderlaufen.
Ein Tipp öffnet den Ort: auf iOS als eigenes Wertziel (`Ziel.ort`), auf Android
über den bestehenden Weg (Bereich „Mithelfen", Liste, Blatt zum Ort).

**Ein Träger-Modell für die ganze App.** Wie die Orte gehört das Verzeichnis der
Umgebung bzw. dem `AppContainer` und nicht der Seite: Die Startseiten-Kachel
zählt daraus, die Ortsansicht fragt es, das Verzeichnis zeigt es. Zwei Modelle
hießen zwei Abrufe und zwei Stände.

## Was bewusst fehlt

- **Keine Angaben, die das Modell nicht hat.** Kontakt, Adresse, Website eines
  Trägers gibt es im Backend nicht — die Apps erfinden sie nicht. (#75 nennt das
  als offene Frage; hier ist die Antwort „später, und dann zuerst im Modell".)
- **Träger anlegen, ändern, zulassen** bleibt in der Web-Verwaltung und im
  MCP-Endpunkt. Zulassen darf ohnehin nur der Betreiber.
- **Befähigungen** (Einweisungen) sind nicht Teil dieses Zugs, obwohl sie am
  selben Träger hängen — das ist ein eigener Bereich mit eigenem Ablauf.
- **Kein Push**, wenn eine neue Anfrage eingeht. Der Vorstand sieht sie beim
  Öffnen der App an der Kachel. Ob das reicht, zeigt der Betrieb.
- **Eine abgelehnte eigene Anfrage** steht nicht dauerhaft im Verzeichnis; oben
  stehen nur die offenen. Der Stand am Träger selbst zeigt sie weiterhin an.

## Nichts am Backend

`backend/` ist unberührt. Beim Bauen ist nichts aufgefallen, was dort fehlt:
Die fünf Endpunkte liefern alles, was die Oberfläche braucht, einschließlich der
aufgelösten Namen in den Anträgen.

## Geprüft

- `cd ios && xcodegen generate && xcodebuild test …` — 261 Tests in 19 Suiten,
  grün (neu: `ios/DorfTests/TraegerTests.swift`).
- `cd android && ./gradlew testDebugUnitTest assembleDebug assembleDebugAndroidTest`
  — grün, 255 Tests (neu: `TraegerViewModelTest`, erweitert: `TraegerAmOrtTest`).
- `python3 .github/scripts/pruefe_lokale_tests.py` und `--selbsttest` — grün.

Fixes #75
Fixes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfZ9C5s2meH45APq947FXT
