### PR TITLE
MCP sagt, was intern ist — und warum es die Betreibersicht zeigt

### DIFF
--- a/backend/internal/mcp/mcp.go
+++ b/backend/internal/mcp/mcp.go
@@ -324,7 +324,10 @@ func (s *Server) registerTools() {
 		{
 			Name: "orte_liste",
 			Description: "Listet alle Pflege-Orte (Blumenkästen, Beete, …) mit ihren Aufgaben, " +
-				"letzter Erledigung und Ampel-Status (green/yellow/red).",
+				"letzter Erledigung und Ampel-Status (green/yellow/red/dormant). " +
+				"Betreibersicht: Enthalten sind auch Aufgaben, die ein Träger als " +
+				"sichtbarkeit=nur_mitglieder eingestellt hat — die gehen nur seine " +
+				"Mitglieder etwas an und sollten nicht weitergetragen werden.",
 			Schema:  obj(nil, map[string]any{}),
 			Handler: s.toolListPlaces,
 		},
@@ -497,6 +500,23 @@ func (s *Server) registerTools() {
 	s.tools = append(s.tools, s.beitrittTools()...)
 }
 
+// toolListPlaces zeigt die **Betreibersicht**: alle Orte aller Träger, auch
+// deren interne Aufgaben.
+//
+// Das ist kein Leck, sondern eine Folge davon, wer hier ankommt: withAuth
+// verlangt für jede Anfrage die globale admin-Rolle, und dieselben Daten
+// stehen für diese Person ohnehin in der Web-Verwaltung. Es entsteht kein
+// Zugang, den es nicht gäbe.
+//
+// **Wer den Endpunkt je für Träger-Admins öffnet, muss vorher hier auf
+// api.AssemblePlacesFuer umstellen** — und bei der Rangliste entsprechend auf
+// AssembleLeaderboardFuer. Sonst geht mit der Öffnung ein Weg an der
+// Sichtbarkeit vorbei auf (#35, #32).
+//
+// Die Sichtbarkeit jeder Aufgabe steht in der Antwort. Das ist Absicht: Wer
+// im Gespräch mit Claude eine interne Aufgabe eines fremden Vereins vor sich
+// hat, soll es sehen können — es ist eine Vertrauensfrage gegenüber den
+// Trägern, nicht bloß eine Frage der Zugriffsrechte.
 func (s *Server) toolListPlaces(json.RawMessage, auth.User) (any, error) {
 	places, factor, err := api.AssemblePlaces(s.DB, s.now())
 	if err != nil {

--- a/backend/internal/mcp/traeger_test.go
+++ b/backend/internal/mcp/traeger_test.go
@@ -256,3 +256,72 @@ func TestZuletztErledigtUeberMCP(t *testing.T) {
 		t.Error("ein Datum in der Zukunft wurde angenommen")
 	}
 }
+
+// --- Betreibersicht ----------------------------------------------------------
+
+// Der MCP-Endpunkt zeigt die Betreibersicht: alle Orte aller Träger, auch
+// deren interne Aufgaben. Das ist kein Leck — wer hier ankommt, hat die
+// globale admin-Rolle und sieht dieselben Daten in der Web-Verwaltung.
+//
+// Damit man im Gespräch mit Claude aber *erkennt*, was intern ist, muss die
+// Sichtbarkeit in der Antwort stehen. Sie steht dort heute, weil sie zum
+// Datensatz gehört — dieser Test hält es fest, damit sie nicht eines Tages
+// stillschweigend herausfällt (#35).
+func TestOrteListeNenntDieSichtbarkeit(t *testing.T) {
+	ts, d := serverMitDB(t)
+
+	text, _ := callTool(t, ts, "ort_anlegen", map[string]any{
+		"name": "Vereinsgarten", "lat": 52.18, "lon": 9.81,
+	})
+	var ort model.Place
+	if err := json.Unmarshal([]byte(text), &ort); err != nil {
+		t.Fatalf("Ort nicht lesbar: %v — %s", err, text)
+	}
+	if _, fehler := callTool(t, ts, "aufgabe_anlegen", map[string]any{
+		"placeId": ort.ID, "kind": "jaeten", "intervalDays": 21, "redAfterDays": 35,
+		"sichtbarkeit": "nur_mitglieder",
+	}); fehler {
+		t.Fatal("interne Aufgabe konnte nicht angelegt werden")
+	}
+
+	text, fehler := callTool(t, ts, "orte_liste", map[string]any{})
+	if fehler {
+		t.Fatalf("orte_liste: %s", text)
+	}
+	var antwort struct {
+		Places []struct {
+			Tasks []struct {
+				Sichtbarkeit string `json:"sichtbarkeit"`
+			} `json:"tasks"`
+		} `json:"places"`
+	}
+	if err := json.Unmarshal([]byte(text), &antwort); err != nil {
+		t.Fatalf("Antwort nicht lesbar: %v — %s", err, text)
+	}
+	var gefunden bool
+	for _, p := range antwort.Places {
+		for _, a := range p.Tasks {
+			if a.Sichtbarkeit == "nur_mitglieder" {
+				gefunden = true
+			}
+		}
+	}
+	if !gefunden {
+		t.Fatalf("die interne Aufgabe steht ohne erkennbare Sichtbarkeit da: %s", text)
+	}
+
+	// Und sie ist wirklich intern — der Test prüft nicht bloß ein Wort.
+	aufgaben, err := d.ListTasks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var intern int
+	for _, a := range aufgaben {
+		if a.PlaceID == ort.ID && a.Sichtbarkeit == model.AufgabeNurMitglieder {
+			intern++
+		}
+	}
+	if intern != 1 {
+		t.Fatalf("in der Datenbank steht etwas anderes: %+v", aufgaben)
+	}
+}


### PR DESCRIPTION
Behebt #35, den kleinsten nützlichen Schritt daraus — und die beiden Folgen, die das Issue festhält.

## Die Lage

Der MCP-Endpunkt zeigt alle Orte aller Träger, auch deren interne Aufgaben (`sichtbarkeit: nur_mitglieder`). **Das ist kein Leck**: `withAuth` verlangt für jede Anfrage die globale `admin`-Rolle, und dieselben Daten stehen für diese Person ohnehin in der Web-Verwaltung unter `/admin/mithelfen/`. Es entsteht kein Zugang, den es nicht gäbe.

Zwei Dinge fehlten trotzdem.

## Erkennbarkeit

Die Sichtbarkeit jeder Aufgabe steht in der Antwort — aber nur, **weil sie zum Datensatz gehört**. Nichts hielt das fest; sie hätte eines Tages stillschweigend herausfallen können. Jetzt tut es ein Test, und die Werkzeugbeschreibung sagt es ausdrücklich:

> Betreibersicht: Enthalten sind auch Aufgaben, die ein Träger als `sichtbarkeit=nur_mitglieder` eingestellt hat — die gehen nur seine Mitglieder etwas an und sollten nicht weitergetragen werden.

Damit liest Claude es bei jedem Aufruf mit. Das ist der Punkt: Wer im Gespräch eine interne Aufgabe eines fremden Vereins vor sich hat, soll es sehen. Eine Vertrauensfrage gegenüber den Trägern, nicht bloß eine Frage der Zugriffsrechte.

## Die Bedingung

Wer den Endpunkt je für **Träger-Admins** öffnet (#32), muss vorher auf `api.AssemblePlacesFuer` und `AssembleLeaderboardFuer` umstellen — sonst geht mit der Öffnung ein Weg an der Sichtbarkeit vorbei auf. Das stand bisher nur im Issue. Jetzt steht es über `toolListPlaces`, also dort, wo jemand es liest, **bevor** er es tut.

## Geprüft

Ein neuer Test: eine interne Aufgabe anlegen, `orte_liste` rufen, prüfen dass die Sichtbarkeit mitkommt — und gegen die Datenbank prüfen, dass sie wirklich intern ist und der Test nicht bloß ein Wort findet. `go vet ./...`, `go test ./...`, `pruefe_lokale_tests.py` grün.