### PR TITLE
Sichtbar machen, wenn jemand über den eigenen Antrag entschieden hat

### DIFF
--- a/backend/internal/admin/templates/traeger.html
+++ b/backend/internal/admin/templates/traeger.html
@@ -166,7 +166,12 @@
               <tr>
                 <td>{{.UserName}}</td>
                 <td>{{.BefaehigungName}}</td>
-                <td><span class="badge {{antragBadge .Status}}">{{antragStatus .Status}}</span></td>
+                <td>
+                  <span class="badge {{antragBadge .Status}}">{{antragStatus .Status}}</span>
+                  {{if .SelbstEntschieden}}
+                    <span class="badge badge-ghost badge-sm" title="Dieselbe Person hat beantragt und entschieden.">selbst erteilt</span>
+                  {{end}}
+                </td>
                 <td class="whitespace-nowrap">{{datumOpt .EntschiedenAm}}</td>
                 <td>{{.Notiz}}</td>
               </tr>
@@ -257,7 +262,12 @@
             {{range .Data.Mitglieder}}
               <tr>
                 <td>{{.UserName}}</td>
-                <td><span class="badge {{antragBadge .Status}}">{{antragStatus .Status}}</span></td>
+                <td>
+                  <span class="badge {{antragBadge .Status}}">{{antragStatus .Status}}</span>
+                  {{if .SelbstEntschieden}}
+                    <span class="badge badge-ghost badge-sm" title="Dieselbe Person hat beantragt und entschieden.">selbst aufgenommen</span>
+                  {{end}}
+                </td>
                 <td class="whitespace-nowrap">{{datumOpt .EntschiedenAm}}</td>
                 <td>{{.Notiz}}</td>
               </tr>

--- a/backend/internal/model/traeger.go
+++ b/backend/internal/model/traeger.go
@@ -483,3 +483,27 @@ func (z Zugriff) DarfBeitrittBeantragen(t Traeger) bool {
 // zweite Regel, sondern dieselbe: Er verwaltet jeden Träger, solange keiner
 // da ist, der es selbst tut.
 func (z Zugriff) DarfBeitrittEntscheiden(t Traeger) bool { return z.DarfVerwalten(t) }
+
+// --- Selbst entschieden ------------------------------------------------------
+
+// SelbstEntschieden sagt, ob dieselbe Person entschieden hat, die den Antrag
+// gestellt hat.
+//
+// Das ist erlaubt und für den Anfang richtig: In einem Dorfverein ist der
+// Vorstand oft eine Person, und er ist ohnehin derjenige, der die Einweisung
+// gibt. Ein erzwungenes Vier-Augen-Prinzip hieße dort, dass sich niemand
+// eine Einweisung eintragen kann und die Aufgabe für alle liegen bleibt.
+//
+// Nachvollziehbar soll es trotzdem sein — deshalb steht es in der Liste
+// dabei, statt still zu passieren (#34).
+func (a BefaehigungsAntrag) SelbstEntschieden() bool {
+	return a.EntschiedenVon != "" && a.EntschiedenVon == a.UserSub
+}
+
+// SelbstEntschieden — siehe BefaehigungsAntrag.SelbstEntschieden. Beim
+// Beitritt wiegt es etwas schwerer: Wer sich selbst aufnimmt, verschafft sich
+// eine Mitgliedschaft, nicht nur eine Einweisung. Verboten ist es trotzdem
+// nicht, aus demselben Grund — sichtbar aber sehr wohl.
+func (b Beitritt) SelbstEntschieden() bool {
+	return b.EntschiedenVon != "" && b.EntschiedenVon == b.UserSub
+}

--- a/backend/internal/model/traeger_test.go
+++ b/backend/internal/model/traeger_test.go
@@ -246,3 +246,36 @@ func TestTraegerOhneDachIstGueltig(t *testing.T) {
 		t.Error("ohne parentId ist er kein Unter-Träger")
 	}
 }
