### PR TITLE
Der Schalter am Namen gilt jetzt überall, nicht nur im Verzeichnis

### DIFF
--- a/backend/internal/admin/beitritt.go
+++ b/backend/internal/admin/beitritt.go
@@ -90,7 +90,7 @@ func (a *App) mitgliedAufnehmen(w http.ResponseWriter, r *http.Request, s sessio
 	namen, nerr := a.db.NameResolver()
 	name := userSub
 	if nerr == nil {
-		if n := namen.Resolve(b.UserSub, ""); n != "" {
+		if n := namen.Resolve(b.UserSub, "", model.SichtVerwaltung); n != "" {
 			name = n
 		}
 	}

--- a/backend/internal/admin/mithelfen.go
+++ b/backend/internal/admin/mithelfen.go
@@ -252,7 +252,7 @@ func (a *App) zeigeOrt(w http.ResponseWriter, r *http.Request, status int, id in
 			return
 		}
 		for _, c := range cs {
-			c.UserName = namen.Resolve(c.UserSub, c.UserName)
+			c.UserName = namen.Resolve(c.UserSub, c.UserName, model.SichtVerwaltung)
 			historie = append(historie, historieEintrag{Aufgabe: aufgabenName(t.CareTask), Erledigung: c})
 		}
 	}
@@ -648,7 +648,7 @@ func (a *App) erledigungZuruecknehmenFrage(w http.ResponseWriter, r *http.Reques
 		menge = " (" + zahl(*c.Liters) + " l)"
 	}
 	if namen, err := a.db.NameResolver(); err == nil {
-		c.UserName = namen.Resolve(c.UserSub, c.UserName)
+		c.UserName = namen.Resolve(c.UserSub, c.UserName, model.SichtVerwaltung)
 	}
 	a.render(w, r, http.StatusOK, "bestaetigen", view{
 		Title: "Erledigung zurücknehmen", Nav: "mithelfen",

--- a/backend/internal/admin/traeger.go
+++ b/backend/internal/admin/traeger.go
@@ -286,7 +286,7 @@ func (a *App) zeigeTraeger(w http.ResponseWriter, r *http.Request, status int,
 	offen := []model.BefaehigungsAntrag{}
 	entschieden := []model.BefaehigungsAntrag{}
 	for _, antrag := range alleAntraege {
-		antrag.UserName = namen.Resolve(antrag.UserSub, "")
+		antrag.UserName = namen.Resolve(antrag.UserSub, "", model.SichtVerwaltung)
 		if antrag.UserName == "" {
 			antrag.UserName = antrag.UserSub
 		}
@@ -317,7 +317,7 @@ func (a *App) zeigeTraeger(w http.ResponseWriter, r *http.Request, status int,
 	offeneBeitritte := []model.Beitritt{}
 	mitglieder := []model.Beitritt{}
 	for _, b := range alleBeitritte {
-		b.UserName = namen.Resolve(b.UserSub, "")
+		b.UserName = namen.Resolve(b.UserSub, "", model.SichtVerwaltung)
 		if b.UserName == "" {
 			b.UserName = b.UserSub
 		}

--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -185,7 +185,7 @@ func AssemblePlacesFuer(d *db.DB, now time.Time, z model.Zugriff) ([]model.Place
 		t.BefaehigungName = befaehigungName[t.BefaehigungID]
 		var lc *model.Completion
 		if c, ok := last[t.ID]; ok {
-			c.UserName = namen.Resolve(c.UserSub, c.UserName)
+			c.UserName = namen.Resolve(c.UserSub, c.UserName, model.SichtDorf)
 			lc = &c
 		}
 		// Der Hitzefaktor beschleunigt nur das Gießen — Jäten etc. bleiben normal.
@@ -800,7 +800,7 @@ func (s *Server) handleListCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for i := range cs {
-		cs[i].UserName = namen.Resolve(cs[i].UserSub, cs[i].UserName)
+		cs[i].UserName = namen.Resolve(cs[i].UserSub, cs[i].UserName, model.SichtDorf)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"completions": cs})
 }

--- a/backend/internal/api/beitritt.go
+++ b/backend/internal/api/beitritt.go
@@ -119,7 +119,7 @@ func (s *Server) namenEintragen(liste []model.Beitritt) error {
 		return err
 	}
 	for i := range liste {
-		liste[i].UserName = namen.Resolve(liste[i].UserSub, "")
+		liste[i].UserName = namen.Resolve(liste[i].UserSub, "", model.SichtVerwaltung)
 	}
 	return nil
 }

--- a/backend/internal/api/leaderboard.go
+++ b/backend/internal/api/leaderboard.go
@@ -114,10 +114,13 @@ func AssembleLeaderboardFuer(d *db.DB, now time.Time, period model.Period, limit
 		return model.Leaderboard{}, err
 	}
 	for i := range entries {
-		entries[i].UserName = namen.Resolve(entries[i].UserSub, entries[i].UserName)
+		entries[i].UserName = namen.Resolve(entries[i].UserSub, entries[i].UserName, model.SichtDorf)
 	}
 	if mine != nil {
-		mine.UserName = namen.Resolve(mine.UserSub, mine.UserName)
+		// Die eigene Zeile: Den eigenen Namen darf man sehen, auch wenn man ihn
+		// nicht freigegeben hat — sonst stünde man sich selbst als Spitzname
+		// gegenüber und hielte es für einen Fehler.
+		mine.UserName = namen.Resolve(mine.UserSub, mine.UserName, model.SichtVerwaltung)
 	}
 
 	return model.Leaderboard{

--- a/backend/internal/api/traeger.go
+++ b/backend/internal/api/traeger.go
@@ -523,7 +523,7 @@ func (s *Server) handleListAntraege(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for i := range liste {
-		liste[i].UserName = namen.Resolve(liste[i].UserSub, "")
+		liste[i].UserName = namen.Resolve(liste[i].UserSub, "", model.SichtVerwaltung)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"antraege": liste})
 }

--- a/backend/internal/api/vergabe.go
+++ b/backend/internal/api/vergabe.go
@@ -171,7 +171,7 @@ func (s *Server) handlePlaceSignups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for i := range liste {
-		liste[i].UserName = namen.Resolve(liste[i].UserSub, "")
+		liste[i].UserName = namen.Resolve(liste[i].UserSub, "", model.SichtDorf)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"signups": liste})
 }
@@ -296,7 +296,7 @@ func ergaenzeVergabe(d *db.DB, orte []model.PlaceWithStatus, namen model.NameRes
 	}
 	proAufgabe := map[int64]model.Assignment{}
 	for _, a := range laufende {
-		a.ClaimedByName = namen.Resolve(a.ClaimedBy, a.ClaimedByName)
+		a.ClaimedByName = namen.Resolve(a.ClaimedBy, a.ClaimedByName, model.SichtDorf)
 		proAufgabe[a.TaskID] = a
 	}
 	anmeldungen, err := d.ListSignups()

--- a/backend/internal/chat/werkzeuge.go
+++ b/backend/internal/chat/werkzeuge.go
@@ -221,7 +221,7 @@ func werkzeugHistorie(args json.RawMessage, s Sitzung) (any, error) {
 		return nil, err
 	}
 	for i := range meldungen {
-		meldungen[i].UserName = namen.Resolve(meldungen[i].UserSub, meldungen[i].UserName)
+		meldungen[i].UserName = namen.Resolve(meldungen[i].UserSub, meldungen[i].UserName, model.SichtVerwaltung)
 	}
 	return map[string]any{"erledigungen": meldungen}, nil
 }

--- a/backend/internal/mcp/beitritt.go
+++ b/backend/internal/mcp/beitritt.go
@@ -61,7 +61,7 @@ func (s *Server) toolListBeitritte(args json.RawMessage, _ auth.User) (any, erro
 			return nil, err
 		}
 		for _, b := range liste {
-			b.UserName = namen.Resolve(b.UserSub, "")
+			b.UserName = namen.Resolve(b.UserSub, "", model.SichtVerwaltung)
 			out = append(out, beitrittAnsicht{Beitritt: b, TraegerName: t.Name})
 		}
 	}

--- a/backend/internal/model/anonymousname_test.go
+++ b/backend/internal/model/anonymousname_test.go
@@ -131,17 +131,17 @@ func TestSpitznameFuelltDieRangliste(t *testing.T) {
 	sub := "888888888888888888"
 	namen := NameResolver{sub: {UserSub: sub}}
 
-	if got := namen.Resolve(sub, ""); got != AnonymousName(sub) {
+	if got := namen.Resolve(sub, "", SichtDorf); got != AnonymousName(sub) {
 		t.Errorf("Rangliste = %q, erwartet den Spitznamen %q", got, AnonymousName(sub))
 	}
 	// Eine von der Verwaltung nachgetragene Meldung läuft unter fremdem
 	// Namen; der bleibt stehen (siehe MatchesStoredName).
-	if got := namen.Resolve(sub, "Karl Nachbar"); got != "Karl Nachbar" {
+	if got := namen.Resolve(sub, "Karl Nachbar", SichtDorf); got != "Karl Nachbar" {
 		t.Errorf("Nachtrag = %q, erwartet den eingefrorenen Namen", got)
 	}
 	// Wer gar kein Profil hat, bekommt keinen Spitznamen: Über ihn ist
 	// nichts bekannt, nicht einmal, dass er die App je geöffnet hat.
-	if got := namen.Resolve("fremde-kennung", "Alte Meldung"); got != "Alte Meldung" {
+	if got := namen.Resolve("fremde-kennung", "Alte Meldung", SichtDorf); got != "Alte Meldung" {
 		t.Errorf("ohne Profil = %q, erwartet den gespeicherten Namen", got)
 	}
 }

--- a/backend/internal/model/profil.go
+++ b/backend/internal/model/profil.go
@@ -73,25 +73,59 @@ type Profile struct {
 	TokenName string `json:"-"`
 }
 
-// EffectiveName ist der Name, unter dem die Person im Dorf auftritt:
-// Nickname, sonst Anzeigename, sonst der Name aus der Rössing-ID — und wenn
-// nichts davon da ist, der Spitzname (siehe AnonymousName).
+// Namenssicht sagt, wer zusieht. Der Schalter am Anzeigenamen heißt „für
+// alle Dorfbewohner" oder „nur für Verwaltende" — er ist eine Entscheidung
+// über den Namen, nicht über eine einzelne Liste. Wer ihn umlegt, darf
+// erwarten, dass er überall gilt.
+type Namenssicht int
+
+const (
+	// SichtDorf: gewöhnliche Angemeldete. Sie sehen nur, was freigegeben ist.
+	SichtDorf Namenssicht = iota
+	// SichtVerwaltung: Betreiber und Träger-Admins. Sie sehen ohnehin alles;
+	// ihnen einen Spitznamen vorzusetzen, hülfe niemandem — sie müssen
+	// Meldungen zuordnen können.
+	SichtVerwaltung
+)
+
+// EffectiveName ist der Name für die **Verwaltung**: Nickname, sonst
+// Anzeigename, sonst der Name aus der Rössing-ID — und wenn nichts davon da
+// ist, der Spitzname (siehe AnonymousName).
 //
 // Der Spitzname steht ausdrücklich am Ende: Er ersetzt keinen Namen, er
 // vertritt ihn nur dort, wo sonst eine Leerstelle stünde. Genau das war der
 // Fall — die Rangliste zeigte Zeilen mit Punkten, Litern und Auszeichnungen,
 // aber ohne Namen.
-func (p Profile) EffectiveName() string {
-	switch {
-	case p.Nickname != "":
-		return p.Nickname
-	case p.DisplayName != "":
-		return p.DisplayName
-	case p.TokenName != "":
-		return p.TokenName
-	default:
+//
+// **Für das Dorf gilt NameFuer(SichtDorf).** Dort werden die
+// Sichtbarkeits-Schalter beachtet, und der Name aus der Rössing-ID kommt gar
+// nicht vor: Er hat keinen Schalter, ihn hat niemand freigegeben.
+func (p Profile) EffectiveName() string { return p.NameFuer(SichtVerwaltung) }
+
+// NameFuer liefert den Namen, den diese Sicht sehen darf.
+func (p Profile) NameFuer(sicht Namenssicht) string {
+	if sicht == SichtVerwaltung {
+		switch {
+		case p.Nickname != "":
+			return p.Nickname
+		case p.DisplayName != "":
+			return p.DisplayName
+		case p.TokenName != "":
+			return p.TokenName
+		}
 		return AnonymousName(p.UserSub)
 	}
+	// Für das Dorf zählt nur, was ausdrücklich freigegeben ist. Der TokenName
+	// fehlt hier mit Absicht: Er kommt aus der Rössing-ID, trägt keinen
+	// Schalter, und wer beide eigenen Namen zurückzieht, hat ihn erst recht
+	// nicht freigegeben.
+	if p.Nickname != "" && p.Visibility.Nickname == VisibilityVillage {
+		return p.Nickname
+	}
+	if p.DisplayName != "" && p.Visibility.DisplayName == VisibilityVillage {
+		return p.DisplayName
+	}
+	return AnonymousName(p.UserSub)
 }
 
 // MatchesStoredName sagt, ob ein in einer Erledigung eingefrorener Name zu
@@ -117,7 +151,15 @@ func (p Profile) MatchesStoredName(gespeichert string) bool {
 // geöffnet haben) bleibt es beim gespeicherten Namen.
 type NameResolver map[string]Profile
 
-func (r NameResolver) Resolve(userSub, gespeichert string) string {
+// Resolve verlangt die Sicht des Betrachters — ausdrücklich als Parameter
+// und nicht als Vorbelegung. Der Schalter am Namen galt eine Zeitlang nur im
+// Verzeichnis der Dorfbewohner und in Rangliste, Historie, Vergabe und Chat
+// gar nicht (#80). Wer hier eine Sicht angeben muss, entscheidet sich
+// bewusst, statt eine bequeme Vorgabe zu erben.
+//
+// Ohne Profil bleibt es beim gespeicherten Namen: Wer die App nie geöffnet
+// hat, hat auch keinen Schalter umgelegt.
+func (r NameResolver) Resolve(userSub, gespeichert string, sicht Namenssicht) string {
 	p, ok := r[userSub]
 	if !ok {
 		return gespeichert
@@ -125,7 +167,7 @@ func (r NameResolver) Resolve(userSub, gespeichert string) string {
 	if !p.MatchesStoredName(gespeichert) {
 		return gespeichert
 	}
-	if name := p.EffectiveName(); name != "" {
+	if name := p.NameFuer(sicht); name != "" {
 		return name
 	}
 	return gespeichert

--- a/backend/internal/model/profil_test.go
+++ b/backend/internal/model/profil_test.go
@@ -1,0 +1,64 @@
+package model
+
+import "testing"
+
+// --- Der Schalter am Namen gilt überall ---------------------------------------
+
+// Der Schalter heißt „für alle Dorfbewohner" oder „nur für Verwaltende". Er
+// ist eine Entscheidung über den Namen, nicht über eine einzelne Liste. Eine
+// Zeitlang galt er nur im Verzeichnis der Dorfbewohner — in Rangliste,
+// Historie, Vergabe und Chat stand der Name trotzdem (#80).
+func TestZurueckgezogenerNameStehtNichtInDerRangliste(t *testing.T) {
+	p := Profile{
+		UserSub: "777777777777777777", DisplayName: "Erna Beispiel", TokenName: "Erna Beispiel",
+		Visibility: ProfileVisibility{
+			DisplayName: VisibilityAdmins, Nickname: VisibilityVillage,
+			Phone: VisibilityAdmins, Email: VisibilityAdmins, Note: VisibilityAdmins,
+		},
+	}
+
+	// Das Dorf sieht den Spitznamen — nicht den Anzeigenamen und erst recht
+	// nicht den Namen aus der Rössing-ID, den niemand freigegeben hat.
+	if got := p.NameFuer(SichtDorf); got != AnonymousName(p.UserSub) {
+		t.Errorf("das Dorf sieht %q, erwartet den Spitznamen %q", got, AnonymousName(p.UserSub))
+	}
+	// Die Verwaltung muss zuordnen können.
+	if got := p.NameFuer(SichtVerwaltung); got != "Erna Beispiel" {
+		t.Errorf("die Verwaltung sieht %q, erwartet den Anzeigenamen", got)
+	}
+	if p.EffectiveName() != "Erna Beispiel" {
+		t.Errorf("EffectiveName ist die Sicht der Verwaltung: %q", p.EffectiveName())
+	}
+}
+
+// Ein freigegebener Name steht überall — der Schalter nimmt nichts weg, was
+// jemand hergegeben hat.
+func TestFreigegebenerNameStehtUeberall(t *testing.T) {
+	p := Profile{
+		UserSub: "666666666666666666", DisplayName: "Olaf Beispiel",
+		Visibility: DefaultVisibility(),
+	}
+	if got := p.NameFuer(SichtDorf); got != "Olaf Beispiel" {
+		t.Errorf("das Dorf sieht %q, erwartet den freigegebenen Namen", got)
+	}
+	if got := p.NameFuer(SichtVerwaltung); got != "Olaf Beispiel" {
+		t.Errorf("die Verwaltung sieht %q", got)
+	}
+}
+
+// Der Nickname geht dem Anzeigenamen vor — aber nur, wenn er freigegeben ist.
+func TestZurueckgezogenerNicknameFaelltAufDenAnzeigenamen(t *testing.T) {
+	p := Profile{
+		UserSub: "555555555555555555", Nickname: "Ernie", DisplayName: "Erna Beispiel",
+		Visibility: ProfileVisibility{
+			Nickname: VisibilityAdmins, DisplayName: VisibilityVillage,
+			Phone: VisibilityAdmins, Email: VisibilityAdmins, Note: VisibilityAdmins,
+		},
+	}
+	if got := p.NameFuer(SichtDorf); got != "Erna Beispiel" {
+		t.Errorf("das Dorf sieht %q, erwartet den freigegebenen Anzeigenamen", got)
+	}
+	if got := p.NameFuer(SichtVerwaltung); got != "Ernie" {
+		t.Errorf("die Verwaltung sieht %q, erwartet den Nickname", got)
+	}
+}

--- a/backend/internal/vergabe/vergabe.go
+++ b/backend/internal/vergabe/vergabe.go
@@ -582,7 +582,8 @@ func (e *Engine) schonVergeben(a *model.Assignment) error {
 	if !a.Active() {
 		return abweisung(http.StatusConflict, "Dieser Vorgang ist schon abgeschlossen.")
 	}
-	name := nameOder(e.namen(), a.ClaimedBy, a.ClaimedByName)
+	// Diese Meldung liest, wer gerade zu spät war — jemand aus dem Dorf.
+	name := nameOder(e.namen(), a.ClaimedBy, a.ClaimedByName, model.SichtDorf)
 	if name == "" || name == unbekannt {
 		name = "jemand anderem"
 	}
@@ -888,7 +889,7 @@ func (e *Engine) Stand(taskID int64) (*Stand, error) {
 		if !s.Matches(*task) {
 			continue
 		}
-		s.UserName = nameOder(namen, s.UserSub, "")
+		s.UserName = nameOder(namen, s.UserSub, "", model.SichtVerwaltung)
 		s.PlaceName = place.Name
 		st.Angemeldete = append(st.Angemeldete, s)
 	}
@@ -900,7 +901,7 @@ func (e *Engine) Stand(taskID int64) (*Stand, error) {
 	if a == nil {
 		return st, nil
 	}
-	a.ClaimedByName = nameOder(namen, a.ClaimedBy, a.ClaimedByName)
+	a.ClaimedByName = nameOder(namen, a.ClaimedBy, a.ClaimedByName, model.SichtVerwaltung)
 	st.Vorgang = a
 	ns, err := e.db.NotificationsForAssignment(a.ID)
 	if err != nil {
@@ -910,7 +911,7 @@ func (e *Engine) Stand(taskID int64) (*Stand, error) {
 		n.PlaceName = place.Name
 		n.TaskName = task.DisplayName()
 		n.TaskKind = task.Kind
-		n.Title = nameOder(namen, n.UserSub, "")
+		n.Title = nameOder(namen, n.UserSub, "", model.SichtVerwaltung)
 		st.Zustellungen = append(st.Zustellungen, n)
 	}
 	return st, nil
@@ -923,7 +924,7 @@ func (e *Engine) AssignmentFor(taskID int64) (*model.Assignment, error) {
 	if err != nil || a == nil {
 		return nil, err
 	}
-	a.ClaimedByName = nameOder(e.namen(), a.ClaimedBy, a.ClaimedByName)
+	a.ClaimedByName = nameOder(e.namen(), a.ClaimedBy, a.ClaimedByName, model.SichtDorf)
 	return a, nil
 }
 
@@ -932,7 +933,7 @@ func (e *Engine) assignmentMitNamen(id int64) (*model.Assignment, error) {
 	if err != nil {
 		return nil, err
 	}
-	a.ClaimedByName = nameOder(e.namen(), a.ClaimedBy, a.ClaimedByName)
+	a.ClaimedByName = nameOder(e.namen(), a.ClaimedBy, a.ClaimedByName, model.SichtDorf)
 	return a, nil
 }
 
@@ -952,11 +953,15 @@ const unbekannt = "Unbekannt"
 
 // nameOder löst den Namen auf; gespeichert ist der Rückfall (z.B. der Name,
 // der bei der Zusage galt).
-func nameOder(namen model.NameResolver, sub, gespeichert string) string {
+//
+// Die Sicht steht ausdrücklich dabei: Derselbe Vorgang wird einmal einer
+// Verwaltung gezeigt, die zuordnen können muss, und einmal jemandem im Dorf,
+// der nur sehen soll, was freigegeben ist (#80).
+func nameOder(namen model.NameResolver, sub, gespeichert string, sicht model.Namenssicht) string {
 	if sub == "" {
 		return ""
 	}
-	if n := namen.Resolve(sub, gespeichert); n != "" {
+	if n := namen.Resolve(sub, gespeichert, sicht); n != "" {
 		return n
 	}
 	return unbekannt


### PR DESCRIPTION
Behebt #80. Gefunden bei der Arbeit an den Spitznamen (#79), dort bewusst nicht mitgeändert.

## Was schief stand

Der Schalter heißt „für alle Dorfbewohner" oder „nur für Verwaltende". Wer ihn umlegt, trifft eine Entscheidung über **seinen Namen** — nicht über eine einzelne Liste.

Er galt aber nur im Verzeichnis der Dorfbewohner (`Profile.AsMember`). Ein Anzeigename auf „nur für Verwaltende" fehlte dort — und stand trotzdem für jeden Angemeldeten in der Rangliste, in der Ortshistorie, bei der Vergabe, an Befähigungsanträgen und im Chat. Dass eine Entscheidung an einer Stelle gilt und an fünf anderen nicht, ist für niemanden vorhersehbar.

## Was jetzt gilt

`NameResolver.Resolve` verlangt die **Sicht des Betrachters** — als Parameter, nicht als Vorbelegung. Das war die eigentliche Arbeit: Der Übersetzer hat damit jede der sechzehn Aufrufstellen einzeln zur Entscheidung gezwungen, statt eine bequeme Vorgabe erben zu lassen.

| Sicht | Wo | Was sie sieht |
| --- | --- | --- |
| `SichtDorf` | Rangliste, Ortshistorie, Erledigungen, Angemeldete, „wurde gerade schon von X übernommen" | nur Freigegebenes, sonst der Spitzname |
| `SichtVerwaltung` | Web-Verwaltung, Chat, MCP, Vergabe-Stand, Antragslisten des Träger-Admins | alles — er muss zuordnen können |

**Der Name aus der Rössing-ID fällt in der Dorfsicht ganz weg.** Er trägt keinen Schalter, also hat ihn auch niemand freigegeben; ihn als Rückfall zu zeigen wäre genau das Leck, um das es geht.

## Eine Ausnahme mit Absicht

Die **eigene Zeile** in der Rangliste (`me`) benutzt die Verwaltungssicht. Den eigenen Namen darf man sehen, auch wenn man ihn nicht freigegeben hat — sonst stünde man sich selbst als „Froher Fuchs" gegenüber und hielte es für einen Fehler.

## Was offen bleibt

Eingefrorene Namen in **alten Erledigungen von Leuten ohne Profil**. Wer die App nie geöffnet hat, hat auch keinen Schalter umgelegt; für ihn gibt es nichts zu beachten. Die zweite Frage aus #80 — was mit alten Zeilen passiert, wenn jemand seinen Namen nachträglich zurückzieht — ist damit für Profilinhaber beantwortet (die Zeilen folgen dem Schalter, weil `MatchesStoredName` greift) und für Profillose gegenstandslos.

## Geprüft

Drei neue Tests: zurückgezogener Name, freigegebener Name, zurückgezogener Nickname mit freigegebenem Anzeigenamen als Rückfall. `go vet ./...`, `go test ./...`, `pruefe_lokale_tests.py` grün. Keine App-Änderung nötig — beide zeigen den Namen so an, wie er kommt.