+
+// --- Selbst entschieden ------------------------------------------------------
+
+// Wer den Träger verwaltet, darf über den eigenen Antrag entscheiden — in
+// einem Dorfverein ist der Vorstand oft eine Person, und er gibt die
+// Einweisung ohnehin selbst. Verboten ist es also nicht. Nachvollziehbar soll
+// es trotzdem sein (#34).
+func TestSelbstEntschiedenIstErkennbar(t *testing.T) {
+	selbst := BefaehigungsAntrag{UserSub: "olaf", EntschiedenVon: "olaf", Status: AntragErteilt}
+	if !selbst.SelbstEntschieden() {
+		t.Error("selbst erteilter Antrag wird nicht erkannt")
+	}
+
+	fremd := BefaehigungsAntrag{UserSub: "erna", EntschiedenVon: "olaf", Status: AntragErteilt}
+	if fremd.SelbstEntschieden() {
+		t.Error("fremd entschiedener Antrag gilt als selbst erteilt")
+	}
+
+	// Noch nicht entschieden ist nicht dasselbe wie selbst entschieden.
+	offen := BefaehigungsAntrag{UserSub: "olaf", Status: AntragBeantragt}
+	if offen.SelbstEntschieden() {
+		t.Error("ein offener Antrag gilt als selbst erteilt")
+	}
+
+	// Beim Beitritt wiegt es schwerer — erkannt wird es genauso.
+	eigen := Beitritt{UserSub: "olaf", EntschiedenVon: "olaf", Status: AntragErteilt}
+	if !eigen.SelbstEntschieden() {
+		t.Error("selbst aufgenommener Beitritt wird nicht erkannt")
+	}
+	if (Beitritt{UserSub: "erna", EntschiedenVon: "olaf"}).SelbstEntschieden() {
+		t.Error("fremd entschiedener Beitritt gilt als selbst aufgenommen")
+	}
+}


### PR DESCRIPTION
Behebt #34 — den kleinsten nützlichen Schritt, den das Issue selbst vorschlägt.

## Was bleibt, wie es ist

Wer den Träger verwaltet, darf über jeden Antrag entscheiden — auch über den eigenen. **Das ändert dieser PR nicht**, und zwar mit Grund: In einem Dorfverein ist der Vorstand oft eine Person, und er ist ohnehin derjenige, der die Einweisung *gibt*. Ein erzwungenes Vier-Augen-Prinzip hieße dort, dass sich niemand eine Einweisung eintragen kann und die Aufgabe für alle liegen bleibt.

## Was sich ändert

In der Liste der entschiedenen Anträge steht jetzt **„selbst erteilt"** — und beim Beitritt **„selbst aufgenommen"** — wo dieselbe Person beantragt und entschieden hat. Die Daten dafür lagen längst in der Tabelle (`entschieden_von`); es fehlte nur die Anzeige.

Beim **Beitritt** wiegt es schwerer als bei einer Einweisung: Wer sich selbst aufnimmt, verschafft sich eine Mitgliedschaft, nicht nur eine Einweisung. Verboten ist es aus demselben Grund trotzdem nicht — sichtbar aber sehr wohl.

## Geprüft

`model.BefaehigungsAntrag.SelbstEntschieden` und `model.Beitritt.SelbstEntschieden`, mit Test: selbst entschieden, fremd entschieden, und ein noch offener Antrag (der ist nicht dasselbe wie selbst entschieden). `go vet ./...`, `go test ./...`, `pruefe_lokale_tests.py` grün, kein CSS-Drift.

## Was offen bleibt

Ein echtes Vier-Augen-Prinzip für Träger mit mehreren Verwaltenden. Das Issue nennt es als Ausblick; es setzt voraus, dass ein Träger überhaupt mehrere Admins hat, und die Frage „wer darf dann noch, wenn nur einer da ist" gehört mitentschieden.